### PR TITLE
follow 3xx redirects on snatch

### DIFF
--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -34,6 +34,16 @@ export async function parseTorrentFromFilename(
 	return Metafile.decode(data);
 }
 
+function isMagnetRedirectError(error: Error): boolean {
+	return (
+		// node-fetch
+		error.message.includes('URL scheme "magnet" is not supported.') ||
+		// undici
+		// @ts-expect-error error causes "not supported yet"
+		error?.cause.message.includes("URL scheme must be a HTTP(S) scheme")
+	);
+}
+
 export async function parseTorrentFromURL(
 	url: string
 ): Promise<Result<Metafile, SnatchError>> {
@@ -49,31 +59,23 @@ export async function parseTorrentFromURL(
 		response = await fetch(url, {
 			headers: { "User-Agent": USER_AGENT },
 			signal: abortController.signal,
-			redirect: "manual",
 		});
 	} catch (e) {
 		if (e.name === "AbortError") {
 			logger.error(`snatching ${url} timed out`);
 			return resultOfErr(SnatchError.ABORTED);
+		} else if (isMagnetRedirectError(e)) {
+			logger.error(`Unsupported: magnet link detected at ${url}`);
+			return resultOfErr(SnatchError.MAGNET_LINK);
 		}
 		logger.error(`failed to access ${url}`);
 		logger.debug(e);
 		return resultOfErr(SnatchError.UNKNOWN_ERROR);
 	}
 
-	if (
-		response.status.toString().startsWith("3") &&
-		response.headers.get("location")?.startsWith("magnet:")
-	) {
-		logger.error(`Unsupported: magnet link detected at ${url}`);
-		return resultOfErr(SnatchError.MAGNET_LINK);
-	} else if (response.status === 429) {
+	if (response.status === 429) {
 		return resultOfErr(SnatchError.RATE_LIMITED);
-	} else if (
-		!response.ok &&
-		response.status !== 301 &&
-		response.status !== 302
-	) {
+	} else if (!response.ok) {
 		logger.error(
 			`error downloading torrent at ${url}: ${response.status} ${response.statusText}`
 		);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -69,7 +69,11 @@ export async function parseTorrentFromURL(
 		return resultOfErr(SnatchError.MAGNET_LINK);
 	} else if (response.status === 429) {
 		return resultOfErr(SnatchError.RATE_LIMITED);
-	} else if (!response.ok) {
+	} else if (
+		!response.ok &&
+		response.status !== 301 &&
+		response.status !== 302
+	) {
 		logger.error(
 			`error downloading torrent at ${url}: ${response.status} ${response.statusText}`
 		);


### PR DESCRIPTION
previously we were explicitly _not_ following redirects so that we could intercept redirects to magnet links, but that was a workaround because the errors thrown by redirecting to magnet links were uncatchable. Since we've switched to fetch, that's no longer a problem and we can now catch the errors caused by redirecting to magnet links, and let fetch follow the redirects otherwise. 

#549 