### PR TITLE
fix(deluge/authenticate): capture errors in authenticate with try block

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -56,11 +56,15 @@ export default class Deluge implements TorrentClient {
 				"You need to define a password in the delugeRpcUrl. (e.g. http://:<PASSWORD>@localhost:8112)"
 			);
 		}
-		const authResponse = await this.call("auth.login", [password], 0);
-		if (!authResponse.result) {
-			throw new CrossSeedError(
-				`Reached Deluge, but failed to authenticate: ${href}`
-			);
+		try {
+			const authResponse = await this.call("auth.login", [password], 0);
+			if (!authResponse.result) {
+				throw new CrossSeedError(
+					`Reached Deluge, but failed to authenticate: ${href}`
+				);
+			}
+		} catch (networkError) {
+			throw new CrossSeedError(networkError);
 		}
 		const connectedResponse = await this.call("web.connected", [], 0);
 


### PR DESCRIPTION
## deluge/authenticate: capture errors in authenticate with try block

### purpose
This PR implements a try block to prevent stack tracing when deluge fails to respond during validateConfig - this is not caught currently.
```Error: Failed to connect to Deluge at http://192.168.1.14:8112/json
    at Deluge.call (file:///usr/src/cross-seed/dist/clients/Deluge.js:75:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Deluge.authenticate (file:///usr/src/cross-seed/dist/clients/Deluge.js:36:30)
    at async Deluge.validateConfig (file:///usr/src/cross-seed/dist/clients/Deluge.js:24:9)
    at async Promise.all (index 2)
    at async doStartupValidation (file:///usr/src/cross-seed/dist/startup.js:29:5)
    at async Command.<anonymous> (file:///usr/src/cross-seed/dist/cmd.js:180:9)
    at async Command.parseAsync (/usr/src/cross-seed/node_modules/commander/lib/command.js:923:5)
    at async file:///usr/src/cross-seed/dist/cmd.js:232:1 {
  [cause]: FetchError: request to http://192.168.1.14:8112/json failed, reason: connect ECONNREFUSED 192.168.1.14:8112
      at ClientRequest.<anonymous> (file:///usr/src/cross-seed/node_modules/node-fetch/src/index.js:108:11)
      at ClientRequest.emit (node:events:529:35)
      at Socket.socketErrorListener (node:_http_client:501:9)
      at Socket.emit (node:events:517:28)
      at emitErrorNT (node:internal/streams/destroy:151:8)
      at emitErrorCloseNT (node:internal/streams/destroy:116:3)
      at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
    type: 'system',
    errno: 'ECONNREFUSED',
    code: 'ECONNREFUSED',
    erroredSysCall: 'connect'
  }
}
```
Not sure if we should move the catch further up in the chain to avoid deauthentication mid-run causing CrossSeedError. Although it does CrossSeedError on bad authentication. Not entirely sure.

I think it could otherwise default to saving, but then this would need to have a try block further up the chain and the user may not know immediately that their URL or webui is bad.

This is just an initial fix/though.

### todo
- [ ] figure out how this affects transient deauthentication?