### PR TITLE
Set a minimum cadence of once a day if excludeRecentSearch hasn't been set

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -40,10 +40,15 @@ function processOptions(options): RuntimeConfig {
 		options.rssCadence = Math.max(ms(options.rssCadence), ms("10 minutes"));
 	}
 	if (options.searchCadence) {
-		options.searchCadence = Math.max(
-			ms(options.searchCadence),
-			ms("1 day")
-		);
+		options.searchCadence = ms(options.searchCadence);
+
+		// Set a minimum cadence of once a day if excludeRecentSearch hasn't been set to avoid flooding requests
+		if (!options.excludeRecentSearch) {
+			options.searchCadence = Math.max(
+				options.searchCadence,
+				ms("1 day")
+			);
+		}
 	}
 
 	if (options.excludeOlder) {


### PR DESCRIPTION
Set a minimum cadence of once a day if excludeRecentSearch hasn't been set to avoid flooding requests

This limitation of 1 day is artificial to avoid spamming servers when doing lookups too frequently.
It is safe to assume that a  user that made use of the `excludeRecentSearch` option has put controls in place to avoid the said flooding, making that limitation unecessary.

Another option would be forcing the `excludeRecentSearch` to a day by default (it would have similar practical effects).