### PR TITLE
add(sanitization/actions): deluge-labeling (injection) and torrent filename (injection/save)

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -188,7 +188,9 @@ export default class Deluge implements TorrentClient {
 						? dataCategory
 						: torrentInfo.label
 						? duplicateCategories
-							? `${torrentInfo.label}.cross-seed`
+							? torrentInfo.label.endsWith(".cross-seed")
+								? torrentInfo.label
+								: `${torrentInfo.label}.cross-seed`
 							: torrentInfo.label
 						: this.delugeLabel
 				);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -5,7 +5,7 @@ import { Metafile } from "../parseTorrent.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import { TorrentClient } from "./TorrentClient.js";
-import { extractCredentialsFromUrl, sanitizeTorrentName } from "../utils.js";
+import { extractCredentialsFromUrl } from "../utils.js";
 import fetch, { Headers, Response } from "node-fetch";
 
 interface DelugeResponse {
@@ -173,7 +173,7 @@ export default class Deluge implements TorrentClient {
 			}
 
 			const params = this.formatData(
-				`${sanitizeTorrentName(newTorrent.name)}.cross-seed.torrent`,
+				`${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`,
 				newTorrent.encode().toString("base64"),
 				path ? path : torrentInfo.save_path,
 				!!searchee.infoHash

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -5,7 +5,7 @@ import { Metafile } from "../parseTorrent.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import { TorrentClient } from "./TorrentClient.js";
-import { extractCredentialsFromUrl } from "../utils.js";
+import { extractCredentialsFromUrl, sanitizeTorrentName } from "../utils.js";
 import fetch, { Headers, Response } from "node-fetch";
 
 interface DelugeResponse {
@@ -173,7 +173,7 @@ export default class Deluge implements TorrentClient {
 			}
 
 			const params = this.formatData(
-				`${newTorrent.name}.cross-seed.torrent`,
+				`${sanitizeTorrentName(newTorrent.name)}.cross-seed.torrent`,
 				newTorrent.encode().toString("base64"),
 				path ? path : torrentInfo.save_path,
 				!!searchee.infoHash

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -10,7 +10,7 @@ import { Label, logger, logOnce } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
-import { extractCredentialsFromUrl } from "../utils.js";
+import { extractCredentialsFromUrl, sanitizeTorrentName } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 
 const X_WWW_FORM_URLENCODED = {
@@ -270,7 +270,9 @@ export default class QBittorrent implements TorrentClient {
 				return InjectionResult.ALREADY_EXISTS;
 			}
 			const buf = newTorrent.encode();
-			const filename = `${newTorrent.name}.cross-seed.torrent`;
+			const filename = `${sanitizeTorrentName(
+				newTorrent.name
+			)}.cross-seed.torrent`;
 			const tempFilepath = join(tmpdir(), filename);
 			await writeFile(tempFilepath, buf, { mode: 0o644 });
 			const { save_path, isComplete, autoTMM, category } = path

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -10,7 +10,7 @@ import { Label, logger, logOnce } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
-import { extractCredentialsFromUrl, sanitizeTorrentName } from "../utils.js";
+import { extractCredentialsFromUrl } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 
 const X_WWW_FORM_URLENCODED = {
@@ -270,9 +270,7 @@ export default class QBittorrent implements TorrentClient {
 				return InjectionResult.ALREADY_EXISTS;
 			}
 			const buf = newTorrent.encode();
-			const filename = `${sanitizeTorrentName(
-				newTorrent.name
-			)}.cross-seed.torrent`;
+			const filename = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
 			const tempFilepath = join(tmpdir(), filename);
 			await writeFile(tempFilepath, buf, { mode: 0o644 });
 			const { save_path, isComplete, autoTMM, category } = path

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -110,6 +110,9 @@ export class Metafile {
 	static decode(buf: Buffer) {
 		return new Metafile(bencode.decode(buf));
 	}
+	getFileSystemSafeName(): string {
+		return this.name.replace("/", "");
+	}
 
 	encode(): Buffer {
 		return bencode.encode(this.raw);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -11,11 +11,7 @@ import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { createSearcheeFromTorrentFile, Searchee } from "./searchee.js";
-import {
-	reformatTitleForSearching,
-	sanitizeTorrentName,
-	stripExtension,
-} from "./utils.js";
+import { reformatTitleForSearching, stripExtension } from "./utils.js";
 
 export interface TorrentLocator {
 	infoHash?: string;
@@ -116,7 +112,7 @@ export function saveTorrentFile(
 	const { outputDir } = getRuntimeConfig();
 	const buf = meta.encode();
 	const name = stripExtension(meta.name);
-	const filename = `[${tag}][${tracker}]${sanitizeTorrentName(name)}.torrent`;
+	const filename = `[${tag}][${tracker}]${meta.getFileSystemSafeName()}.torrent`;
 	fs.writeFileSync(path.join(outputDir, filename), buf, { mode: 0o644 });
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -111,8 +111,9 @@ export function saveTorrentFile(
 ): void {
 	const { outputDir } = getRuntimeConfig();
 	const buf = meta.encode();
-	const name = stripExtension(meta.name);
-	const filename = `[${tag}][${tracker}]${stripExtension(meta.getFileSystemSafeName())}.torrent`;
+	const filename = `[${tag}][${tracker}]${stripExtension(
+		meta.getFileSystemSafeName()
+	)}.torrent`;
 	fs.writeFileSync(path.join(outputDir, filename), buf, { mode: 0o644 });
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -112,7 +112,7 @@ export function saveTorrentFile(
 	const { outputDir } = getRuntimeConfig();
 	const buf = meta.encode();
 	const name = stripExtension(meta.name);
-	const filename = `[${tag}][${tracker}]${meta.getFileSystemSafeName()}.torrent`;
+	const filename = `[${tag}][${tracker}]${stripExtension(meta.getFileSystemSafeName())}.torrent`;
 	fs.writeFileSync(path.join(outputDir, filename), buf, { mode: 0o644 });
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -11,7 +11,11 @@ import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { createSearcheeFromTorrentFile, Searchee } from "./searchee.js";
-import { reformatTitleForSearching, stripExtension } from "./utils.js";
+import {
+	reformatTitleForSearching,
+	sanitizeTorrentName,
+	stripExtension,
+} from "./utils.js";
 
 export interface TorrentLocator {
 	infoHash?: string;
@@ -112,7 +116,7 @@ export function saveTorrentFile(
 	const { outputDir } = getRuntimeConfig();
 	const buf = meta.encode();
 	const name = stripExtension(meta.name);
-	const filename = `[${tag}][${tracker}]${name}.torrent`;
+	const filename = `[${tag}][${tracker}]${sanitizeTorrentName(name)}.torrent`;
 	fs.writeFileSync(path.join(outputDir, filename), buf, { mode: 0o644 });
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,3 +113,8 @@ export function extractCredentialsFromUrl(
 		return resultOfErr("invalid URL");
 	}
 }
+
+export function sanitizeTorrentName(name: string): string {
+	const sanitizedName = name.replace("/", "");
+	return sanitizedName;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,8 +113,3 @@ export function extractCredentialsFromUrl(
 		return resultOfErr("invalid URL");
 	}
 }
-
-export function sanitizeTorrentName(name: string): string {
-	const sanitizedName = name.replace("/", "");
-	return sanitizedName;
-}


### PR DESCRIPTION
This PR adds some string sanitization to both the injection and saving of torrents where the name is used. This applies to some trackers that don't use normal file/folder structure and naming for their .torrents and then causes cross-seed to ENOENT on injection or incorrectly save.

Also addresses injecting into Deluge when the source is a torrent already in a '.cross-seed' label, will now check for the '.cross-seed' tag and not duplicate it to '.cross-seed.cross-seed'