### PR TITLE
fix(logging/config): validates config file action methods

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -23,6 +23,16 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
 import { saveTorrentFile } from "./torrent.js";
 import { getTag } from "./utils.js";
+import { CrossSeedError } from "./errors.js";
+
+export async function validateAction(): Promise<void> {
+	const { action } = getRuntimeConfig();
+	if (action !== Action.INJECT && action !== Action.SAVE) {
+		throw new CrossSeedError(
+			`Action method "${action}" is invalid. Allowed choices are "save" and "inject".`
+		);
+	}
+}
 
 export async function performAction(
 	newMeta: Metafile,

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -5,6 +5,7 @@ import { logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { validateTorrentDir } from "./torrent.js";
 import { validateTorznabUrls } from "./torznab.js";
+import { validateAction } from "./action.js";
 
 function validateOptions() {
 	const {
@@ -43,6 +44,7 @@ export async function doStartupValidation(): Promise<void> {
 	const downloadClient = getClient();
 	await Promise.all<void>(
 		[
+			validateAction(),
 			validateTorznabUrls(),
 			downloadClient?.validateConfig(),
 			validateTorrentDir(),


### PR DESCRIPTION
will not silently proceed to save if erroneous values are set for action in the config file.

- Fixes #478 