### PR TITLE
Remove workaround for the qBittorrent Subfolder bug

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -288,9 +288,11 @@ export default class QBittorrent implements TorrentClient {
 
 			if (!isComplete) return InjectionResult.TORRENT_NOT_COMPLETE;
 
-			const shouldSetSubfolderContentLayout =
+			const contentLayout =
 				isSingleFileTorrent(newTorrent) &&
-				(await this.isSubfolderContentLayout(searchee));
+				(await this.isSubfolderContentLayout(searchee))
+					? "Subfolder"
+					: "Original";
 
 			const file = await fileFrom(
 				tempFilepath,
@@ -307,11 +309,7 @@ export default class QBittorrent implements TorrentClient {
 				formData.append("autoTMM", "false");
 				formData.append("savepath", save_path);
 			}
-
-			if (shouldSetSubfolderContentLayout) {
-				formData.append("contentLayout", "Subfolder");
-			}
-
+			formData.append("contentLayout", contentLayout);
 			formData.append("skip_checking", "true");
 			formData.append("paused", "false");
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -11,7 +11,6 @@ import { Label, logger, logOnce } from "../logger.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import { isSingleFileTorrent } from "../torrent.js";
-import { tapLog } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 
 const X_WWW_FORM_URLENCODED = {


### PR DESCRIPTION
closes #249

before this PR, `Subfolder` torrents were injected as paused, rechecked, and resumed because of a bug in qBittorrent. As of https://github.com/qbittorrent/qBittorrent/pull/16825 (released as qBittorrent v4.4.3) that bug is fixed and we no longer need this workaround.

