### PR TITLE
fix(regex): movie and tv (pack and episode) regex

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,11 +6,11 @@ export const PROGRAM_NAME = packageDotJson.name;
 export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
 
-export const EP_REGEX = /^(?<title>.+)[. ](?<season>S\d+)(?<episode>E\d+)/i;
+export const EP_REGEX = /^(?<title>.+?)[\s._](?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[-\s]?E?\d+)?)/i;
 export const SEASON_REGEX =
-	/^(?<title>.+)[. ](?<season>S\d+)(?:\s?-\s?(?<seasonmax>S?\d+))?(?!E\d+)/i;
+	/^(?<title>.+?)[_.\s](?<season>S\d+)(?:[.\-\s]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
-	/^(?<title>.+)[. ][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
+	/^(?<title>.+?)[._\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi"];
 


### PR DESCRIPTION
The following are changes made to improve matching for TV (season pack and episode) as well as movies.

# All Regex's
* Replaced literal space (' ') in expressions with \s
* Changed <title> capture group to match lazily, reducing the total steps per match proportionally to the total string length after the second capture group.

# MOVIE_REGEX
* Added support for '_' in release name.

# SEASON_REGEX
* Added support for '_' in release naming. (Does not use in season numbering range for multi-season packs)
* Capture multiple variations (including poorly named) of multiple season packs properly.
* Fixed matching incorrectly when season has more than one digit

# EP_REGEX
* Added more variations on multi-episode capturing

If you run some test cases and find any outliers or mismatching, please comment and note what release naming you used to demonstrate.