### PR TITLE
improve could not find a torrent with criteria messaging

### DIFF
--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -258,7 +258,7 @@ export async function getTorrentByCriteria(
 		.first();
 
 	if (findResult === undefined) {
-		const message = `could not find a torrent with the criteria ${inspect(
+		const message = `torrentDir does not have any torrent with criteria ${inspect(
 			criteria
 		)}`;
 		throw new Error(message);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the error message clarity for unsuccessful torrent searches to indicate no matches found in the torrent directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->