### PR TITLE
feat(linking): support linking for torrent-backed searchees

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -42,9 +42,10 @@ export async function performAction(
 ): Promise<ActionResult> {
 	const { action, linkDir } = getRuntimeConfig();
 	const trackerLinkDir = linkDir ? join(linkDir, tracker) : undefined;
+
 	if (trackerLinkDir) {
 		const downloadDirResult = await getClient().getDownloadDir(searchee);
-		if (downloadDirResult.isErr()) {
+		if (searchee.infoHash && downloadDirResult.isErr()) {
 			// TODO figure out something better or add logging
 			return InjectionResult.FAILURE;
 		}
@@ -64,6 +65,7 @@ export async function performAction(
 		} else if (decision == Decision.MATCH_SIZE_ONLY) {
 			// Size only matching is only supported for single file or
 			// single, nested file torrents.
+
 			const candidateParentDir = dirname(newMeta.files[0].path);
 			let correctedlinkDir = trackerLinkDir;
 			// Candidate is single, nested file

--- a/src/action.ts
+++ b/src/action.ts
@@ -66,7 +66,6 @@ export async function performAction(
 			// single, nested file torrents.
 			const candidateParentDir = dirname(newMeta.files[0].path);
 			let correctedlinkDir = trackerLinkDir;
-
 			// Candidate is single, nested file
 			if (candidateParentDir !== ".") {
 				correctedlinkDir = join(trackerLinkDir, candidateParentDir);
@@ -74,10 +73,17 @@ export async function performAction(
 			}
 			linkFile(
 				searchee.infoHash
-					? downloadDirResult.unwrapOrThrow()
+					? `${downloadDirResult.unwrapOrThrow()}${sep}${
+							searchee.files[0].path
+					  }`
 					: searchee.path!,
 
-				join(correctedlinkDir, newMeta.files[0].name)
+				join(
+					correctedlinkDir,
+					newMeta.isSingleFileTorrent
+						? newMeta.files[0].name
+						: basename(newMeta.files[0].path)
+				)
 			);
 		}
 	}

--- a/src/action.ts
+++ b/src/action.ts
@@ -54,7 +54,7 @@ export async function performAction(
 			linkExact(
 				searchee.infoHash
 					? downloadDirResult.unwrapOrThrow()
-					: searchee.path,
+					: searchee.path!,
 				trackerLinkDir
 			);
 		} else if (decision == Decision.MATCH_SIZE_ONLY) {
@@ -71,7 +71,7 @@ export async function performAction(
 			linkFile(
 				searchee.infoHash
 					? downloadDirResult.unwrapOrThrow()
-					: searchee.path,
+					: searchee.path!,
 
 				join(correctedlinkDir, newMeta.files[0].name)
 			);

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,7 +7,7 @@ import {
 	statSync,
 	symlinkSync,
 } from "fs";
-import { basename, dirname, join, resolve } from "path";
+import { basename, dirname, join, resolve, sep } from "path";
 import { getClient } from "./clients/TorrentClient.js";
 import {
 	Action,
@@ -53,7 +53,11 @@ export async function performAction(
 		if (decision == Decision.MATCH) {
 			linkExact(
 				searchee.infoHash
-					? downloadDirResult.unwrapOrThrow()
+					? `${downloadDirResult.unwrapOrThrow()}${sep}${
+							newMeta.isSingleFileTorrent
+								? newMeta.files[0].name
+								: searchee.name
+					  }`
 					: searchee.path!,
 				trackerLinkDir
 			);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -6,7 +6,7 @@ import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import { TorrentClient } from "./TorrentClient.js";
 import { extractCredentialsFromUrl } from "../utils.js";
-
+import { Result, resultOf, resultOfErr } from "../Result.js";
 interface TorrentInfo {
 	complete?: boolean;
 	save_path: string;
@@ -310,27 +310,31 @@ export default class Deluge implements TorrentClient {
 	/**
 	 * returns directory of a infohash in deluge as a string
 	 */
-	async getDownloadDir(searchee: Searchee): Promise<string> {
-		let torrent: TorrentInfo;
-		const params = [["save_path"], { hash: searchee.infoHash }];
-		const response = await this.call<TorrentStatus>(
-			"web.update_ui",
-			params
-		);
-
+	async getDownloadDir(
+		searchee: Searchee
+	): Promise<
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+	> {
+		let torrent: TorrentInfo, response: DelugeJSON<TorrentStatus>;
+		const params = [["save_path", "progress"], { hash: searchee.infoHash }];
+		try {
+			response = await this.call<TorrentStatus>("web.update_ui", params);
+		} catch (e) {
+			return resultOfErr("NETWORK_ERROR");
+		}
 		if (response.result.torrents) {
 			torrent = response.result.torrents?.[searchee.infoHash];
 		} else {
-			throw new Error(
-				"Client returned unexpected response (object missing)"
-			);
+			return resultOfErr("NETWORK_ERROR");
 		}
 		if (torrent === undefined) {
-			throw new Error(
-				`Torrent not found in client (${searchee.infoHash})`
-			);
+			return resultOfErr("NOT_FOUND");
+		} else if (
+			response.result.torrents?.[searchee.infoHash].progress !== 100
+		) {
+			return resultOfErr("TORRENT_NOT_COMPLETE");
 		}
-		return torrent.save_path;
+		return resultOf(torrent.save_path);
 	}
 
 	/**

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -313,19 +313,19 @@ export default class Deluge implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
 	> {
 		let torrent: TorrentInfo, response: DelugeJSON<TorrentStatus>;
 		const params = [["save_path", "progress"], { hash: searchee.infoHash }];
 		try {
 			response = await this.call<TorrentStatus>("web.update_ui", params);
 		} catch (e) {
-			return resultOfErr("UNKNOWN_ERROR");
+			return resultOfErr("NETWORK_ERROR");
 		}
 		if (response.result!.torrents) {
 			torrent = response.result!.torrents?.[searchee.infoHash!];
 		} else {
-			return resultOfErr("UNKNOWN_ERROR");
+			return resultOfErr("NETWORK_ERROR");
 		}
 		if (torrent === undefined) {
 			return resultOfErr("NOT_FOUND");

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -313,19 +313,19 @@ export default class Deluge implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		let torrent: TorrentInfo, response: DelugeJSON<TorrentStatus>;
 		const params = [["save_path", "progress"], { hash: searchee.infoHash }];
 		try {
 			response = await this.call<TorrentStatus>("web.update_ui", params);
 		} catch (e) {
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		if (response.result!.torrents) {
 			torrent = response.result!.torrents?.[searchee.infoHash!];
 		} else {
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		if (torrent === undefined) {
 			return resultOfErr("NOT_FOUND");

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -308,6 +308,32 @@ export default class Deluge implements TorrentClient {
 	}
 
 	/**
+	 * returns directory of a infohash in deluge as a string
+	 */
+	async getDownloadDir(searchee: Searchee): Promise<string> {
+		let torrent: TorrentInfo;
+		const params = [["save_path"], { hash: searchee.infoHash }];
+		const response = await this.call<TorrentStatus>(
+			"web.update_ui",
+			params
+		);
+
+		if (response.result.torrents) {
+			torrent = response.result.torrents?.[searchee.infoHash];
+		} else {
+			throw new Error(
+				"Client returned unexpected response (object missing)"
+			);
+		}
+		if (torrent === undefined) {
+			throw new Error(
+				`Torrent not found in client (${searchee.infoHash})`
+			);
+		}
+		return torrent.save_path;
+	}
+
+	/**
 	 * returns information needed to complete/validate injection
 	 */
 	private async getTorrentInfo(searchee: Searchee): Promise<TorrentInfo> {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -313,19 +313,19 @@ export default class Deluge implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		let torrent: TorrentInfo, response: DelugeJSON<TorrentStatus>;
 		const params = [["save_path", "progress"], { hash: searchee.infoHash }];
 		try {
 			response = await this.call<TorrentStatus>("web.update_ui", params);
 		} catch (e) {
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		if (response.result.torrents) {
 			torrent = response.result.torrents?.[searchee.infoHash];
 		} else {
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		if (torrent === undefined) {
 			return resultOfErr("NOT_FOUND");

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -322,15 +322,15 @@ export default class Deluge implements TorrentClient {
 		} catch (e) {
 			return resultOfErr("UNKNOWN_ERROR");
 		}
-		if (response.result.torrents) {
-			torrent = response.result.torrents?.[searchee.infoHash];
+		if (response.result!.torrents) {
+			torrent = response.result!.torrents?.[searchee.infoHash!];
 		} else {
 			return resultOfErr("UNKNOWN_ERROR");
 		}
 		if (torrent === undefined) {
 			return resultOfErr("NOT_FOUND");
 		} else if (
-			response.result.torrents?.[searchee.infoHash].progress !== 100
+			response.result!.torrents?.[searchee.infoHash!].progress !== 100
 		) {
 			return resultOfErr("TORRENT_NOT_COMPLETE");
 		}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -224,7 +224,7 @@ export default class QBittorrent implements TorrentClient {
 	> {
 		let torrentInfo: TorrentConfiguration;
 		try {
-			if (await this.isInfoHashInClient(searchee.infoHash)) {
+			if (await this.isInfoHashInClient(searchee.infoHash!)) {
 				torrentInfo = await this.getTorrentConfiguration(searchee);
 				if (torrentInfo.save_path === undefined) {
 					return resultOfErr("NOT_FOUND");
@@ -236,7 +236,7 @@ export default class QBittorrent implements TorrentClient {
 			}
 			return resultOfErr("UNKNOWN_ERROR");
 		}
-		return resultOf(torrentInfo.save_path);
+		return resultOf(torrentInfo!.save_path);
 	}
 
 	async getTorrentConfiguration(
@@ -289,7 +289,7 @@ export default class QBittorrent implements TorrentClient {
 				return InjectionResult.ALREADY_EXISTS;
 			}
 
-const filename = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
+			const filename = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
 			const buffer = new Blob([newTorrent.encode()], {
 				type: "application/x-bittorrent",
 			});

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -275,7 +275,7 @@ export default class QBittorrent implements TorrentClient {
 						isComplete: true,
 						autoTMM: false,
 						category: dataCategory,
-				  }
+					}
 				: await this.getTorrentConfiguration(searchee);
 
 			const newCategoryName =

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -220,7 +220,7 @@ export default class QBittorrent implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		let torrentInfo: TorrentConfiguration;
 		try {
@@ -234,7 +234,7 @@ export default class QBittorrent implements TorrentClient {
 			if (e.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		return resultOf(torrentInfo.save_path);
 	}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -220,7 +220,7 @@ export default class QBittorrent implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
 	> {
 		let torrentInfo: TorrentConfiguration;
 		try {
@@ -234,7 +234,7 @@ export default class QBittorrent implements TorrentClient {
 			if (e.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
-			return resultOfErr("UNKNOWN_ERROR");
+			return resultOfErr("NETWORK_ERROR");
 		}
 		return resultOf(torrentInfo!.save_path);
 	}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -220,7 +220,7 @@ export default class QBittorrent implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		let torrentInfo: TorrentConfiguration;
 		try {
@@ -234,7 +234,7 @@ export default class QBittorrent implements TorrentClient {
 			if (e.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
-			return resultOfErr("NETWORK_ERROR");
+			return resultOfErr("UNKNOWN_ERROR");
 		}
 		return resultOf(torrentInfo!.save_path);
 	}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -299,7 +299,7 @@ export default class QBittorrent implements TorrentClient {
 						isComplete: true,
 						autoTMM: false,
 						category: dataCategory,
-					}
+				  }
 				: await this.getTorrentConfiguration(searchee);
 
 			const newCategoryName =

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -263,7 +263,9 @@ export default class RTorrent implements TorrentClient {
 	): Promise<
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
-		const result = await this.checkOriginalTorrent(searchee);
+		const result = await this.checkOriginalTorrent(
+			searchee as SearcheeWithInfoHash
+		);
 		return result
 			.mapOk(({ directoryBase, isMultiFile }) => {
 				return isMultiFile ? dirname(directoryBase) : directoryBase;

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -6,11 +6,16 @@ import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
 import Transmission from "./Transmission.js";
 import Deluge from "./Deluge.js";
+import { Result } from "../Result.js";
 
 let activeClient: TorrentClient;
 
 export interface TorrentClient {
-	getDownloadDir: (searchee: Searchee) => Promise<string>;
+	getDownloadDir: (
+		searchee: Searchee
+	) => Promise<
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+	>;
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -10,6 +10,7 @@ import Deluge from "./Deluge.js";
 let activeClient: TorrentClient;
 
 export interface TorrentClient {
+	getDownloadDir: (searchee: Searchee) => Promise<string>;
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -14,7 +14,7 @@ export interface TorrentClient {
 	getDownloadDir: (
 		searchee: Searchee
 	) => Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
 	>;
 	inject: (
 		newTorrent: Metafile,

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -14,7 +14,7 @@ export interface TorrentClient {
 	getDownloadDir: (
 		searchee: Searchee
 	) => Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	>;
 	inject: (
 		newTorrent: Metafile,

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -157,7 +157,9 @@ export default class Transmission implements TorrentClient {
 	): Promise<
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
-		const result = await this.checkOriginalTorrent(searchee);
+		const result = await this.checkOriginalTorrent(
+			searchee as SearcheeWithInfoHash
+		);
 		return result
 			.mapOk((r) => r.downloadDir)
 			.mapErr((err) => (err === "FAILURE" ? "UNKNOWN_ERROR" : err));

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -155,22 +155,14 @@ export default class Transmission implements TorrentClient {
 	async getDownloadDir(
 		searchee: Searchee
 	): Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR">
+		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		const result = await this.checkOriginalTorrent(
 			searchee as SearcheeWithInfoHash
 		);
 		return result
 			.mapOk((r) => r.downloadDir)
-			.mapErr((err) => {
-				if (err === InjectionResult.FAILURE) {
-					return "NETWORK_ERROR";
-				} else if (err === InjectionResult.TORRENT_NOT_COMPLETE) {
-					return "TORRENT_NOT_COMPLETE";
-				} else {
-					return "NOT_FOUND";
-				}
-			});
+			.mapErr((err) => (err === "FAILURE" ? "UNKNOWN_ERROR" : err));
 	}
 
 	async inject(
@@ -178,20 +170,17 @@ export default class Transmission implements TorrentClient {
 		searchee: Searchee,
 		path?: string
 	): Promise<InjectionResult> {
-		let downloadDir:
-			| string
-			| Result<
-					string,
-					"NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "NETWORK_ERROR"
-			  >;
+		let downloadDir: string;
 		if (path) {
 			downloadDir = path;
 		} else {
-			downloadDir = await this.getDownloadDir(
+			const result = await this.getDownloadDir(
 				searchee as SearcheeWithInfoHash
 			);
-			if (downloadDir.isErr()) {
+			if (result.isErr()) {
 				return InjectionResult.FAILURE;
+			} else {
+				downloadDir = result.unwrapOrThrow();
 			}
 		}
 

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -152,23 +152,26 @@ export default class Transmission implements TorrentClient {
 		return resultOf({ downloadDir });
 	}
 
+	async getDownloadDir(searchee: Searchee): Promise<string> {
+		const result = await this.checkOriginalTorrent(searchee);
+		if (result.isErr()) {
+			return result.unwrapErrOrThrow();
+		}
+		return result.unwrapOrThrow().downloadDir;
+	}
+
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
 		path?: string
 	): Promise<InjectionResult> {
 		let downloadDir: string;
-
 		if (path) {
 			downloadDir = path;
 		} else {
-			const result = await this.checkOriginalTorrent(
+			downloadDir = await this.getDownloadDir(
 				searchee as SearcheeWithInfoHash
 			);
-			if (result.isErr()) {
-				return result.unwrapErrOrThrow();
-			}
-			downloadDir = result.unwrapOrThrow().downloadDir;
 		}
 
 		let addResponse: TorrentAddResponse;

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -118,6 +118,11 @@ function createCommandWithSharedOptions(name, description) {
 			"Directory to output data-matched hardlinks to",
 			fileConfig.linkDir
 		)
+		.option(
+			"--legacy-linking",
+			"Use flat linking directory structure (without individual tracker folders)",
+			fallback(fileConfig.legacyLinking, false)
+		)
 		.addOption(
 			new Option(
 				"--link-type <type>",

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -20,6 +20,8 @@ const ZodErrorMessages = {
 	riskyRecheckWarn:
 		"It is strongly recommended to not skip rechecking for risky matching mode.",
 	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
+	qBitLegacyLinking:
+		"Using Automatic Torrent Management in qBittorrent without legacyLinking enabled can result in injection path failures.",
 };
 
 /**
@@ -110,6 +112,10 @@ export const VALIDATION_SCHEMA = z
 		dataCategory: z.string().nullish(),
 		linkDir: z.string().transform(checkValidPathFormat).nullish(),
 		linkType: z.nativeEnum(LinkType),
+		legacyLinking: z
+			.boolean()
+			.nullish()
+			.transform((value) => (typeof value !== "boolean" ? value : false)),
 		skipRecheck: z.boolean(),
 		maxDataDepth: z.number().gte(1),
 		torrentDir: z.string(),
@@ -169,6 +175,16 @@ export const VALIDATION_SCHEMA = z
 		torrents: z.array(z.string()).optional(),
 	})
 	.strict()
+	.refine((config) => {
+		if (
+			config.action == Action.INJECT &&
+			config.qbittorrentUrl &&
+			!config.legacyLinking
+		) {
+			logger.warn(ZodErrorMessages.qBitLegacyLinking);
+		}
+		return true;
+	})
 	.refine(
 		(config) =>
 			!(

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -24,6 +24,7 @@ interface FileConfig {
 	matchMode?: MatchMode;
 	linkDir?: string;
 	linkType?: string;
+	legacyLinking?: boolean;
 	skipRecheck?: boolean;
 	maxDataDepth?: number;
 	dataCategory?: string;

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -129,7 +129,7 @@ async function assessCandidateHelper(
 	searchee: Searchee,
 	hashesToExclude: string[]
 ): Promise<ResultAssessment> {
-	const { matchMode } = getRuntimeConfig();
+	const { matchMode, linkDir } = getRuntimeConfig();
 
 	if (size && !sizeDoesMatch(size, searchee)) {
 		return { decision: Decision.SIZE_MISMATCH };
@@ -157,13 +157,17 @@ async function assessCandidateHelper(
 	if (perfectMatch) {
 		return { decision: Decision.MATCH, metafile: candidateMeta };
 	}
-	if (!searchee.path) {
+	if (!searchee.path && !linkDir) {
 		return { decision: Decision.FILE_TREE_MISMATCH };
 	}
 	if (
 		matchMode == MatchMode.RISKY &&
-		!statSync(searchee.path).isDirectory() &&
-		compareFileTreesIgnoringNames(candidateMeta, searchee)
+		((searchee.path &&
+			!statSync(searchee.path).isDirectory() &&
+			compareFileTreesIgnoringNames(candidateMeta, searchee)) ||
+			(searchee.infoHash &&
+				linkDir &&
+				compareFileTreesIgnoringNames(candidateMeta, searchee)))
 	) {
 		return { decision: Decision.MATCH_SIZE_ONLY, metafile: candidateMeta };
 	}

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -7,6 +7,7 @@ export interface RuntimeConfig {
 	matchMode: MatchMode;
 	linkDir: string;
 	linkType: LinkType;
+	legacyLinking: boolean;
 	skipRecheck: boolean;
 	maxDataDepth: number;
 	dataCategory: string;


### PR DESCRIPTION
completes tracker subdir in linkdir for torrent linking to #563 

## torrent backed linking todo

### clients
- [x] transmission
- [x] rtorrent
- [x] deluge
- [x] qbittorrent
-  - [ ] check autotmm implications
- [ ] implement getDownloadDir (remove optional on TorrentClient when done)
- - [x] transmission
- - [x] rtorrent
- - [x] deluge
- - [x] qbittorrent
- [ ] have implementation reviewed

### testing
- [x] figure out linkDir not being set behavior
- [x] figure out if multi-file linking can work (and how)
- more soon