### PR TITLE
feat(client/deluge): injection support for deluge torrent client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "5.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"axios": "^1.5.1",
 				"bencode": "^2.0.1",
 				"better-sqlite3": "^8.0.1",
 				"chalk": "^5.0.0",
@@ -45,15 +44,6 @@
 			},
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/axios": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-			"integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "5.6.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"axios": "^1.5.1",
 				"bencode": "^2.0.1",
 				"better-sqlite3": "^8.0.1",
 				"chalk": "^5.0.0",
@@ -44,6 +45,15 @@
 			},
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"node_modules/axios": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+			"integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cross-seed",
 	"version": "5.6.0",
-	"description": "Query Jackett for cross-seedable torrents",
+	"description": "Fully-automatic cross-seeding with Torznab",
 	"scripts": {
 		"test": "true",
 		"build": "tsc",

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -6,14 +6,21 @@ import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import { TorrentClient } from "./TorrentClient.js";
 import fetch, { Headers, Response } from "node-fetch";
+
+interface DelugeResponse {
+	error?: {
+		message?: string;
+		code?: number;
+	};
+	result?: any;
+}
+
 export default class Deluge implements TorrentClient {
 	private msgId = 0;
-	private loggedIn = false;
 	private delugeCookie = "";
 	private delugeWebUrl: URL;
 	private delugeLabel: string;
 	private isLabelEnabled: Promise<boolean>;
-	private delugeRetries: number;
 
 	constructor() {
 		this.delugeWebUrl = new URL(`${getRuntimeConfig().delugeWebUrl}`);
@@ -38,9 +45,9 @@ export default class Deluge implements TorrentClient {
 	 * connects and authenticates to the webui
 	 */
 	private async authenticate(): Promise<void> {
-		let response = await this.call({
-			params: [this.delugeWebUrl.password],
+		const response = await this.call({
 			method: "auth.login",
+			params: [this.delugeWebUrl.password],
 		});
 
 		if (response === null) {
@@ -48,41 +55,11 @@ export default class Deluge implements TorrentClient {
 				`failed to establish a connection to deluge: ${this.delugeWebUrl.origin}`
 			);
 		}
-
-		if (response.data.result && response.headers.has("Set-Cookie")) {
-			this.delugeCookie = response.headers
-				.get("Set-Cookie")
-				.split(";")[0];
-			this.loggedIn = true;
-			return;
-		}
-		throw new CrossSeedError(
-			`failed to authenticate the session in deluge: ${this.delugeWebUrl.origin}`
-		);
 	}
 
 	/**
 	 * ensures authentication and sends JSON-RPC calls to deluge
 	 */
-	private async sendCall(method: string, params: any[]) {
-		let response;
-		response = await this.call({
-			params: params,
-			method,
-		});
-
-		if (response.code == 1) {
-			await this.authenticate();
-			response = await this.call({
-				params: params,
-				method,
-			});
-		}
-		return response && response.data && response.data.error === null
-			? response.data
-			: response.data.error;
-	}
-
 	private async call(body: { method: string; params: any[] }) {
 		this.msgId = (this.msgId + 1) % 1024;
 
@@ -90,46 +67,82 @@ export default class Deluge implements TorrentClient {
 		if (this.delugeCookie) headers.set("Cookie", this.delugeCookie);
 
 		const url = this.delugeWebUrl.origin + this.delugeWebUrl.pathname;
-		let response: Response;
+		let response: Response, json: DelugeResponse;
 		try {
 			response = await fetch(url, {
-				body: JSON.stringify({ ...body, msgId: this.msgId }),
+				body: JSON.stringify({ ...body, id: this.msgId }),
 				method: "POST",
 				headers: headers,
 			});
+			json = (await response.json()) as DelugeResponse;
 		} catch (networkError) {
 			return null;
 		}
 
+		if (json && json.error && json.error.code && json.error.code === 1) {
+			await this.authenticate();
+			try {
+				response = await fetch(url, {
+					body: JSON.stringify({ ...body, id: this.msgId }),
+					method: "POST",
+					headers: headers,
+				});
+			} catch (networkError) {
+				return null;
+			}
+			json = (await response.json()) as DelugeResponse;
+		}
 		if (!response.ok) {
 			return null;
 		}
-		return { ...response, data: (await response.json()) as any };
+
+		if (response.headers && response.headers.has("Set-Cookie")) {
+			this.delugeCookie = response.headers
+				.get("Set-Cookie")
+				.split(";")[0];
+		} else if (body.method == "auth.login") {
+			throw new CrossSeedError(
+				`failed to authenticate the session in deluge: ${this.delugeWebUrl.origin}`
+			);
+		}
+		return json;
 	}
 
 	/**
-	 * lists plugins and adds/sets labels
+	 * checks enabled plugins for "Label"
 	 * returns true if successful.
 	 */
 	private async labelEnabled() {
-		const enabledLabels = await this.sendCall(
-			"core.get_enabled_plugins",
-			[]
-		);
+		const enabledLabels = await this.call({
+			method: "core.get_enabled_plugins",
+			params: [],
+		});
 		return enabledLabels.result && enabledLabels.result.includes("Label");
 	}
+
+	/**
+	 * if Label plugin is loaded, adds (if necessary)
+	 * and sets the label based on torrent hash.
+	 */
 	private async setLabel(infoHash: string): Promise<void> {
 		if (this.isLabelEnabled) {
-			const setResult = await this.sendCall("label.set_torrent", [
-				infoHash,
-				this.delugeLabel,
-			]);
-			if (setResult.code && setResult.code == 4) {
-				await this.sendCall("label.add", [this.delugeLabel]);
-				await this.sendCall("label.set_torrent", [
-					infoHash,
-					this.delugeLabel,
-				]);
+			const setResult = await this.call({
+				method: "label.set_torrent",
+				params: [infoHash, this.delugeLabel],
+			});
+			if (
+				setResult.error &&
+				setResult.error.code &&
+				setResult.error.code == 4
+			) {
+				await this.call({
+					method: "label.add",
+					params: [this.delugeLabel],
+				});
+				await this.call({
+					method: "label.set_torrent",
+					params: [infoHash, this.delugeLabel],
+				});
 			}
 		}
 	}
@@ -150,17 +163,23 @@ export default class Deluge implements TorrentClient {
 			newTorrent.encode().toString("base64"),
 			path
 		);
-		const addResult = await this.sendCall("core.add_torrent_file", params);
+		const addResult = await this.call({
+			method: "core.add_torrent_file",
+			params: params,
+		});
 		if (addResult.result) {
 			this.setLabel(newTorrent.infoHash);
 			return InjectionResult.SUCCESS;
-		}
-		if (addResult.message && addResult.message.includes("already")) {
+		} else if (
+			addResult.error &&
+			addResult.error.message &&
+			addResult.error.message.includes("already")
+		) {
 			return InjectionResult.ALREADY_EXISTS;
-		} else {
+		} else if (addResult.error && addResult.error.message) {
 			logger.debug({
 				label: Label.DELUGE,
-				message: `injection failed: ${addResult.message}`,
+				message: `injection failed: ${addResult.error.message}`,
 			});
 			return InjectionResult.FAILURE;
 		}
@@ -186,14 +205,21 @@ export default class Deluge implements TorrentClient {
 	 */
 	async checkCompleted(searchee: Searchee): Promise<boolean> {
 		try {
-			const params = [
-				["name", "state", "save_path"],
-				{ hash: searchee.infoHash },
-			];
-			const response = await this.sendCall("web.update_ui", params);
+			const params = [["state", "progress"], { hash: searchee.infoHash }];
 
+			const response = await this.call({
+				method: "web.update_ui",
+				params: params,
+			});
 			return (
-				response.result.torrents[searchee.infoHash].state === "Seeding"
+				response.result &&
+				response.result.torrents &&
+				(response.result.torrents[searchee.infoHash].state ===
+					"Seeding" ||
+					(response.result.torrents[searchee.infoHash].state ===
+						"Paused" &&
+						response.result.torrents[searchee.infoHash].progress ===
+							100))
 			);
 		} catch (e) {
 			logger.debug({

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -84,7 +84,7 @@ export default class Deluge implements TorrentClient {
 				headers: headers,
 			});
 		} catch (networkError) {
-			// @ts-expect-error ts needs updating
+			// @ts-expect-error needs es2022 target (tsconfig)
 			throw new Error(`Failed to connect to Deluge at ${href}`, {
 				cause: networkError,
 			});

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,0 +1,207 @@
+import axios, { AxiosResponse } from "axios";
+import { InjectionResult } from "../constants.js";
+import { CrossSeedError } from "../errors.js";
+import { Label, logger } from "../logger.js";
+import { Metafile } from "../parseTorrent.js";
+import { getRuntimeConfig } from "../runtimeConfig.js";
+import { Searchee } from "../searchee.js";
+import { TorrentClient } from "./TorrentClient.js";
+
+export default class Deluge implements TorrentClient {
+	private msgId = 0;
+	private loggedIn = false;
+	private delugeCookie = "";
+	private delugeWebUrl: URL;
+	private delugeLabel: string;
+	private isLabelEnabled: Promise<boolean>;
+	private delugeRetries: number;
+
+	constructor() {
+		this.delugeWebUrl = new URL(`${getRuntimeConfig().delugeWebUrl}`);
+		this.delugeLabel = "cross-seed";
+	}
+
+	/**
+	 * validates the login and host for deluge webui
+	 */
+	async validateConfig(): Promise<void> {
+		const url = new URL(this.delugeWebUrl);
+		if (url.username && !url.password) {
+			throw new CrossSeedError(
+				"you need to define a password in the delugeWebUrl. (eg: http://:<PASSWORD>@localhost:8112)"
+			);
+		}
+		await this.authenticate();
+		this.isLabelEnabled = this.labelEnabled();
+	}
+
+	/**
+	 * connects and authenticates to the webui
+	 */
+	private async authenticate(): Promise<void> {
+		let response = await this.call({
+			params: [this.delugeWebUrl.password],
+			method: "auth.login",
+		});
+
+		if (response === null) {
+			throw new CrossSeedError(
+				`failed to establish a connection to deluge: ${this.delugeWebUrl.origin}`
+			);
+		}
+
+		if (
+			response.data.result &&
+			response.headers &&
+			response.headers["set-cookie"]
+		) {
+			this.delugeCookie = response.headers["set-cookie"][0].split(";")[0];
+			this.loggedIn = true;
+			return;
+		}
+		throw new CrossSeedError(
+			`failed to authenticate the session in deluge: ${this.delugeWebUrl.origin}`
+		);
+	}
+
+	/**
+	 * ensures authentication and sends JSON-RPC calls to deluge
+	 */
+	private async sendCall(method: string, params: any[]) {
+		let response;
+		response = await this.call({
+			params: params,
+			method,
+		});
+
+		if (response.code == 1) {
+			await this.authenticate();
+			response = await this.call({
+				params: params,
+				method,
+			});
+		}
+		return response && response.data && response.data.error === null
+			? response.data
+			: response.data.error;
+	}
+
+	private async call(body: any): Promise<AxiosResponse | null> {
+		return new Promise((resolve) => {
+			body.id = ++this.msgId;
+			if (this.msgId > 1024) this.msgId = 0;
+			axios
+				.post(
+					this.delugeWebUrl.origin + this.delugeWebUrl.pathname,
+					body,
+					{
+						headers: {
+							"Content-Type": "application/json",
+							Cookie: this.delugeCookie,
+						},
+					}
+				)
+				.then((data) => {
+					resolve(data);
+				})
+				.catch(() => resolve(null));
+		});
+	}
+
+	/**
+	 * lists plugins and adds/sets labels
+	 * returns true if successful.
+	 */
+	private async labelEnabled() {
+		const enabledLabels = await this.sendCall(
+			"core.get_enabled_plugins",
+			[]
+		);
+		return enabledLabels.result && enabledLabels.result.includes("Label");
+	}
+	private async setLabel(infoHash: string): Promise<void> {
+		if (this.isLabelEnabled) {
+			const setResult = await this.sendCall("label.set_torrent", [
+				infoHash,
+				this.delugeLabel,
+			]);
+			if (setResult.code && setResult.code == 4) {
+				await this.sendCall("label.add", [this.delugeLabel]);
+				await this.sendCall("label.set_torrent", [
+					infoHash,
+					this.delugeLabel,
+				]);
+			}
+		}
+	}
+
+	/**
+	 * injects a torrent into deluge client
+	 */
+	async inject(
+		newTorrent: Metafile,
+		searchee: Searchee,
+		path?: string
+	): Promise<InjectionResult> {
+		if (searchee.infoHash && !(await this.checkCompleted(searchee))) {
+			return InjectionResult.TORRENT_NOT_COMPLETE;
+		}
+		const params = this.formatData(
+			`${newTorrent.name}.cross-seed.torrent`,
+			newTorrent.encode().toString("base64"),
+			path
+		);
+		const addResult = await this.sendCall("core.add_torrent_file", params);
+		if (addResult.result) {
+			this.setLabel(newTorrent.infoHash);
+			return InjectionResult.SUCCESS;
+		}
+		if (addResult.message && addResult.message.includes("already")) {
+			return InjectionResult.ALREADY_EXISTS;
+		} else {
+			logger.debug({
+				label: Label.DELUGE,
+				message: `injection failed: ${addResult.message}`,
+			});
+			return InjectionResult.FAILURE;
+		}
+	}
+
+	/**
+	 * formats the json for rpc calls to inject
+	 */
+	private formatData(filename: string, filedump: string, path: string) {
+		return [
+			filename,
+			filedump,
+			{
+				add_paused: false,
+				seed_mode: getRuntimeConfig().skipRecheck,
+				download_location: path,
+			},
+		];
+	}
+
+	/**
+	 * returns true if the torrent hash is Seeding (completed)
+	 */
+	async checkCompleted(searchee: Searchee): Promise<boolean> {
+		try {
+			let params = [
+				["name", "state", "save_path"],
+				{ hash: searchee.infoHash },
+			];
+			const response = await this.sendCall("web.update_ui", params);
+
+			return (
+				response.result.torrents[searchee.infoHash].state === "Seeding"
+			);
+		} catch (e) {
+			logger.debug({
+				label: Label.DELUGE,
+				message: `failed to fetch torrent state: ${searchee.name} - ${searchee.infoHash}`,
+			});
+		}
+		return false;
+	}
+}

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -187,7 +187,11 @@ export default class Deluge implements TorrentClient {
 			return InjectionResult.FAILURE;
 		}
 		if (addResult?.result) {
-			await this.setLabel(newTorrent.infoHash, this.delugeLabel);
+			const { dataCategory } = getRuntimeConfig();
+			await this.setLabel(
+				newTorrent.infoHash,
+				searchee.path ? dataCategory : this.delugeLabel
+			);
 			return InjectionResult.SUCCESS;
 		} else if (addResult?.error?.message?.includes("already")) {
 			return InjectionResult.ALREADY_EXISTS;
@@ -213,10 +217,8 @@ export default class Deluge implements TorrentClient {
 			filename,
 			filedump,
 			{
-				add_paused: false,
-				seed_mode: isTorrent
-					? isTorrent
-					: getRuntimeConfig().skipRecheck,
+				add_paused: isTorrent ? false : !getRuntimeConfig().skipRecheck,
+				seed_mode: isTorrent ? true : getRuntimeConfig().skipRecheck,
 				download_location: path,
 			},
 		];

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -19,7 +19,7 @@ export interface TorrentClient {
 }
 
 function instantiateDownloadClient() {
-	const { rtorrentRpcUrl, qbittorrentUrl, transmissionRpcUrl, delugeWebUrl } =
+	const { rtorrentRpcUrl, qbittorrentUrl, transmissionRpcUrl, delugeRpcUrl } =
 		getRuntimeConfig();
 	if (rtorrentRpcUrl) {
 		activeClient = new RTorrent();
@@ -27,7 +27,7 @@ function instantiateDownloadClient() {
 		activeClient = new QBittorrent();
 	} else if (transmissionRpcUrl) {
 		activeClient = new Transmission();
-	} else if (delugeWebUrl) {
+	} else if (delugeRpcUrl) {
 		activeClient = new Deluge();
 	}
 }

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -5,6 +5,7 @@ import { Searchee } from "../searchee.js";
 import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
 import Transmission from "./Transmission.js";
+import Deluge from "./Deluge.js";
 
 let activeClient: TorrentClient;
 
@@ -18,7 +19,7 @@ export interface TorrentClient {
 }
 
 function instantiateDownloadClient() {
-	const { rtorrentRpcUrl, qbittorrentUrl, transmissionRpcUrl } =
+	const { rtorrentRpcUrl, qbittorrentUrl, transmissionRpcUrl, delugeWebUrl } =
 		getRuntimeConfig();
 	if (rtorrentRpcUrl) {
 		activeClient = new RTorrent();
@@ -26,6 +27,8 @@ function instantiateDownloadClient() {
 		activeClient = new QBittorrent();
 	} else if (transmissionRpcUrl) {
 		activeClient = new Transmission();
+	} else if (delugeWebUrl) {
+		activeClient = new Deluge();
 	}
 }
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -189,6 +189,11 @@ function createCommandWithSharedOptions(name, description) {
 			fileConfig.transmissionRpcUrl
 		)
 		.option(
+			"--deluge-web-url <url>",
+			"The url of your Deluge WebUI interface. Requires '-A inject'. See the docs for more information.",
+			fileConfig.delugeWebUrl
+		)
+		.option(
 			"--duplicate-categories",
 			"Create and inject using categories with the same save paths as your normal categories",
 			fileConfig.duplicateCategories

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -189,9 +189,9 @@ function createCommandWithSharedOptions(name, description) {
 			fileConfig.transmissionRpcUrl
 		)
 		.option(
-			"--deluge-web-url <url>",
-			"The url of your Deluge WebUI interface. Requires '-A inject'. See the docs for more information.",
-			fileConfig.delugeWebUrl
+			"--deluge-rpc-url <url>",
+			"The url of your Deluge JSON-RPC interface. Requires '-A inject'. See the docs for more information.",
+			fileConfig.delugeRpcUrl
 		)
 		.option(
 			"--duplicate-categories",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -19,6 +19,11 @@ module.exports = {
 	/**
 	 * To search with downloaded data, you can pass in directories to your downloaded torrent data
 	 * to find matches rather using the torrent files themselves for matching.
+	 *
+	 * If enabled, this needs to be surrounded by brackets.
+	 * eg:
+	 * 		dataDirs: ["/path/here"],
+	 * 		dataDirs: ["/path/here", "/other/path/here"],
 	 */
 	dataDirs: undefined,
 
@@ -160,7 +165,7 @@ module.exports = {
 	 * Supply your WebUI password as well
 	 * "http://:password@localhost:8112/json"
 	 */
-	delugeWebUrl: undefined,
+	delugeRpcUrl: undefined,
 
 	/**
 	 * qBittorrent-specific

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -154,6 +154,15 @@ module.exports = {
 	transmissionRpcUrl: undefined,
 
 	/**
+	 * The url of your Deluge JSON-RPC interface.
+	 * Usually ends with "/json".
+	 * Only relevant with action: "inject".
+	 * Supply your WebUI password as well
+	 * "http://:password@localhost:8112/json"
+	 */
+	delugeWebUrl: undefined,
+
+	/**
 	 * qBittorrent-specific
 	 * Whether to inject using categories with the same save paths as your normal categories.
 	 * Example: if you have a category called "Movies",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -12,18 +12,20 @@ module.exports = {
 	 * List of Torznab URLs.
 	 * For Jackett, click "Copy RSS feed"
 	 * For Prowlarr, click on the indexer name and copy the Torznab Url, then append "?apikey=YOUR_PROWLARR_API_KEY"
-	 * Wrap each URL in quotation marks, and separate them with commas.
+	 * Wrap each URL in quotation marks, and separate them with commas, and surround the entire set in brackets.
 	 */
 	torznab: [],
 
 	/**
-	 * To search with downloaded data, you can pass in directories to your downloaded torrent data
-	 * to find matches rather using the torrent files themselves for matching.
+	 * To search with downloaded data, you can pass in directories to your downloaded torrent
+	 * data to find matches rather using the torrent files themselves for matching.
 	 *
-	 * If enabled, this needs to be surrounded by brackets.
-	 * eg:
+	 * If enabled, this needs to be surrounded by brackets. Windows users will need to use
+	 * double backslash in all paths in this config.
+	 * e.g.
 	 * 		dataDirs: ["/path/here"],
 	 * 		dataDirs: ["/path/here", "/other/path/here"],
+	 * 		dataDirs: ["C:\\My Data\\Downloads"]
 	 */
 	dataDirs: undefined,
 
@@ -68,10 +70,12 @@ module.exports = {
 	maxDataDepth: 2,
 
 	/**
-	 * Directory containing torrent files.
+	 * Directory containing .torrent files.
+	 * For qBittorrent, this is BT_Backup
 	 * For rtorrent, this is your session directory
-	 * as configured in your .rtorrent.rc file.
-	 * For deluge, this is ~/.config/deluge/state.
+	 * 		as configured in your .rtorrent.rc file.
+	 * For Deluge, this is ~/.config/deluge/state.
+	 * For Transmission, this would be ~/.config/transmission/torrents
 	 */
 	torrentDir: "/path/to/torrent/file/dir",
 

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -12,18 +12,20 @@ module.exports = {
 	 * List of Torznab URLs.
 	 * For Jackett, click "Copy RSS feed"
 	 * For Prowlarr, click on the indexer name and copy the Torznab Url, then append "?apikey=YOUR_PROWLARR_API_KEY"
-	 * Wrap each URL in quotation marks, and separate them with commas.
+	 * Wrap each URL in quotation marks, and separate them with commas, and surround the entire set in brackets.
 	 */
 	torznab: [],
 
 	/**
-	 * To search with downloaded data, you can pass in directories to your downloaded torrent data
-	 * to find matches rather using the torrent files themselves for matching.
+	 * To search with downloaded data, you can pass in directories to your downloaded torrent
+	 * data to find matches rather using the torrent files themselves for matching.
 	 *
-	 * If enabled, this needs to be surrounded by brackets.
-	 * eg:
+	 * If enabled, this needs to be surrounded by brackets. Windows users will need to use
+	 * double backslash in all paths in this config.
+	 * e.g.
 	 * 		dataDirs: ["/path/here"],
 	 * 		dataDirs: ["/path/here", "/other/path/here"],
+	 * 		dataDirs: ["C:\\My Data\\Downloads"]
 	 */
 	dataDirs: undefined,
 
@@ -68,10 +70,13 @@ module.exports = {
 	maxDataDepth: 2,
 
 	/**
-	 * Directory containing torrent files.
+	 * Directory containing .torrent files.
+	 * For qBittorrent, this is BT_Backup
 	 * For rtorrent, this is your session directory
-	 * as configured in your .rtorrent.rc file.
-	 * For deluge, this is ~/.config/deluge/state.
+	 * 		as configured in your .rtorrent.rc file.
+	 * For Deluge, this is ~/.config/deluge/state.
+	 * For Transmission, this would be ~/.config/transmission/torrents
+	 *
 	 * Don't change this for Docker.
 	 * Instead set the volume mapping on your docker container.
 	 */

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -19,6 +19,11 @@ module.exports = {
 	/**
 	 * To search with downloaded data, you can pass in directories to your downloaded torrent data
 	 * to find matches rather using the torrent files themselves for matching.
+	 *
+	 * If enabled, this needs to be surrounded by brackets.
+	 * eg:
+	 * 		dataDirs: ["/path/here"],
+	 * 		dataDirs: ["/path/here", "/other/path/here"],
 	 */
 	dataDirs: undefined,
 
@@ -164,7 +169,7 @@ module.exports = {
 	 * Supply your WebUI password as well
 	 * "http://:password@localhost:8112/json"
 	 */
-	delugeWebUrl: undefined,
+	delugeRpcUrl: undefined,
 
 	/**
 	 * qBittorrent-specific

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -158,6 +158,15 @@ module.exports = {
 	transmissionRpcUrl: undefined,
 
 	/**
+	 * The url of your Deluge JSON-RPC interface.
+	 * Usually ends with "/json".
+	 * Only relevant with action: "inject".
+	 * Supply your WebUI password as well
+	 * "http://:password@localhost:8112/json"
+	 */
+	delugeWebUrl: undefined,
+
+	/**
 	 * qBittorrent-specific
 	 * Whether to inject using categories with the same save paths as your normal categories.
 	 * Example: if you have a category called "Movies",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,6 +31,7 @@ interface FileConfig {
 	torznab?: string[];
 	qbittorrentUrl?: string;
 	transmissionRpcUrl?: string;
+	delugeWebUrl?: string;
 	duplicateCategories?: boolean;
 	notificationWebhookUrl?: string;
 	port?: number;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,7 +31,7 @@ interface FileConfig {
 	torznab?: string[];
 	qbittorrentUrl?: string;
 	transmissionRpcUrl?: string;
-	delugeWebUrl?: string;
+	delugeRpcUrl?: string;
 	duplicateCategories?: boolean;
 	notificationWebhookUrl?: string;
 	port?: number;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,6 +8,7 @@ export enum Label {
 	QBITTORRENT = "qbittorrent",
 	RTORRENT = "rtorrent",
 	TRANSMISSION = "transmission",
+	DELUGE = "deluge",
 	DECIDE = "decide",
 	PREFILTER = "prefilter",
 	CONFIGDUMP = "configdump",

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -24,7 +24,7 @@ export interface RuntimeConfig {
 	rtorrentRpcUrl: string;
 	qbittorrentUrl: string;
 	transmissionRpcUrl: string;
-	delugeWebUrl: string;
+	delugeRpcUrl: string;
 	duplicateCategories: boolean;
 	notificationWebhookUrl: string;
 	torrents: string[];

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -24,6 +24,7 @@ export interface RuntimeConfig {
 	rtorrentRpcUrl: string;
 	qbittorrentUrl: string;
 	transmissionRpcUrl: string;
+	delugeWebUrl: string;
 	duplicateCategories: boolean;
 	notificationWebhookUrl: string;
 	torrents: string[];

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -13,6 +13,7 @@ function validateOptions() {
 		rtorrentRpcUrl,
 		qbittorrentUrl,
 		transmissionRpcUrl,
+		delugeWebUrl,
 		dataDirs,
 		linkDir,
 		matchMode,
@@ -20,15 +21,20 @@ function validateOptions() {
 	} = getRuntimeConfig();
 	if (
 		action === "inject" &&
-		!(rtorrentRpcUrl || qbittorrentUrl || transmissionRpcUrl)
+		!(
+			rtorrentRpcUrl ||
+			qbittorrentUrl ||
+			transmissionRpcUrl ||
+			delugeWebUrl
+		)
 	) {
 		throw new CrossSeedError(
-			"You need to specify --rtorrent-rpc-url, --transmission-rpc-url, or --qbittorrent-url when using '-A inject'."
+			"You need to specify --rtorrent-rpc-url, --transmission-rpc-url, --qbittorrent-url, or --deluge-web-url when using '-A inject'."
 		);
 	}
 	if ((dataDirs && !linkDir) || (!dataDirs && linkDir)) {
 		throw new CrossSeedError(
-			"Data based matching requries both --link-dir and --data-dirs"
+			"Data based matching requires both --link-dir and --data-dirs"
 		);
 	}
 	if (matchMode == MatchMode.RISKY && skipRecheck) {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -13,7 +13,7 @@ function validateOptions() {
 		rtorrentRpcUrl,
 		qbittorrentUrl,
 		transmissionRpcUrl,
-		delugeWebUrl,
+		delugeRpcUrl,
 		dataDirs,
 		linkDir,
 		matchMode,
@@ -25,11 +25,11 @@ function validateOptions() {
 			rtorrentRpcUrl ||
 			qbittorrentUrl ||
 			transmissionRpcUrl ||
-			delugeWebUrl
+			delugeRpcUrl
 		)
 	) {
 		throw new CrossSeedError(
-			"You need to specify --rtorrent-rpc-url, --transmission-rpc-url, --qbittorrent-url, or --deluge-web-url when using '-A inject'."
+			"You need to specify --rtorrent-rpc-url, --transmission-rpc-url, --qbittorrent-url, or --deluge-rpc-url when using '-A inject'."
 		);
 	}
 	if ((dataDirs && !linkDir) || (!dataDirs && linkDir)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,6 @@ export function humanReadable(timestamp: number): string {
 }
 
 export function formatAsList(strings: string[]) {
-	// @ts-expect-error Intl.ListFormat totally exists on node 12
 	return new Intl.ListFormat("en", {
 		style: "long",
 		type: "conjunction",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,11 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"allowJs": true,
-		"target": "es2019",
+		"target": "es2021",
 		"module": "nodenext",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
+		"moduleResolution": "nodenext",
 		"sourceMap": true
 	},
 	"include": ["./src/**/*"]


### PR DESCRIPTION
# Deluge Client Integration

This PR adds support for injection to Deluge v2 torrent clients.

- Closes #58 

### notes:
- requires RpcUrl uses extractCredential function
- uses JSON-RPC endpoint in deluge's webUI
- utilizes node-fetch library for sending calls
- bare function documentation
- logging and validation of config
- returns InjectionResults properly with appropriate handling

### todo:
- [x] add authentication vs connection errors (timeout/refuse/etc)
- [x] improve the label integration (it's crude atm)
- - [x] conform to current label usage behavior
- [x] remove axios (use node-fetch)
- [x] remove extra delugeWebPassword 
- - [x] get deluge's webUrl to be redacted in logging
- [x] more complete logging
- - [x] standardize logging messaging
- [x] transient auth errors handled with limited retry
- More.....