### PR TITLE
Handle URL paths better

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,7 @@ export function extractCredentialsFromUrl(
 			username: decodeURIComponent(username),
 			password: decodeURIComponent(password),
 			href: basePath
-				? origin + join(pathname, basePath)
+				? origin + path.posix.join(pathname, basePath)
 				: pathname === "/"
 				? origin
 				: origin + pathname,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { basename } from "path";
+import path, { basename, join } from "path";
 import {
 	EP_REGEX,
 	MOVIE_REGEX,
@@ -96,14 +96,19 @@ export function fallback<T>(...args: T[]): T {
 }
 
 export function extractCredentialsFromUrl(
-	url: string
+	url: string,
+	basePath?: string
 ): Result<{ username: string; password: string; href: string }, "invalid URL"> {
 	try {
 		const { origin, pathname, username, password } = new URL(url);
 		return resultOf({
 			username: decodeURIComponent(username),
 			password: decodeURIComponent(password),
-			href: origin + pathname,
+			href: basePath
+				? origin + join(pathname, basePath)
+				: pathname === "/"
+				? origin
+				: origin + pathname,
 		});
 	} catch (e) {
 		return resultOfErr("invalid URL");


### PR DESCRIPTION
added a `basePath` argument to `extractCredentialsFromURL` that should hopefully prevent us from making the same mistake I made again.

```js
> extractCredentialsFromUrl('http://admin:adminadmin@localhost:8080/qbit')
OkResult {
  contents: {
    username: 'admin',
    password: 'adminadmin',
    href: 'http://localhost:8080/qbit'
  }
}
> extractCredentialsFromUrl('http://admin:adminadmin@localhost:8080')
OkResult {
  contents: {
    username: 'admin',
    password: 'adminadmin',
    href: 'http://localhost:8080'
  }
}
> extractCredentialsFromUrl('http://admin:adminadmin@localhost:8080/qbit', '/api/v2')
OkResult {
  contents: {
    username: 'admin',
    password: 'adminadmin',
    href: 'http://localhost:8080/qbit/api/v2'
  }
}
> extractCredentialsFromUrl('http://admin:adminadmin@localhost:8080', '/api/v2')
OkResult {
  contents: {
    username: 'admin',
    password: 'adminadmin',
    href: 'http://localhost:8080/api/v2'
  }
}
```