### PR TITLE
chore: tag image with semver compliant container tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/cross-seed
             ${{ secrets.DOCKERHUB_USERNAME }}/cross-seed
           tags: |
-            type=semver,pattern=version-{{version}}
+            type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/cross-seed
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=ref,event=branch
             type=ref,event=pr
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/cross-seed
             ${{ secrets.DOCKERHUB_USERNAME }}/cross-seed
           tags: |
+            type=semver,pattern=version-{{version}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
Hi 👋🏼 

I don't see a reason to have the `version-` prefix on this tag but curious to know if there was a reason for it :)

This changes also makes it easier for automation tools like Renovate that expect semver to automatically sort and filter the tag correctly.

Thanks!