### PR TITLE
Make timeouts configurable

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -49,6 +49,12 @@ function processOptions(options): RuntimeConfig {
 	if (options.excludeRecentSearch) {
 		options.excludeRecentSearch = ms(options.excludeRecentSearch);
 	}
+	if (options.snatchTimeout) {
+		options.snatchTimeout = ms(options.snatchTimeout);
+	}
+	if (options.searchTimeout) {
+		options.searchTimeout = ms(options.searchTimeout);
+	}
 	return options;
 }
 
@@ -64,7 +70,7 @@ function createCommandWithSharedOptions(name, description) {
 			fallback(fileConfig.torznab)
 		)
 		.option(
-			"-d, --data-dirs <dirs...>",
+			"--data-dirs <dirs...>",
 			"Directories to use if searching by data instead of torrents (separated by spaces)",
 			fallback(fileConfig.dataDirs)
 		)
@@ -78,7 +84,7 @@ function createCommandWithSharedOptions(name, description) {
 				.makeOptionMandatory()
 		)
 		.option(
-			"-dc --dataCategory <cat>",
+			"--data-category <cat>",
 			"Category to assign torrents from data-based matching",
 			fallback(fileConfig.dataCategory, "cross-seed-data")
 		)
@@ -188,6 +194,16 @@ function createCommandWithSharedOptions(name, description) {
 			"Pause duration (seconds) between searches",
 			parseFloat,
 			fallback(fileConfig.delay, 10)
+		)
+		.requiredOption(
+			"--snatch-timeout <timeout>",
+			"Timeout for unresponsive snatches",
+			fallback(fileConfig.snatchTimeout, "30 seconds")
+		)
+		.requiredOption(
+			"--search-timeout <timeout>",
+			"Timeout for unresponsive searches",
+			fallback(fileConfig.searchTimeout, "30 seconds")
 		);
 }
 

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -191,4 +191,28 @@ module.exports = {
 	 * "3 days"
 	 */
 	searchCadence: undefined,
+
+	/**
+	 * Fail snatch requests that haven't responded after this long.
+	 * Set to null for an infinite timeout.
+	 * Format: https://github.com/vercel/ms
+	 * Examples:
+	 * "30sec"
+	 * "10s"
+	 * "1min"
+	 * null
+	 */
+	snatchTimeout: undefined,
+
+	/**
+	 * Fail search requests that haven't responded after this long.
+	 * Set to null for an infinite timeout.
+	 * Format: https://github.com/vercel/ms
+	 * Examples:
+	 * "30sec"
+	 * "10s"
+	 * "1min"
+	 * null
+	 */
+	searchTimeout: undefined,
 };

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -195,4 +195,28 @@ module.exports = {
 	 * "3 days"
 	 */
 	searchCadence: undefined,
+
+	/**
+	 * Fail snatch requests that haven't responded after this long.
+	 * Set to null for an infinite timeout.
+	 * Format: https://github.com/vercel/ms
+	 * Examples:
+	 * "30sec"
+	 * "10s"
+	 * "1min"
+	 * null
+	 */
+	snatchTimeout: undefined,
+
+	/**
+	 * Fail search requests that haven't responded after this long.
+	 * Set to null for an infinite timeout.
+	 * Format: https://github.com/vercel/ms
+	 * Examples:
+	 * "30sec"
+	 * "10s"
+	 * "1min"
+	 * null
+	 */
+	searchTimeout: undefined,
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,6 +36,8 @@ interface FileConfig {
 	host?: string;
 	searchCadence?: string;
 	rssCadence?: string;
+	snatchTimeout?: string;
+	searchTimeout?: string;
 }
 
 interface GenerateConfigParams {

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -28,6 +28,8 @@ export interface RuntimeConfig {
 	port: number | false | null;
 	searchCadence: number;
 	rssCadence: number;
+	snatchTimeout: number;
+	searchTimeout: number;
 }
 
 let runtimeConfig: RuntimeConfig;

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -37,7 +37,12 @@ export async function parseTorrentFromURL(
 	url: string
 ): Promise<Result<Metafile, SnatchError>> {
 	const abortController = new AbortController();
-	setTimeout(() => void abortController.abort(), 30000).unref();
+	const { snatchTimeout } = getRuntimeConfig();
+
+	console.log("parseTorrentFromURL", snatchTimeout);
+	if (typeof snatchTimeout === "number") {
+		setTimeout(() => void abortController.abort(), snatchTimeout).unref();
+	}
 
 	let response: Response;
 	try {


### PR DESCRIPTION
closes #386

This PR adds two options:
- `--search-timeout`/`searchTimeout`, in `vercel/ms` format.
- `--snatch-timeout`/`snatchTimeout`, in `vercel/ms` format.

These options govern the amount of time `cross-seed` waits for searches and snatches, respectively, before moving on. Both default to 30 seconds.