### PR TITLE
fix(migrations): set config initial value

### DIFF
--- a/src/migrations/02-timestamps.ts
+++ b/src/migrations/02-timestamps.ts
@@ -11,7 +11,7 @@ function getApikey(url: string) {
 }
 
 async function backfill(knex: Knex.Knex) {
-	const { torznab } = getRuntimeConfig();
+	const torznab = getRuntimeConfig()?.torznab ?? [];
 
 	if (torznab.length > 0) {
 		await knex("indexer")


### PR DESCRIPTION
How to reproduce: on a clear environment run `cross-seed api-key`

```
migration file "02-timestamps" failed
migration failed with error: Cannot destructure property 'torznab' of 'getRuntimeConfig(...)' as it is undefined.
file:///usr/local/lib/node_modules/cross-seed/dist/migrations/02-timestamps.js:10
    const { torznab } = getRuntimeConfig();
            ^

TypeError: Cannot destructure property 'torznab' of 'getRuntimeConfig(...)' as it is undefined.
    at backfill (file:///usr/local/lib/node_modules/cross-seed/dist/migrations/02-timestamps.js:10:13)
    at Object.up (file:///usr/local/lib/node_modules/cross-seed/dist/migrations/02-timestamps.js:42:11)
    at async Migrator._runBatch (/usr/local/lib/node_modules/cross-seed/node_modules/knex/lib/migrations/migrate/Migrator.js:381:19)
```

The commands `api-key` and `reset-api-key` will fail when running the migrations for the first time. 

- `getRuntimeConfig` _needs_ to always return an object to the destructure works.
- if `torznab` doesnt exist, `.length` will fail as well, optional chaining protect us against undefined.
