### PR TITLE
Fix rTorrent injection incorrect paths

### DIFF
--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -1,5 +1,5 @@
 import { promises as fs, Stats } from "fs";
-import { basename, resolve, sep } from "path";
+import { dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
 import xmlrpc, { Client } from "xmlrpc";
 import { InjectionResult } from "../constants.js";
@@ -22,27 +22,37 @@ interface LibTorrentResume {
 	bitfield: number;
 	files: LibTorrentResumeFileEntry[];
 }
+
+interface DownloadLocation {
+	/**
+	 * directoryBase is the root directory of a multi-file torrent,
+	 * or the parent directory of a single-file torrent.
+	 */
+	directoryBase: string;
+	basePath: string;
+	downloadDir: string;
+}
+
 async function createLibTorrentResumeTree(
 	meta: Metafile,
-	dataDir: string,
-	isBasePath: boolean
+	basePath: string
 ): Promise<LibTorrentResume> {
 	async function getFileResumeData(
 		file: File
 	): Promise<LibTorrentResumeFileEntry> {
-		let filePath = file.path;
-		if (isBasePath && filePath.indexOf(sep) != -1) {
-			filePath = filePath.split(sep).slice(1).join(sep);
-		}
+		const filePathWithoutFirstSegment = file.path
+			.split(sep)
+			.slice(1)
+			.join(sep);
 
-		const normalizedFilePath = resolve(dataDir, filePath);
+		const resolvedFilePath = resolve(basePath, filePathWithoutFirstSegment);
 		const fileStat = await fs
-			.lstat(normalizedFilePath)
+			.stat(resolvedFilePath)
 			.catch(() => ({ isFile: () => false } as Stats));
 		if (!fileStat.isFile() || fileStat.size !== file.length) {
 			logger.debug({
 				label: Label.RTORRENT,
-				message: `File ${normalizedFilePath} either doesn't exist or is the wrong size.`,
+				message: `File ${resolvedFilePath} either doesn't exist or is the wrong size.`,
 			});
 			return {
 				completed: 0,
@@ -69,12 +79,11 @@ async function createLibTorrentResumeTree(
 async function saveWithLibTorrentResume(
 	meta: Metafile,
 	savePath: string,
-	dataDir: string,
-	isBasePath: boolean
+	basePath: string
 ): Promise<void> {
 	const rawWithLibtorrentResume = {
 		...meta.raw,
-		libtorrent_resume: await createLibTorrentResumeTree(meta, dataDir, isBasePath),
+		libtorrent_resume: await createLibTorrentResumeTree(meta, basePath),
 	};
 	await fs.writeFile(
 		savePath,
@@ -132,19 +141,19 @@ export default class RTorrent implements TorrentClient {
 		return downloadList.includes(infoHash.toUpperCase());
 	}
 
-	async checkOriginalTorrent(
+	private async checkOriginalTorrent(
 		searchee: Searchee
 	): Promise<
 		Result<
-			{ downloadDir: string },
+			{ directoryBase: string },
 			InjectionResult.FAILURE | InjectionResult.TORRENT_NOT_COMPLETE
 		>
 	> {
 		const infoHash = searchee.infoHash.toUpperCase();
-		type returnType = [["0" | "1"], [string], ["0" | "1"]];
+		type ReturnType = [[string], ["0" | "1"]];
 		let result;
 		try {
-			result = await this.methodCallP<returnType>("system.multicall", [
+			result = await this.methodCallP<ReturnType>("system.multicall", [
 				[
 					{
 						methodName: "d.directory",
@@ -163,19 +172,45 @@ export default class RTorrent implements TorrentClient {
 
 		// temp diag for #154
 		try {
-			const [[dir], [isCompleteStr]] = result;
+			const [[directoryBase], [isCompleteStr]] = result;
 			const isComplete = Boolean(Number(isCompleteStr));
 			if (!isComplete) {
 				return resultOfErr(InjectionResult.TORRENT_NOT_COMPLETE);
 			}
-			return resultOf({
-				downloadDir: dir,
-			});
+			return resultOf({ directoryBase });
 		} catch (e) {
 			logger.error(e);
 			logger.debug("Failure caused by server response below:");
 			logger.debug(inspect(result));
 			return resultOfErr(InjectionResult.FAILURE);
+		}
+	}
+
+	private async getDownloadLocation(
+		meta: Metafile,
+		searchee: Searchee,
+		path?: string
+	): Promise<
+		Result<
+			DownloadLocation,
+			InjectionResult.FAILURE | InjectionResult.TORRENT_NOT_COMPLETE
+		>
+	> {
+		if (path) {
+			const basePath = join(path, searchee.name);
+			const directoryBase = meta.isSingleFileTorrent ? path : basePath;
+			return resultOf({ downloadDir: path, basePath, directoryBase });
+		} else {
+			const result = await this.checkOriginalTorrent(searchee);
+			return result.mapOk(({ directoryBase }) => ({
+				directoryBase,
+				downloadDir: meta.isSingleFileTorrent
+					? directoryBase
+					: dirname(directoryBase),
+				basePath: meta.isSingleFileTorrent
+					? join(directoryBase, searchee.name)
+					: directoryBase,
+			}));
 		}
 	}
 
@@ -205,38 +240,23 @@ export default class RTorrent implements TorrentClient {
 			return InjectionResult.ALREADY_EXISTS;
 		}
 
-		let downloadDir: string;
-
-		if (path) {
-			downloadDir = path;
-		} else {
-			const result = await this.checkOriginalTorrent(searchee);
-
-			if (result.isErr()) {
-				return result.unwrapErrOrThrow();
-			}
-
-			downloadDir = result.unwrapOrThrow().downloadDir;
-		}
+		const result = await this.getDownloadLocation(meta, searchee, path);
+		if (result.isErr()) return result.unwrapErrOrThrow();
+		const { directoryBase, basePath } = result.unwrapOrThrow();
 
 		const torrentFilePath = resolve(
 			outputDir,
 			`${meta.name}.tmp.${Date.now()}.torrent`
 		);
 
-		await saveWithLibTorrentResume(
-			meta,
-			torrentFilePath,
-			downloadDir,
-			!Boolean(path)
-		);
+		await saveWithLibTorrentResume(meta, torrentFilePath, basePath);
 
 		for (let i = 0; i < 5; i++) {
 			try {
 				await this.methodCallP<void>("load.start", [
 					"",
 					torrentFilePath,
-					`d.${path ? "directory" : "directory_base"}.set="${downloadDir}"`,
+					`d.directory_base.set="${directoryBase}"`,
 					`d.custom1.set="cross-seed"`,
 					`d.custom.set=addtime,${Math.round(Date.now() / 1000)}`,
 				]);

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -233,7 +233,7 @@ export default class RTorrent implements TorrentClient {
 				await this.methodCallP<void>("load.start", [
 					"",
 					torrentFilePath,
-					`d.directory_base.set="${downloadDir}"`,
+					`d.${path ? "directory" : "directory_base"}.set="${downloadDir}"`,
 					`d.custom1.set="cross-seed"`,
 					`d.custom.set=addtime,${Math.round(Date.now() / 1000)}`,
 				]);

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -24,13 +24,14 @@ interface LibTorrentResume {
 }
 async function createLibTorrentResumeTree(
 	meta: Metafile,
-	dataDir: string
+	dataDir: string,
+	isBasePath: boolean
 ): Promise<LibTorrentResume> {
 	async function getFileResumeData(
 		file: File
 	): Promise<LibTorrentResumeFileEntry> {
 		let filePath = file.path;
-		if (filePath.indexOf(sep) != -1) {
+		if (isBasePath && filePath.indexOf(sep) != -1) {
 			filePath = filePath.split(sep).slice(1).join(sep);
 		}
 
@@ -68,11 +69,12 @@ async function createLibTorrentResumeTree(
 async function saveWithLibTorrentResume(
 	meta: Metafile,
 	savePath: string,
-	dataDir: string
+	dataDir: string,
+	isBasePath: boolean
 ): Promise<void> {
 	const rawWithLibtorrentResume = {
 		...meta.raw,
-		libtorrent_resume: await createLibTorrentResumeTree(meta, dataDir),
+		libtorrent_resume: await createLibTorrentResumeTree(meta, dataDir, isBasePath),
 	};
 	await fs.writeFile(
 		savePath,
@@ -225,7 +227,8 @@ export default class RTorrent implements TorrentClient {
 		await saveWithLibTorrentResume(
 			meta,
 			torrentFilePath,
-			path ? path : downloadDir
+			downloadDir,
+			!Boolean(path)
 		);
 
 		for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
Closes #502 .
Tested on:
1. Single-file unrenamed torrent
2. Multi-file unrenamed folder
3. Single-file renamed (without its name in path) torrent
4. Multi-file renamed (without its name in path) torrent

Also checks the data for torrent resume correctly.