### PR TITLE
Force the content layout when injecting file in qbittorrent

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -322,6 +322,7 @@ export default class QBittorrent implements TorrentClient {
 				formData.append("savepath", save_path);
 			}
 			if (path) {
+				formData.append("contentLayout", "Original");
 				formData.append("skip_checking", skipRecheck.toString());
 				formData.append("paused", (!skipRecheck).toString());
 			} else {


### PR DESCRIPTION
Currently when doing a data based search, the injected content uses the default settings from qbittorrent when picking the content layout.

If the instance of qbittorrent uses `Subfolder` as the default content layout, cross-seed copies the content in the original layout and adds the torrent which can't be resumed as it expects the subfolder layout.

To counteract that, there are two options; copying the file in the right location (depending on the default layout set by qbittorrent); or forcing the layout to be `Original`.

This is the latter approach.