### PR TITLE
Dont wait for delay when theres no indexers to search

### DIFF
--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -51,7 +51,7 @@ export async function getEnabledIndexers() {
 export async function filterIndexersByTimestamp(
 	name: string,
 	excludeRecentSearch: number,
-	excludeOlder: number,
+	excludeOlder: number
 ) {
 	const enabledIndexers = await getEnabledIndexers();
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -143,8 +143,11 @@ export async function queryRssFeeds(): Promise<Candidate[]> {
 }
 
 export async function searchTorznab(
-	name: string
+	name: string,
+	indexersToUse: Indexer[]
 ): Promise<{ indexerId: number; candidates: Candidate[] }[]> {
+	const enabledIndexers = await getEnabledIndexers();
+
 	const timestampCallout = " (filtered by timestamps)";
 	logger.info({
 		label: Label.TORZNAB,

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -17,7 +17,6 @@ import {
 	cleanseSeparators,
 	getTag,
 	MediaType,
-	nMsAgo,
 	reformatTitleForSearching,
 	stripExtension,
 } from "./utils.js";
@@ -146,36 +145,6 @@ export async function queryRssFeeds(): Promise<Candidate[]> {
 export async function searchTorznab(
 	name: string
 ): Promise<{ indexerId: number; candidates: Candidate[] }[]> {
-	const { excludeRecentSearch, excludeOlder } = getRuntimeConfig();
-
-	const enabledIndexers = await getEnabledIndexers();
-
-	// search history for name across all indexers
-	const timestampDataSql = await db("searchee")
-		.join("timestamp", "searchee.id", "timestamp.searchee_id")
-		.join("indexer", "timestamp.indexer_id", "indexer.id")
-		.whereIn(
-			"indexer.id",
-			enabledIndexers.map((i) => i.id)
-		)
-		.andWhere({ name })
-		.select({
-			indexerId: "indexer.id",
-			firstSearched: "timestamp.first_searched",
-			lastSearched: "timestamp.last_searched",
-		});
-	const indexersToUse = enabledIndexers.filter((indexer) => {
-		const entry = timestampDataSql.find(
-			(entry) => entry.indexerId === indexer.id
-		);
-		return (
-			!entry ||
-			((!excludeOlder || entry.firstSearched > nMsAgo(excludeOlder)) &&
-				(!excludeRecentSearch ||
-					entry.lastSearched < nMsAgo(excludeRecentSearch)))
-		);
-	});
-
 	const timestampCallout = " (filtered by timestamps)";
 	logger.info({
 		label: Label.TORZNAB,


### PR DESCRIPTION
Currently, the pipeline is responsable to wait for the config delay. 

But we dont want to wait for it, if theres no search to be done.
I tried to move the delay to another place but it doesnt look good.

The solution I found here was move the filter out of the `searchTorznab` method, than we can call it early and pass it forward via parameters.

I totally agree that It does not look too good to overload the methods argument, but yet I could not present better solution. 

Thats just what I can present today, just trying to help.