### PR TITLE
(fix) enhance logger cleansing of notification urls

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,7 +52,7 @@ function redactMessage(message: string | unknown) {
 	// redact torznab api keys
 	ret = ret.replace(/apikey=[a-zA-Z0-9]+/g, `apikey=${redactionMsg}`);
 	ret = ret.replace(
-		/\/notification\/crossSeed\/\w+/g,
+		/\/notification\/crossSeed\/[a-zA-Z-0-9_-]+/g,
 		`/notification/crossSeed/${redactionMsg}`
 	);
 	for (const [key, urlStr] of Object.entries(runtimeConfig)) {


### PR DESCRIPTION
cleanse notifiarr url

current console output
`  notificationWebhookUrl: 'https://notifiarr.com/api/v1/notification/crossSeed/[REDACTED]-1234-568-9d05-1fghj1i678uik',`

this changes from /w to 0-9-a-zA-Z_- which covers `-` as well as `/w` 

also aligns regex with the torznab logic for consistency