### PR TITLE
fix(deluge-labels): non-static label support during injection

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -172,9 +172,10 @@ module.exports = {
 	delugeRpcUrl: undefined,
 
 	/**
-	 * qBittorrent-specific
-	 * Whether to inject using categories with the same save paths as your normal categories.
-	 * Example: if you have a category called "Movies",
+	 * qBittorrent and Deluge specific
+	 * Whether to inject using the same labels/categories as the original torrent.
+	 * qBittorrent: This will apply the category's save path
+	 * Example: if you have a label/category called "Movies",
 	 * this will automatically inject cross-seeds to "Movies.cross-seed"
 	 */
 	duplicateCategories: false,

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -177,9 +177,10 @@ module.exports = {
 	delugeRpcUrl: undefined,
 
 	/**
-	 * qBittorrent-specific
-	 * Whether to inject using categories with the same save paths as your normal categories.
-	 * Example: if you have a category called "Movies",
+	 * qBittorrent and Deluge specific
+	 * Whether to inject using the same labels/categories as the original torrent.
+	 * qBittorrent: This will apply the category's save path
+	 * Example: if you have a label/category called "Movies",
 	 * this will automatically inject cross-seeds to "Movies.cross-seed"
 	 */
 	duplicateCategories: false,


### PR DESCRIPTION
# Deluge Labels

## Purpose

this mirrors the qbittorrent behavior where a matched torrent's label will now be used during injection (if a label is set)

- [x] duplicateCategories (true) will append ".cross-seed" to the same label.
- [x] dataCategory will be used for data-based matches
- [x] if "No Label" is set, default will be "cross-seed"

Closes #538 