### PR TITLE
feat(daemon): add API auth

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@ import { db } from "./db.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 
 function generateApiKey(): string {
-	return randomBytes(16).toString("hex");
+	return randomBytes(24).toString("hex");
 }
 
 export async function resetApiKey(): Promise<string> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@ import { db } from "./db.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 
 function generateApiKey(): string {
-	return randomBytes(32).toString("hex");
+	return randomBytes(16).toString("hex");
 }
 
 export async function resetApiKey(): Promise<string> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,8 +19,8 @@ export async function getApiKeyFromDatabase(): Promise<string> {
 }
 
 export async function checkApiKey(keyToCheck: string): Promise<boolean> {
-	const { auth } = getRuntimeConfig();
-	if (!auth) return true;
+	const { apiAuth } = getRuntimeConfig();
+	if (!apiAuth) return true;
 	const apikey = await getApiKeyFromDatabase();
 	return apikey === keyToCheck;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,1 @@
+import { db } from "./db.js";

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,1 +1,26 @@
+import { randomBytes } from "node:crypto";
 import { db } from "./db.js";
+import { getRuntimeConfig } from "./runtimeConfig.js";
+
+function generateApiKey(): string {
+	return randomBytes(32).toString("hex");
+}
+
+export async function resetApiKey(): Promise<string> {
+	const apikey = generateApiKey();
+	await db("settings").update({ apikey });
+	return apikey;
+}
+
+export async function getApiKeyFromDatabase(): Promise<string> {
+	const { apikey } = await db("settings").select("apikey").first();
+	if (!apikey) return resetApiKey();
+	return apikey;
+}
+
+export async function checkApiKey(keyToCheck: string): Promise<boolean> {
+	const { auth } = getRuntimeConfig();
+	if (!auth) return true;
+	const apikey = await getApiKeyFromDatabase();
+	return apikey === keyToCheck;
+}

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -309,7 +309,11 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 		fallback(fileConfig.port, 2468)
 	)
 	.option("--host <host>", "Bind to a specific IP address", fileConfig.host)
-	.option("--api-auth", "Require API auth via API key", fileConfig.apiAuth)
+	.option(
+		"--api-auth",
+		"Require API auth via API key",
+		fallback(fileConfig.apiAuth, false)
+	)
 	.option("--no-api-auth", "Don't require API auth")
 	.option("--no-port", "Do not listen on any port")
 	.option(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -291,6 +291,7 @@ program
 	.action(async () => {
 		await db.migrate.latest();
 		console.log(await getApiKeyFromDatabase());
+		await db.destroy();
 	});
 
 program
@@ -299,6 +300,7 @@ program
 	.action(async () => {
 		await db.migrate.latest();
 		console.log(await resetApiKey());
+		await db.destroy();
 	});
 
 createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { Option, program } from "commander";
 import ms from "ms";
 import { inspect } from "util";
+import { getApiKeyFromDatabase, resetApiKey } from "./auth.js";
 import { generateConfig, getFileConfig } from "./configuration.js";
 import {
 	Action,
@@ -282,6 +283,22 @@ program
 		console.log(
 			createSearcheeFromMetafile(await parseTorrentFromFilename(fn))
 		);
+	});
+
+program
+	.command("api-key")
+	.description("Show the api key")
+	.action(async () => {
+		await db.migrate.latest();
+		console.log(await getApiKeyFromDatabase());
+	});
+
+program
+	.command("reset-api-key")
+	.description("Reset the api key")
+	.action(async () => {
+		await db.migrate.latest();
+		console.log(await resetApiKey());
 	});
 
 createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -309,7 +309,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 		fallback(fileConfig.port, 2468)
 	)
 	.option("--host <host>", "Bind to a specific IP address", fileConfig.host)
-	.option("--apikey <apikey>", "Require API auth", fileConfig.apikey)
+	.option("--auth", "Require API auth", fileConfig.auth)
 	.option("--no-port", "Do not listen on any port")
 	.option(
 		"--search-cadence <cadence>",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -309,7 +309,8 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 		fallback(fileConfig.port, 2468)
 	)
 	.option("--host <host>", "Bind to a specific IP address", fileConfig.host)
-	.option("--auth", "Require API auth", fileConfig.auth)
+	.option("--api-auth", "Require API auth via API key", fileConfig.apiAuth)
+	.option("--no-api-auth", "Don't require API auth")
 	.option("--no-port", "Do not listen on any port")
 	.option(
 		"--search-cadence <cadence>",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -292,6 +292,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 		fallback(fileConfig.port, 2468)
 	)
 	.option("--host <host>", "Bind to a specific IP address", fileConfig.host)
+	.option("--apikey <apikey>", "Require API auth", fileConfig.apikey)
 	.option("--no-port", "Do not listen on any port")
 	.option(
 		"--search-cadence <cadence>",
@@ -316,7 +317,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 			});
 			await db.migrate.latest();
 			await doStartupValidation();
-			serve(options.port, options.host);
+			serve(options.port, options.host, options.apikey);
 			jobsLoop();
 		} catch (e) {
 			exitOnCrossSeedErrors(e);

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -334,7 +334,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 			});
 			await db.migrate.latest();
 			await doStartupValidation();
-			serve(options.port, options.host, options.apikey);
+			serve(options.port, options.host);
 			jobsLoop();
 		} catch (e) {
 			exitOnCrossSeedErrors(e);

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -181,6 +181,12 @@ module.exports = {
 	host: undefined,
 
 	/**
+	 * Force authentication for API
+	 * Example: "my-long-good-token"
+	 */
+	apikey: undefined,
+
+	/**
 	 * Run rss scans on a schedule. Format: https://github.com/vercel/ms
 	 * Set to undefined or null to disable. Minimum of 10 minutes.
 	 * Examples:

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -181,10 +181,11 @@ module.exports = {
 	host: undefined,
 
 	/**
-	 * Force authentication for API
-	 * Example: "my-long-good-token"
+	 * Whether to require authentication for API.
+	 * Run the command `cross-seed api-key` to find your api key.
+	 * Keys can be provided in an X-Api-Key HTTP header or a query param.
 	 */
-	apikey: undefined,
+	apiAuth: true,
 
 	/**
 	 * Run rss scans on a schedule. Format: https://github.com/vercel/ms

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -185,10 +185,11 @@ module.exports = {
 	host: undefined,
 
 	/**
-	 * Force authentication for API
-	 * Example: "my-long-good-token"
+	 * Whether to require authentication for API.
+	 * Run the command `cross-seed api-key` to find your api key.
+	 * Keys can be provided in an X-Api-Key HTTP header or a query param.
 	 */
-	apikey: undefined,
+	apiAuth: true,
 
 	/**
 	 * Run rss scans on a schedule. Format: https://github.com/vercel/ms

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -185,6 +185,12 @@ module.exports = {
 	host: undefined,
 
 	/**
+	 * Force authentication for API
+	 * Example: "my-long-good-token"
+	 */
+	apikey: undefined,
+
+	/**
 	 * Run rss scans on a schedule. Format: https://github.com/vercel/ms
 	 * Set to undefined or null to disable. Minimum of 10 minutes.
 	 * Examples:

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -35,7 +35,7 @@ interface FileConfig {
 	notificationWebhookUrl?: string;
 	port?: number;
 	host?: string;
-	apikey?: string;
+	auth?: boolean;
 	searchCadence?: string;
 	rssCadence?: string;
 	snatchTimeout?: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -35,6 +35,7 @@ interface FileConfig {
 	notificationWebhookUrl?: string;
 	port?: number;
 	host?: string;
+	apikey?: string;
 	searchCadence?: string;
 	rssCadence?: string;
 	snatchTimeout?: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -35,7 +35,7 @@ interface FileConfig {
 	notificationWebhookUrl?: string;
 	port?: number;
 	host?: string;
-	auth?: boolean;
+	apiAuth?: boolean;
 	searchCadence?: string;
 	rssCadence?: string;
 	snatchTimeout?: string;

--- a/src/migrations/04-auth.ts
+++ b/src/migrations/04-auth.ts
@@ -6,6 +6,7 @@ async function up(knex: Knex.Knex): Promise<void> {
 		table.check("id = 0");
 		table.string("apikey");
 	});
+	await knex("settings").insert({ id: 0 });
 }
 
 function down(): void {

--- a/src/migrations/04-auth.ts
+++ b/src/migrations/04-auth.ts
@@ -9,8 +9,8 @@ async function up(knex: Knex.Knex): Promise<void> {
 	await knex("settings").insert({ id: 0 });
 }
 
-function down(): void {
-	// no new tables created
+async function down(knex: Knex.Knex): Promise<void> {
+	await knex.schema.dropTable("settings");
 }
 
 export default { name: "04-auth", up, down };

--- a/src/migrations/04-auth.ts
+++ b/src/migrations/04-auth.ts
@@ -1,0 +1,15 @@
+import Knex from "knex";
+
+async function up(knex: Knex.Knex): Promise<void> {
+	await knex.schema.createTable("settings", (table) => {
+		table.integer("id").primary();
+		table.check("id = 0");
+		table.string("apikey");
+	});
+}
+
+function down(): void {
+	// no new tables created
+}
+
+export default { name: "04-auth", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -2,10 +2,11 @@ import initialSchema from "./00-initialSchema.js";
 import jobs from "./01-jobs.js";
 import timestamps from "./02-timestamps.js";
 import rateLimits from "./03-rateLimits.js";
+import auth from "./04-auth.js";
 
 export const migrations = {
 	getMigrations: () =>
-		Promise.resolve([initialSchema, jobs, timestamps, rateLimits]),
+		Promise.resolve([initialSchema, jobs, timestamps, rateLimits, auth]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,
 };

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -33,6 +33,7 @@ export interface RuntimeConfig {
 	snatchTimeout: number;
 	searchTimeout: number;
 	searchLimit: number;
+	auth: boolean;
 }
 
 let runtimeConfig: RuntimeConfig;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -33,7 +33,7 @@ export interface RuntimeConfig {
 	snatchTimeout: number;
 	searchTimeout: number;
 	searchLimit: number;
-	auth: boolean;
+	apiAuth: boolean;
 }
 
 let runtimeConfig: RuntimeConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,18 +50,17 @@ async function authorize(
 	req: IncomingMessage,
 	res: ServerResponse
 ): Promise<boolean> {
+	const url = new URL(req.url, `http://${req.headers.host}`);
 	const apiKey =
-		(req.headers["x-api-key"] as string) ??
-		new URL(req.url).searchParams.get("apikey");
+		(req.headers["x-api-key"] as string) ?? url.searchParams.get("apikey");
 	const isAuthorized = await checkApiKey(apiKey);
 	if (!isAuthorized) {
 		const ipAddress =
 			(req.headers["x-forwarded-for"] as string)?.split(",").shift() ||
 			req.socket?.remoteAddress;
-		const pathname = new URL(req.url).pathname;
 		logger.error({
 			label: Label.SERVER,
-			message: `Unauthorized API access attempt to ${pathname} from ${ipAddress}`,
+			message: `Unauthorized API access attempt to ${url.pathname} from ${ipAddress}`,
 		});
 		res.writeHead(401, "Unauthorized");
 		res.end(

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,8 +75,6 @@ async function search(
 	req: IncomingMessage,
 	res: ServerResponse
 ): Promise<void> {
-	if (!(await authorize(req, res))) return;
-
 	const dataStr = await getData(req);
 	let data;
 	try {
@@ -139,8 +137,6 @@ async function announce(
 	req: IncomingMessage,
 	res: ServerResponse
 ): Promise<void> {
-	if (!(await authorize(req, res))) return;
-
 	const dataStr = await getData(req);
 	let data;
 	try {
@@ -205,6 +201,8 @@ async function handleRequest(
 	req: IncomingMessage,
 	res: ServerResponse
 ): Promise<void> {
+	if (!(await authorize(req, res))) return;
+
 	if (req.method !== "POST") {
 		res.writeHead(405);
 		res.end("Methods allowed: POST");

--- a/src/server.ts
+++ b/src/server.ts
@@ -236,10 +236,6 @@ async function handleRequest(
 }
 
 export function serve(port: number, host: string | undefined): void {
-	if (apiKey) {
-		secretApiKey = apiKey;
-	}
-
 	if (port) {
 		const server = http.createServer(handleRequest);
 		server.listen(port, host);

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ function parseData(data) {
 function isValidAPIKey(req: IncomingMessage): boolean {
 	// if no api key is set then always return true
 	if (secretApiKey === "") {
-		return true
+		return true;
 	}
 
 	const parsedUrl = url.parse(req.url, true);
@@ -61,7 +61,7 @@ function isValidAPIKey(req: IncomingMessage): boolean {
 	const apiKeyQueryParam = parsedUrl.query.apikey;
 
 	// get apikey from header
-	const apiKeyHeader = req.headers['x-api-key'];
+	const apiKeyHeader = req.headers["x-api-key"];
 
 	if (apiKeyQueryParam === secretApiKey || apiKeyHeader === secretApiKey) {
 		return true; // API key is valid.
@@ -246,9 +246,13 @@ async function handleRequest(
 	}
 }
 
-export function serve(port: number, host: string | undefined, apiKey: string | undefined): void {
+export function serve(
+	port: number,
+	host: string | undefined,
+	apiKey: string | undefined
+): void {
 	if (apiKey) {
-		secretApiKey = apiKey
+		secretApiKey = apiKey;
 	}
 
 	if (port) {


### PR DESCRIPTION
Hey!

This is simple implementation of adding auth to the API endpoints.

The apiKey can be set as:
 - query param `/api/webhook?apikey=my-secret-key`
 - as a header `X-API-KEY`.

If the `apikey` is set in the config file and it does not match it responds with `401 Unauthorized`.

Could be improved with a micro framework like Express or Fastify or similar that implements middlewares, but this is simple enough for the current 2 endpoints of the project.

The global var `secretApiKey` in `server.ts` might not be the best solution, but it works and makes it available to the needed functions.

:white_check_mark: Tested and it works as intended

Fixes #306 