### PR TITLE
Fix ci for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1          
+        uses: docker/setup-buildx-action@v1
       -
         name: Login to GHCR
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -50,6 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Login to DockerHub
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -58,7 +60,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ !github.event.pull_request.head.repo.fork }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This skips all the steps involving pushing artifacts if running in a fork.