### PR TITLE
Fix category setup boolean

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -293,7 +293,7 @@ export default class QBittorrent implements TorrentClient {
 				: await this.getTorrentConfiguration(searchee);
 
 			const newCategoryName =
-				duplicateCategories && !searchee.infoHash
+				duplicateCategories && searchee.infoHash
 					? await this.setUpCrossSeedCategory(category)
 					: category;
 


### PR DESCRIPTION
Was causing .cross-seed to not get appended when duplicate categories was set to true.