### PR TITLE
Fix search limit config item

### DIFF
--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -86,7 +86,6 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			last_searched_all: db.raw("coalesce(timestamp.last_searched, 0)"),
 		})
 		.first();
-		
 	const { first_searched_all, last_searched_all } = timestampDataSql;
 	function logReason(reason) {
 		logger.verbose({

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -82,7 +82,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 				"coalesce(timestamp.first_searched, 9223372036854775807)"
 			),
 		})
-		.max({
+		.min({
 			last_searched_all: db.raw("coalesce(timestamp.last_searched, 0)"),
 		})
 		.first();

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -78,7 +78,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			enabledIndexers.map((i) => i.id)
 		)
 		.min({
-			first_searched_all: db.raw(
+			first_searched_any: db.raw(
 				"coalesce(timestamp.first_searched, 9223372036854775807)"
 			),
 		})
@@ -87,7 +87,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		})
 		.first();
 
-	const { first_searched_all, last_searched_all } = timestampDataSql;
+	const { first_searched_any, last_searched_all } = timestampDataSql;
 	function logReason(reason) {
 		logger.verbose({
 			label: Label.PREFILTER,
@@ -97,12 +97,12 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 
 	if (
 		typeof excludeOlder === "number" &&
-		first_searched_all &&
-		first_searched_all < nMsAgo(excludeOlder)
+		first_searched_any &&
+		first_searched_any < nMsAgo(excludeOlder)
 	) {
 		logReason(
 			`its first search timestamp ${humanReadable(
-				first_searched_all
+				first_searched_any
 			)} is older than ${ms(excludeOlder, { long: true })} ago`
 		);
 		return false;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -86,6 +86,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			last_searched_all: db.raw("coalesce(timestamp.last_searched, 0)"),
 		})
 		.first();
+
 	const { first_searched_all, last_searched_all } = timestampDataSql;
 	function logReason(reason) {
 		logger.verbose({

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -63,16 +63,16 @@ export function filterDupes(searchees: Searchee[]): Searchee[] {
 export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 	const { excludeOlder, excludeRecentSearch } = getRuntimeConfig();
 	const enabledIndexers = await getEnabledIndexers();
-  const timestampDataSql = await db("searchee")
+	const timestampDataSql = await db("searchee")
 		// @ts-expect-error crossJoin supports string
 		.crossJoin("indexer")
 		.leftOuterJoin("timestamp", {
 			"timestamp.indexer_id": "indexer.id",
 			"timestamp.searchee_id": "searchee.id",
 		})
-    .where("searchee.name",
-    searchee.name
-    )
+		.where("searchee.name",
+		searchee.name
+		)
 		.whereIn(
 			"indexer.id",
 			enabledIndexers.map((i) => i.id)
@@ -86,7 +86,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			last_searched_all: db.raw("coalesce(timestamp.last_searched, 0)"),
 		})
 		.first();
-    
+		
 	const { first_searched_all, last_searched_all } = timestampDataSql;
 	function logReason(reason) {
 		logger.verbose({


### PR DESCRIPTION
The SQL query for the filterTimestamps function was malformed and would return the same (too high, low) timestamp every time, since it didn't filter for torrent name, and because max and min were reversed. It would never filter any torrent unless every single torrent had an extant entry in the db for every indexer.

Fixes cross-seed/cross-seed#453