### PR TITLE
fix(api-auth): improper endpoint parsing with url parameter

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -213,7 +213,7 @@ async function handleRequest(
 		return;
 	}
 
-	switch (req.url) {
+	switch (req.url.split("?")[0]) {
 		case "/api/webhook": {
 			logger.verbose({
 				label: Label.SERVER,


### PR DESCRIPTION
this corrects the URL parsing for the api endpoint switch

currently, if you pass a URL parameter (`?apikey=`) the switch triggers a 404

Closes #542