### PR TITLE
Allow specifying the path to config file via an environment variable

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -75,7 +75,7 @@ export async function getFileConfig(): Promise<FileConfig> {
 	const configPath = path.join(appDir(), "config.js");
 
 	try {
-		return (await import(pathToFileURL(configPath).toString())).default;
+		return (await import(process.env.CONFIG_PATH || pathToFileURL(configPath).toString())).default;
 	} catch (e) {
 		if (e.code !== "ERR_MODULE_NOT_FOUND") throw e;
 		return {};


### PR DESCRIPTION
Similar to how the configuration directory is specificable via the `CONFIG_DIR` environment variable, this makes the configuration file path itself configurable, in case it lies outside of the configuration directory.