### PR TITLE
fix(regex): title capturing trailing separator

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -263,7 +263,7 @@ export default class QBittorrent implements TorrentClient {
 		searchee: Searchee,
 		path?: string
 	): Promise<InjectionResult> {
-		const { duplicateCategories, linkDir, skipRecheck, dataCategory } =
+		const { duplicateCategories, skipRecheck, dataCategory } =
 			getRuntimeConfig();
 		try {
 			if (await this.isInfoHashInClient(newTorrent.infoHash)) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,9 +7,9 @@ export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
 
 export const EP_REGEX =
-	/^(?<title>.+?)[\s._](?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[-\s]?E?\d+)?)/i;
+	/^(?<title>.+?)[\s._-]+(?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[-\s]?E?\d+)?)/i;
 export const SEASON_REGEX =
-	/^(?<title>.+?)[_.\s](?<season>S\d+)(?:[.\-\s]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
+	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[.\-\s_]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)[._\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import path, { basename, join } from "path";
+import path, { basename } from "path";
 import {
 	EP_REGEX,
 	MOVIE_REGEX,


### PR DESCRIPTION
## TV REGEX <title> group capturing trailing separator

the regex previously captures separators trailing <title> capture group needlessly when separated with a space prior to SxxExx/Sxx (" - ") and will add the non-space separator to the search string. this usually applies when data searching an arr library/root folder.

this PR fixes this behavior and removes the separators after title from title's capture group.

- [x] EP_REGEX Test Cases: https://regex101.com/r/fuE0bM/2
- [x] SEASON_REGEX Test Cases: https://regex101.com/r/fuE0bM/1

(also removed unused variable from qbit injection function)