### PR TITLE
Try/Catch exception when a single sample search fails

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -147,21 +147,26 @@ async function findMatchesBatch(
 
 	let totalFound = 0;
 	for (const [i, sample] of samples.entries()) {
-		const sleep = new Promise((r) => setTimeout(r, delay * 1000));
+		try {
+			const sleep = new Promise((r) => setTimeout(r, delay * 1000));
 
-		const progress = chalk.blue(`[${i + 1}/${samples.length}]`);
-		const name = stripExtension(sample.name);
-		logger.info("%s %s %s", progress, chalk.dim("Searching for"), name);
+			const progress = chalk.blue(`[${i + 1}/${samples.length}]`);
+			const name = stripExtension(sample.name);
+			logger.info("%s %s %s", progress, chalk.dim("Searching for"), name);
 
-		const { matches, searchedIndexers } = await findOnOtherSites(
-			sample,
-			hashesToExclude
-		);
-		totalFound += matches;
+			const { matches, searchedIndexers } = await findOnOtherSites(
+				sample,
+				hashesToExclude
+			);
+			totalFound += matches;
 
-		// if all indexers were rate limited, don't sleep
-		if (searchedIndexers === 0) continue;
-		await sleep;
+			// if all indexers were rate limited, don't sleep
+			if (searchedIndexers === 0) continue;
+			await sleep;
+		} catch (e) {
+			logger.error(`error searching for ${sample.name}`);
+			logger.debug(e);
+		}
 	}
 	return totalFound;
 }


### PR DESCRIPTION
Avoid an exception for a single search breaking the entire search batch.

Addresses concerns from #424

When running a batch search, treat each search as a possible failing element, catching the exception and proceeding onto the next item in the batch.
It doesn't fix entirely the issue raised in #424, but it avoid the batch search to crash entirely if during the batch processing an item gets removed.