### PR TITLE
Search torrentDir before dataDirs

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -239,6 +239,9 @@ async function findSearchableTorrents() {
 			.filter((t) => t.isOk())
 			.map((t) => t.unwrapOrThrow());
 	} else {
+		if (typeof torrentDir === "string") {
+			allSearchees.push(...(await loadTorrentDirLight()));
+		}
 		if (Array.isArray(dataDirs)) {
 			const searcheeResults = await Promise.all(
 				findSearcheesFromAllDataDirs().map(createSearcheeFromPath)
@@ -248,9 +251,6 @@ async function findSearchableTorrents() {
 					.filter((t) => t.isOk())
 					.map((t) => t.unwrapOrThrow())
 			);
-		}
-		if (typeof torrentDir === "string") {
-			allSearchees.push(...(await loadTorrentDirLight()));
 		}
 	}
 


### PR DESCRIPTION
Run the search on TorrentDir first as it will look for exact matches as a first order.

Currently cross-seed will process the dataDirs before considering a lookup of the torrentDir.
In practice, searches using the torrent dir allows to find exact matches to cross-seed. It requires fewer operations (no hardlinks) and uses the same category as the original torrent. It is overall "safer".

Because of this, it would be preferable to process the entire content of the torrentDir first, and only then do a more thorough lookup which may or may not get hits.