### PR TITLE
resolve relative directories before creating symlinks to them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ output/
 input/
 *.heapsnapshot
 qbit/
+docker/
 cache.json
 docker-compose.yml
 utils.zsh

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -61,5 +61,10 @@
         <option name="USE_TAB_CHARACTER" value="true" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="yaml">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
   </code_scheme>
 </component>


### PR DESCRIPTION
I noticed a bug with symbolic links while I was testing #503—symlinks were being created pointing to relative paths from the POV of cross-seed's working directory. 

Some other changes with mkdir— `recursive: true` will silently succeed if the directory already exists, so we are able to skip some `existsSync` precondition checks and some `try/catch`es as well. 