### PR TITLE
Create the directory recursively when doing a path search

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -44,7 +44,7 @@ export async function performAction(
 			// Candidate is single, nested file
 			if (candidateParentDir != ".") {
 				if (!existsSync(path.join(linkDir, candidateParentDir))) {
-					mkdirSync(path.join(linkDir, candidateParentDir));
+					mkdirSync(path.join(linkDir, candidateParentDir), { recursive: true });
 				}
 				correctedlinkDir = path.join(linkDir, candidateParentDir);
 			}


### PR DESCRIPTION
If for any reason the `candidateParentDir` doesn't exist when doing a search match, ensure that it gets created on the fly.

This avoid issues where `candidateParentDir` isn't present during a match:
```
info: [torznab] Searching 12 indexers for Series.S01E03.2160p.WEB-DL.DDPA5.1.HDR.HEVC-NTb.mkv
error: ENOENT: no such file or directory, mkdir '/data/torrents/completed/others/Series.S01E03.2160p.WEB-DL.DDPA5.1.HDR.HEVC-NTb'
```