### PR TITLE
fix(announce/size): ignores erroneous size being used ("0")

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -104,7 +104,7 @@ async function assessCandidateHelper(
 ): Promise<ResultAssessment> {
 	const { matchMode } = getRuntimeConfig();
 
-	if (size != null && !sizeDoesMatch(size, searchee)) {
+	if (size && !sizeDoesMatch(size, searchee)) {
 		return { decision: Decision.SIZE_MISMATCH };
 	}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,11 @@ function parseData(data: string) {
 		if ("infoHash" in parsed) {
 			parsed.infoHash = parsed.infoHash.toLowerCase();
 		}
-		if ("size" in parsed && typeof parsed.size === "string") {
+		if (
+			"size" in parsed &&
+			typeof parsed.size === "string" &&
+			parsed.size !== "0"
+		) {
 			parsed.size = Number(parsed.size);
 		}
 	} catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,11 +37,7 @@ function parseData(data: string) {
 		if ("infoHash" in parsed) {
 			parsed.infoHash = parsed.infoHash.toLowerCase();
 		}
-		if (
-			"size" in parsed &&
-			typeof parsed.size === "string" &&
-			parsed.size !== "0"
-		) {
+		if ("size" in parsed && typeof parsed.size === "string") {
 			parsed.size = Number(parsed.size);
 		}
 	} catch (e) {


### PR DESCRIPTION
addresses potential problems when size is not provided in announce, which in autobrr results in "0" being provided as a size.

result is an automatic size mismatch, when it could/should otherwise be discarded as erroneous