### PR TITLE
Update Typescript config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
 		"ecmaVersion": 2022
 	},
 	"rules": {
+		"no-mixed-spaces-and-tabs": "off",
 		"@typescript-eslint/no-var-requires": "off"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,10 +12,9 @@
 		"plugin:@typescript-eslint/recommended"
 	],
 	"parserOptions": {
-		"ecmaVersion": 2020
+		"ecmaVersion": 2022
 	},
 	"rules": {
-		"no-mixed-spaces-and-tabs": "off",
 		"@typescript-eslint/no-var-requires": "off"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cross-seed",
-	"version": "5.9.0",
+	"version": "5.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cross-seed",
-			"version": "5.9.0",
+			"version": "5.9.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bencode": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,14 +33,14 @@
 				"@types/lowdb": "^1.0.9",
 				"@types/xml2js": "^0.4.9",
 				"@types/xmlrpc": "^1.3.6",
-				"@typescript-eslint/eslint-plugin": "^5.8.1",
-				"@typescript-eslint/parser": "^5.8.1",
-				"eslint": "^8.5.0",
+				"@typescript-eslint/eslint-plugin": "^6.16.0",
+				"@typescript-eslint/parser": "^6.16.0",
+				"eslint": "^8.56.0",
 				"husky": "^7.0.0",
 				"lint-staged": "^12.1.4",
 				"prettier": "^2.0.5",
 				"rimraf": "^3.0.2",
-				"typescript": "^4.7.4"
+				"typescript": "^5.3.3"
 			},
 			"engines": {
 				"node": ">=16"
@@ -65,53 +65,93 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-			"integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.2.0",
-				"globals": "^13.9.0",
-				"ignore": "^4.0.6",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+		"node_modules/@eslint/js": {
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
 			"dev": true,
 			"engines": {
-				"node": ">= 4"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-			"integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^1.2.1",
+				"@humanwhocodes/object-schema": "^2.0.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
 			}
 		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -159,9 +199,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
@@ -185,6 +225,12 @@
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"dev": true
+		},
 		"node_modules/@types/xml2js": {
 			"version": "0.4.9",
 			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
@@ -204,30 +250,33 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.1.tgz",
-			"integrity": "sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.16.0.tgz",
+			"integrity": "sha512-O5f7Kv5o4dLWQtPX4ywPPa+v9G+1q1x8mz0Kr0pXUtKsevo+gIJHLkGc8RxaZWtP8RrhwhSNIWThnW42K9/0rQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/experimental-utils": "5.8.1",
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/type-utils": "6.16.0",
+				"@typescript-eslint/utils": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^5.0.0",
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -235,71 +284,27 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-			"dev": true,
-			"dependencies": {
-				"tslib": "^1.8.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-			}
-		},
-		"node_modules/@typescript-eslint/experimental-utils": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.1.tgz",
-			"integrity": "sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==",
-			"dev": true,
-			"dependencies": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/typescript-estree": "5.8.1",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.1.tgz",
-			"integrity": "sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.16.0.tgz",
+			"integrity": "sha512-H2GM3eUo12HpKZU9njig3DF5zJ58ja6ahj1GoHEHOgQvYxzoFJJEvC1MQ7T2l9Ha+69ZSOn7RTxOdpC/y3ikMw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/typescript-estree": "5.8.1",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+				"eslint": "^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -308,29 +313,56 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.1.tgz",
-			"integrity": "sha512-DGxJkNyYruFH3NIZc3PwrzwOQAg7vvgsHsHCILOLvUpupgkwDZdNq/cXU3BjF4LNrCsVg0qxEyWasys5AiJ85Q==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.16.0.tgz",
+			"integrity": "sha512-0N7Y9DSPdaBQ3sqSCwlrm9zJwkpOuc6HYm7LpzLAPqBL7dmzAUimr4M29dMkOP/tEwvOCC/Cxo//yOfJD3HUiw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/visitor-keys": "5.8.1"
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.16.0.tgz",
+			"integrity": "sha512-ThmrEOcARmOnoyQfYkHw/DX2SEYBalVECmoldVuH6qagKROp/jMnfXpAU/pAIWub9c4YTxga+XwgAkoA0pxfmg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"@typescript-eslint/utils": "6.16.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.1.tgz",
-			"integrity": "sha512-L/FlWCCgnjKOLefdok90/pqInkomLnAcF9UAzNr+DSqMC3IffzumHTQTrINXhP1gVp9zlHiYYjvozVZDPleLcA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.16.0.tgz",
+			"integrity": "sha512-hvDFpLEvTJoHutVl87+MG/c5C8I6LOgEx05zExTSJDEVU7hhR3jhV8M5zuggbdFCw98+HhZWPHZeKS97kS3JoQ==",
 			"dev": true,
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -338,21 +370,22 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.1.tgz",
-			"integrity": "sha512-26lQ8l8tTbG7ri7xEcCFT9ijU5Fk+sx/KRRyyzCv7MQ+rZZlqiDPtMKWLC8P7o+dtCnby4c+OlxuX1tp8WfafQ==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.16.0.tgz",
+			"integrity": "sha512-VTWZuixh/vr7nih6CfrdpmFNLEnoVBF1skfjdyGnNwXOH1SLeHItGdZDHhhAIzd3ACazyY2Fg76zuzOVTaknGA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/visitor-keys": "5.8.1",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -364,57 +397,82 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true
-		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^1.8.1"
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.16.0.tgz",
+			"integrity": "sha512-T83QPKrBm6n//q9mv7oiSvy/Xq/7Hyw9SzSEhMHJwznEmQayfBM87+oAlkNAMEO7/MjIwKyOHgBJbxB0s7gx2A==",
+			"dev": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": "^16.0.0 || >=18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+				"eslint": "^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.1.tgz",
-			"integrity": "sha512-SWgiWIwocK6NralrJarPZlWdr0hZnj5GXHIgfdm8hNkyKvpeQuFyLP6YjSIe9kf3YBIfU6OHSZLYkQ+smZwtNg==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.16.0.tgz",
+			"integrity": "sha512-QSFQLruk7fhs91a/Ep/LqRdbJCZ1Rq03rqBdKT5Ky17Sz8zRLUksqIe9DW0pKtg/Z35/ztbLQ6qpOCN6rOC11A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.8.1",
-				"eslint-visitor-keys": "^3.0.0"
+				"@typescript-eslint/types": "6.16.0",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^16.0.0 || >=18.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-			"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -475,6 +533,8 @@
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
 			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -921,6 +981,8 @@
 			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
 			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-colors": "^4.1.1"
 			},
@@ -949,49 +1011,49 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.5.0.tgz",
-			"integrity": "sha512-tVGSkgNbOfiHyVte8bCM8OmX+xG9PzVG/B4UCF60zx7j61WIVY/AqJECDgpLD4DbbESD0e174gOg3ZlrX15GDg==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
 			"dependencies": {
-				"@eslint/eslintrc": "^1.0.5",
-				"@humanwhocodes/config-array": "^0.9.2",
-				"ajv": "^6.10.0",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.56.0",
+				"@humanwhocodes/config-array": "^0.11.13",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
-				"enquirer": "^2.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.0",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.1.0",
-				"espree": "^9.2.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^6.0.1",
-				"globals": "^13.6.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
-				"progress": "^2.0.0",
-				"regexpp": "^3.2.0",
-				"semver": "^7.2.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -1004,43 +1066,31 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
+				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"dependencies": {
-				"eslint-visitor-keys": "^2.0.0"
-			},
-			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
-			},
-			"peerDependencies": {
-				"eslint": ">=5"
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
-				"node": ">=10"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/chalk": {
@@ -1059,37 +1109,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-			"integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-			"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/eslint/node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1102,15 +1121,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/eslint/node_modules/ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/esm": {
 			"version": "3.2.25",
 			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
@@ -1120,47 +1130,32 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.2.0.tgz",
-			"integrity": "sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.6.0",
-				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^3.1.0"
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-			"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/esquery/node_modules/estraverse": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
 			}
 		},
 		"node_modules/esrecurse": {
@@ -1175,19 +1170,10 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/esrecurse/node_modules/estraverse": {
+		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
@@ -1252,9 +1238,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1264,7 +1250,7 @@
 				"micromatch": "^4.0.4"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6.0"
 			}
 		},
 		"node_modules/fast-json-stable-stringify": {
@@ -1280,9 +1266,9 @@
 			"dev": true
 		},
 		"node_modules/fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1352,6 +1338,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -1402,12 +1404,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
 		},
 		"node_modules/fuse.js": {
 			"version": "6.6.2",
@@ -1468,9 +1464,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-			"integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -1483,16 +1479,16 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -1501,6 +1497,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"node_modules/has": {
 			"version": "1.0.3",
@@ -1566,9 +1568,9 @@
 			]
 		},
 		"node_modules/ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1675,6 +1677,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-stream": {
@@ -1986,6 +1997,21 @@
 				}
 			}
 		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2292,6 +2318,36 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/p-map": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -2317,6 +2373,15 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/path-is-absolute": {
@@ -2414,15 +2479,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -2433,9 +2489,9 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -2505,18 +2561,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
 		"node_modules/resolve": {
@@ -2650,9 +2694,9 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"node_modules/semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2965,6 +3009,18 @@
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
 			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
+		"node_modules/ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.13.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.2.0"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -3007,16 +3063,16 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uri-js": {
@@ -3032,12 +3088,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"node_modules/v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-			"dev": true
 		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.2.0",
@@ -3187,6 +3237,18 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -3206,46 +3268,65 @@
 				"kuler": "^2.0.0"
 			}
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"dev": true
+		},
 		"@eslint/eslintrc": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-			"integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.2.0",
-				"globals": "^13.9.0",
-				"ignore": "^4.0.6",
+				"espree": "^9.6.0",
+				"globals": "^13.19.0",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
-			},
-			"dependencies": {
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				}
 			}
+		},
+		"@eslint/js": {
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+			"integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+			"dev": true
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
-			"integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
 			"dev": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^1.2.1",
+				"@humanwhocodes/object-schema": "^2.0.1",
 				"debug": "^4.1.1",
-				"minimatch": "^3.0.4"
+				"minimatch": "^3.0.5"
 			}
 		},
+		"@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true
+		},
 		"@humanwhocodes/object-schema": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
 			"dev": true
 		},
 		"@nodelib/fs.scandir": {
@@ -3284,9 +3365,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
 		"@types/lodash": {
@@ -3310,6 +3391,12 @@
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.5.6",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+			"integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+			"dev": true
+		},
 		"@types/xml2js": {
 			"version": "0.4.9",
 			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
@@ -3329,134 +3416,136 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.1.tgz",
-			"integrity": "sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.16.0.tgz",
+			"integrity": "sha512-O5f7Kv5o4dLWQtPX4ywPPa+v9G+1q1x8mz0Kr0pXUtKsevo+gIJHLkGc8RxaZWtP8RrhwhSNIWThnW42K9/0rQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "5.8.1",
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-					"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-					"dev": true,
-					"requires": {
-						"tslib": "^1.8.1"
-					}
-				}
-			}
-		},
-		"@typescript-eslint/experimental-utils": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.1.tgz",
-			"integrity": "sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==",
-			"dev": true,
-			"requires": {
-				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/typescript-estree": "5.8.1",
-				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"@eslint-community/regexpp": "^4.5.1",
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/type-utils": "6.16.0",
+				"@typescript-eslint/utils": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.4",
+				"natural-compare": "^1.4.0",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.1.tgz",
-			"integrity": "sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.16.0.tgz",
+			"integrity": "sha512-H2GM3eUo12HpKZU9njig3DF5zJ58ja6ahj1GoHEHOgQvYxzoFJJEvC1MQ7T2l9Ha+69ZSOn7RTxOdpC/y3ikMw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.8.1",
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/typescript-estree": "5.8.1",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.1.tgz",
-			"integrity": "sha512-DGxJkNyYruFH3NIZc3PwrzwOQAg7vvgsHsHCILOLvUpupgkwDZdNq/cXU3BjF4LNrCsVg0qxEyWasys5AiJ85Q==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.16.0.tgz",
+			"integrity": "sha512-0N7Y9DSPdaBQ3sqSCwlrm9zJwkpOuc6HYm7LpzLAPqBL7dmzAUimr4M29dMkOP/tEwvOCC/Cxo//yOfJD3HUiw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/visitor-keys": "5.8.1"
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0"
+			}
+		},
+		"@typescript-eslint/type-utils": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.16.0.tgz",
+			"integrity": "sha512-ThmrEOcARmOnoyQfYkHw/DX2SEYBalVECmoldVuH6qagKROp/jMnfXpAU/pAIWub9c4YTxga+XwgAkoA0pxfmg==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"@typescript-eslint/utils": "6.16.0",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.1.tgz",
-			"integrity": "sha512-L/FlWCCgnjKOLefdok90/pqInkomLnAcF9UAzNr+DSqMC3IffzumHTQTrINXhP1gVp9zlHiYYjvozVZDPleLcA==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.16.0.tgz",
+			"integrity": "sha512-hvDFpLEvTJoHutVl87+MG/c5C8I6LOgEx05zExTSJDEVU7hhR3jhV8M5zuggbdFCw98+HhZWPHZeKS97kS3JoQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.1.tgz",
-			"integrity": "sha512-26lQ8l8tTbG7ri7xEcCFT9ijU5Fk+sx/KRRyyzCv7MQ+rZZlqiDPtMKWLC8P7o+dtCnby4c+OlxuX1tp8WfafQ==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.16.0.tgz",
+			"integrity": "sha512-VTWZuixh/vr7nih6CfrdpmFNLEnoVBF1skfjdyGnNwXOH1SLeHItGdZDHhhAIzd3ACazyY2Fg76zuzOVTaknGA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.8.1",
-				"@typescript-eslint/visitor-keys": "5.8.1",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/visitor-keys": "6.16.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
-				"tsutils": "^3.21.0"
+				"minimatch": "9.0.3",
+				"semver": "^7.5.4",
+				"ts-api-utils": "^1.0.1"
 			},
 			"dependencies": {
-				"tslib": {
-					"version": "1.14.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"dev": true
-				},
-				"tsutils": {
-					"version": "3.21.0",
-					"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-					"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 					"dev": true,
 					"requires": {
-						"tslib": "^1.8.1"
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
 					}
 				}
 			}
 		},
-		"@typescript-eslint/visitor-keys": {
-			"version": "5.8.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.1.tgz",
-			"integrity": "sha512-SWgiWIwocK6NralrJarPZlWdr0hZnj5GXHIgfdm8hNkyKvpeQuFyLP6YjSIe9kf3YBIfU6OHSZLYkQ+smZwtNg==",
+		"@typescript-eslint/utils": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.16.0.tgz",
+			"integrity": "sha512-T83QPKrBm6n//q9mv7oiSvy/Xq/7Hyw9SzSEhMHJwznEmQayfBM87+oAlkNAMEO7/MjIwKyOHgBJbxB0s7gx2A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.8.1",
-				"eslint-visitor-keys": "^3.0.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-					"dev": true
-				}
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"@types/json-schema": "^7.0.12",
+				"@types/semver": "^7.5.0",
+				"@typescript-eslint/scope-manager": "6.16.0",
+				"@typescript-eslint/types": "6.16.0",
+				"@typescript-eslint/typescript-estree": "6.16.0",
+				"semver": "^7.5.4"
 			}
 		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.16.0.tgz",
+			"integrity": "sha512-QSFQLruk7fhs91a/Ep/LqRdbJCZ1Rq03rqBdKT5Ky17Sz8zRLUksqIe9DW0pKtg/Z35/ztbLQ6qpOCN6rOC11A==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "6.16.0",
+				"eslint-visitor-keys": "^3.4.1"
+			}
+		},
+		"@ungap/structured-clone": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"dev": true
+		},
 		"acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -3500,7 +3589,9 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
 			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"ansi-escapes": {
 			"version": "4.3.2",
@@ -3835,6 +3926,8 @@
 			"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
 			"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"ansi-colors": "^4.1.1"
 			}
@@ -3851,49 +3944,49 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.5.0.tgz",
-			"integrity": "sha512-tVGSkgNbOfiHyVte8bCM8OmX+xG9PzVG/B4UCF60zx7j61WIVY/AqJECDgpLD4DbbESD0e174gOg3ZlrX15GDg==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+			"integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
 			"dev": true,
 			"requires": {
-				"@eslint/eslintrc": "^1.0.5",
-				"@humanwhocodes/config-array": "^0.9.2",
-				"ajv": "^6.10.0",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.6.1",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.56.0",
+				"@humanwhocodes/config-array": "^0.11.13",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@nodelib/fs.walk": "^1.2.8",
+				"@ungap/structured-clone": "^1.2.0",
+				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
-				"enquirer": "^2.3.5",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.0",
-				"eslint-utils": "^3.0.0",
-				"eslint-visitor-keys": "^3.1.0",
-				"espree": "^9.2.0",
-				"esquery": "^1.4.0",
+				"eslint-scope": "^7.2.2",
+				"eslint-visitor-keys": "^3.4.3",
+				"espree": "^9.6.1",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
-				"functional-red-black-tree": "^1.0.1",
-				"glob-parent": "^6.0.1",
-				"globals": "^13.6.0",
-				"ignore": "^4.0.6",
-				"import-fresh": "^3.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"globals": "^13.19.0",
+				"graphemer": "^1.4.0",
+				"ignore": "^5.2.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
+				"is-path-inside": "^3.0.3",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.1",
-				"progress": "^2.0.0",
-				"regexpp": "^3.2.0",
-				"semver": "^7.2.1",
+				"optionator": "^0.9.3",
 				"strip-ansi": "^6.0.1",
-				"strip-json-comments": "^3.1.0",
-				"text-table": "^0.2.0",
-				"v8-compile-cache": "^2.0.3"
+				"text-table": "^0.2.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -3906,28 +3999,6 @@
 						"supports-color": "^7.1.0"
 					}
 				},
-				"eslint-scope": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-					"integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.3.0",
-						"estraverse": "^5.2.0"
-					}
-				},
-				"eslint-visitor-keys": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-					"dev": true
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				},
 				"glob-parent": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3936,38 +4007,23 @@
 					"requires": {
 						"is-glob": "^4.0.3"
 					}
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
 				}
 			}
 		},
 		"eslint-scope": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"requires": {
 				"esrecurse": "^4.3.0",
-				"estraverse": "^4.1.1"
-			}
-		},
-		"eslint-utils": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-			"dev": true,
-			"requires": {
-				"eslint-visitor-keys": "^2.0.0"
+				"estraverse": "^5.2.0"
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true
 		},
 		"esm": {
@@ -3976,39 +4032,23 @@
 			"integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
 		},
 		"espree": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.2.0.tgz",
-			"integrity": "sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "^8.6.0",
-				"acorn-jsx": "^5.3.1",
-				"eslint-visitor-keys": "^3.1.0"
-			},
-			"dependencies": {
-				"eslint-visitor-keys": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-					"integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-					"dev": true
-				}
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
 		},
 		"esrecurse": {
@@ -4018,20 +4058,12 @@
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.2.0"
-			},
-			"dependencies": {
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				}
 			}
 		},
 		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true
 		},
 		"esutils": {
@@ -4077,9 +4109,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-			"integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -4102,9 +4134,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+			"integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -4155,6 +4187,16 @@
 				"to-regex-range": "^5.0.1"
 			}
 		},
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
 		"flat-cache": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4200,12 +4242,6 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"dev": true
-		},
 		"fuse.js": {
 			"version": "6.6.2",
 			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
@@ -4250,27 +4286,33 @@
 			}
 		},
 		"globals": {
-			"version": "13.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-			"integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
 		},
 		"globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			}
+		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+			"dev": true
 		},
 		"has": {
 			"version": "1.0.3",
@@ -4304,9 +4346,9 @@
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+			"integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
 			"dev": true
 		},
 		"import-fresh": {
@@ -4383,6 +4425,12 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
 		"is-stream": {
@@ -4578,6 +4626,15 @@
 				"rxjs": "^7.4.0",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^5.0.0"
 			}
 		},
 		"lodash": {
@@ -4808,6 +4865,24 @@
 				"type-check": "^0.4.0"
 			}
 		},
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"requires": {
+				"yocto-queue": "^0.1.0"
+			}
+		},
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
 		"p-map": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -4825,6 +4900,12 @@
 			"requires": {
 				"callsites": "^3.0.0"
 			}
+		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -4891,12 +4972,6 @@
 			"integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
 			"dev": true
 		},
-		"progress": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4907,9 +4982,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -4953,12 +5028,6 @@
 			"requires": {
 				"resolve": "^1.20.0"
 			}
-		},
-		"regexpp": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-			"dev": true
 		},
 		"resolve": {
 			"version": "1.22.0",
@@ -5041,9 +5110,9 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -5260,6 +5329,13 @@
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
 			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
+		"ts-api-utils": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+			"integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+			"dev": true,
+			"requires": {}
+		},
 		"tslib": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -5290,9 +5366,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true
 		},
 		"uri-js": {
@@ -5308,12 +5384,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-			"dev": true
 		},
 		"web-streams-polyfill": {
 			"version": "3.2.0",
@@ -5421,6 +5491,12 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cross-seed",
-	"version": "5.8.7",
+	"version": "5.9.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cross-seed",
-			"version": "5.8.7",
+			"version": "5.9.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bencode": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 			"devDependencies": {
 				"@types/bencode": "^2.0.1",
 				"@types/lowdb": "^1.0.9",
+				"@types/node": "^20.10.6",
 				"@types/xml2js": "^0.4.9",
 				"@types/xmlrpc": "^1.3.6",
 				"@typescript-eslint/eslint-plugin": "^6.16.0",
@@ -220,10 +221,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-			"dev": true
+			"version": "20.10.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+			"integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/semver": {
 			"version": "7.5.6",
@@ -3075,6 +3079,12 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3386,10 +3396,13 @@
 			}
 		},
 		"@types/node": {
-			"version": "17.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
-			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
-			"dev": true
+			"version": "20.10.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+			"integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+			"dev": true,
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@types/semver": {
 			"version": "7.5.6",
@@ -5369,6 +5382,12 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
 			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"dev": true
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
 		"@types/lowdb": "^1.0.9",
 		"@types/xml2js": "^0.4.9",
 		"@types/xmlrpc": "^1.3.6",
-		"@typescript-eslint/eslint-plugin": "^5.8.1",
-		"@typescript-eslint/parser": "^5.8.1",
-		"eslint": "^8.5.0",
+		"@typescript-eslint/eslint-plugin": "^6.16.0",
+		"@typescript-eslint/parser": "^6.16.0",
+		"eslint": "^8.56.0",
 		"husky": "^7.0.0",
 		"lint-staged": "^12.1.4",
 		"prettier": "^2.0.5",
 		"rimraf": "^3.0.2",
-		"typescript": "^4.7.4"
+		"typescript": "^5.3.3"
 	},
 	"prettier": {
 		"tabWidth": 4,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cross-seed",
-	"version": "5.9.0",
+	"version": "5.9.1",
 	"description": "Fully-automatic cross-seeding with Torznab",
 	"scripts": {
 		"test": "true",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cross-seed",
-	"version": "5.8.7",
+	"version": "5.9.0",
 	"description": "Fully-automatic cross-seeding with Torznab",
 	"scripts": {
 		"test": "true",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"xmlrpc": "^1.3.2"
 	},
 	"devDependencies": {
+		"@types/node": "^20.10.6",
 		"@types/bencode": "^2.0.1",
 		"@types/lowdb": "^1.0.9",
 		"@types/xml2js": "^0.4.9",

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -139,7 +139,6 @@ export default class Deluge implements TorrentClient {
 				headers,
 			});
 		} catch (networkError) {
-			// @ts-expect-error needs es2022 target (tsconfig)
 			throw new Error(`Failed to connect to Deluge at ${href}`, {
 				cause: networkError,
 			});

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -144,7 +144,7 @@ export default class Deluge implements TorrentClient {
 			});
 		}
 		try {
-			json = await response.json();
+			json = (await response.json()) as DelugeResponse;
 		} catch (jsonParseError) {
 			throw new Error(
 				`Deluge method ${method} response was non-JSON ${jsonParseError}`

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -8,12 +8,12 @@ import { TorrentClient } from "./TorrentClient.js";
 import { extractCredentialsFromUrl } from "../utils.js";
 import fetch, { Headers, Response } from "node-fetch";
 
-interface DelugeResponse {
-	error?: {
-		message?: string;
-		code?: DelugeErrorCode;
-	};
-	result?: string | boolean;
+interface TorrentInfo {
+	complete?: boolean;
+	save_path: string;
+	state?: string;
+	progress?: number;
+	label?: string;
 }
 enum DelugeErrorCode {
 	NO_AUTH = 1,
@@ -22,11 +22,23 @@ enum DelugeErrorCode {
 	RPC_FAIL = 4,
 	BAD_JSON = 5,
 }
-interface TorrentInfo {
-	complete: boolean;
-	save_path: string;
-	label?: string;
-}
+type InjectData = [
+	filename: string,
+	filedump: string,
+	options: {
+		add_paused: boolean;
+		seed_mode: boolean;
+		download_location: string;
+	}
+];
+type WebHostList = [string, string, number, string][];
+type ErrorType = { message?: string; code?: DelugeErrorCode };
+type TorrentStatus = { torrents?: Record<string, TorrentInfo> };
+
+type DelugeJSON<ResultType> = {
+	result?: ResultType;
+	error?: ErrorType;
+};
 
 export default class Deluge implements TorrentClient {
 	private delugeCookie: string | null = null;
@@ -57,7 +69,11 @@ export default class Deluge implements TorrentClient {
 			);
 		}
 		try {
-			const authResponse = await this.call("auth.login", [password], 0);
+			const authResponse = await this.call<boolean>(
+				"auth.login",
+				[password],
+				0
+			);
 			if (!authResponse.result) {
 				throw new CrossSeedError(
 					`Reached Deluge, but failed to authenticate: ${href}`
@@ -66,19 +82,27 @@ export default class Deluge implements TorrentClient {
 		} catch (networkError) {
 			throw new CrossSeedError(networkError);
 		}
-		const connectedResponse = await this.call("web.connected", [], 0);
+		const connectedResponse = await this.call<boolean>(
+			"web.connected",
+			[],
+			0
+		);
 
 		if (!connectedResponse.result) {
 			logger.warn(
 				"Deluge WebUI disconnected from daemon...attempting to reconnect."
 			);
-			const webuiHostList = await this.call("web.get_hosts", [], 0);
-			const connectResponse = await this.call(
+			const webuiHostList = await this.call<WebHostList>(
+				"web.get_hosts",
+				[],
+				0
+			);
+			const connectResponse = await this.call<undefined>(
 				"web.connect",
 				[webuiHostList.result[0][0]],
 				0
 			);
-			if (connectResponse) {
+			if (!connectResponse.error) {
 				logger.info("Deluge WebUI connected to the daemon.");
 			} else {
 				throw new CrossSeedError(
@@ -91,22 +115,28 @@ export default class Deluge implements TorrentClient {
 	/**
 	 * ensures authentication and sends JSON-RPC calls to deluge
 	 */
-	private async call(method: string, params: object, retries = 1) {
+	private async call<ResultType>(
+		method: string,
+		params: unknown[],
+		retries = 1
+	): Promise<DelugeJSON<ResultType>> {
 		const { delugeRpcUrl } = getRuntimeConfig();
 		const { href } =
 			extractCredentialsFromUrl(delugeRpcUrl).unwrapOrThrow();
 		const headers = new Headers({ "Content-Type": "application/json" });
 		if (this.delugeCookie) headers.set("Cookie", this.delugeCookie);
 
-		let response: Response, json: DelugeResponse;
+		let response: Response, json: DelugeJSON<ResultType>;
+		const id = Math.floor(Math.random() * 0x7fffffff);
 		try {
 			response = await fetch(href, {
 				body: JSON.stringify({
-					...{ method: method, params: params },
-					id: Math.floor(Math.random() * 0x7fffffff),
+					method,
+					params,
+					id,
 				}),
 				method: "POST",
-				headers: headers,
+				headers,
 			});
 		} catch (networkError) {
 			// @ts-expect-error needs es2022 target (tsconfig)
@@ -121,11 +151,11 @@ export default class Deluge implements TorrentClient {
 				`Deluge method ${method} response was non-JSON ${jsonParseError}`
 			);
 		}
-		if (json?.error?.code === DelugeErrorCode.NO_AUTH && retries > 0) {
+		if (json.error?.code === DelugeErrorCode.NO_AUTH && retries > 0) {
 			this.delugeCookie = null;
 			await this.authenticate();
 			if (this.delugeCookie) {
-				return this.call(method, params, 0);
+				return this.call<ResultType>(method, params, 0);
 			} else {
 				throw new Error(
 					"Connection lost with Deluge. Reauthentication failed."
@@ -150,8 +180,13 @@ export default class Deluge implements TorrentClient {
 	 * returns true if successful.
 	 */
 	private async labelEnabled() {
-		const enabledLabels = await this.call("core.get_enabled_plugins", []);
-		return enabledLabels?.result?.includes?.("Label");
+		const enabledPlugins = await this.call<string>(
+			"core.get_enabled_plugins",
+			[]
+		);
+		return enabledPlugins.error
+			? false
+			: enabledPlugins.result.includes("Label");
 	}
 
 	/**
@@ -160,13 +195,13 @@ export default class Deluge implements TorrentClient {
 	 */
 	private async setLabel(infoHash: string, label: string): Promise<void> {
 		if (this.isLabelEnabled) {
-			const setResult = await this.call("label.set_torrent", [
+			const setResult = await this.call<void>("label.set_torrent", [
 				infoHash,
 				label,
 			]);
-			if (setResult?.error?.code == DelugeErrorCode.RPC_FAIL) {
-				await this.call("label.add", [label]);
-				await this.call("label.set_torrent", [infoHash, label]);
+			if (setResult.error?.code === DelugeErrorCode.RPC_FAIL) {
+				await this.call<void>("label.add", [label]);
+				await this.call<void>("label.set_torrent", [infoHash, label]);
 			}
 		}
 	}
@@ -182,18 +217,19 @@ export default class Deluge implements TorrentClient {
 		try {
 			let torrentInfo: TorrentInfo;
 			const { duplicateCategories } = getRuntimeConfig();
+
 			if (searchee.infoHash) {
 				torrentInfo = await this.getTorrentInfo(searchee);
 				if (!torrentInfo.complete) {
-					if (
-						torrentInfo.save_path == "missing" &&
-						!path &&
-						!searchee.path
-					) {
-						return InjectionResult.FAILURE;
-					}
 					return InjectionResult.TORRENT_NOT_COMPLETE;
 				}
+			}
+			if (!path && (!searchee.infoHash || !torrentInfo)) {
+				logger.debug({
+					label: Label.DELUGE,
+					message: `Injection failure: ${newTorrent.name} was missing critical data.`,
+				});
+				return InjectionResult.FAILURE;
 			}
 
 			const params = this.formatData(
@@ -202,9 +238,11 @@ export default class Deluge implements TorrentClient {
 				path ? path : torrentInfo.save_path,
 				!!searchee.infoHash
 			);
-			const addResult = await this.call("core.add_torrent_file", params);
-
-			if (addResult?.result) {
+			const addResult = await this.call<string>(
+				"core.add_torrent_file",
+				params
+			);
+			if (addResult.result) {
 				const { dataCategory } = getRuntimeConfig();
 				await this.setLabel(
 					newTorrent.infoHash,
@@ -219,22 +257,36 @@ export default class Deluge implements TorrentClient {
 						: this.delugeLabel
 				);
 				return InjectionResult.SUCCESS;
-			} else if (addResult?.error?.message?.includes("already")) {
+			} else if (addResult.error.message.includes("already")) {
 				return InjectionResult.ALREADY_EXISTS;
-			} else if (addResult?.error?.message) {
+			} else if (addResult.error.message) {
 				logger.debug({
 					label: Label.DELUGE,
 					message: `Injection failed: ${addResult.error.message}`,
 				});
 				return InjectionResult.FAILURE;
+			} else {
+				logger.debug({
+					label: Label.DELUGE,
+					message: `Unknown injection failure: ${newTorrent.name} (${newTorrent.infoHash})`,
+				});
+				return InjectionResult.FAILURE;
 			}
 		} catch (injectResult) {
-			logger.error({
-				label: Label.DELUGE,
-				message: `Injection failed: ${injectResult}`,
-			});
-			logger.debug(injectResult);
-			return InjectionResult.FAILURE;
+			if (injectResult.includes("label.set_torrent")) {
+				logger.warning({
+					label: Label.DELUGE,
+					message: `Labeling failure: ${newTorrent.name} (${newTorrent.infoHash})`,
+				});
+				return InjectionResult.SUCCESS;
+			} else {
+				logger.error({
+					label: Label.DELUGE,
+					message: `Injection failed: ${injectResult}`,
+				});
+				logger.debug(injectResult);
+				return InjectionResult.FAILURE;
+			}
 		}
 	}
 
@@ -246,7 +298,7 @@ export default class Deluge implements TorrentClient {
 		filedump: string,
 		path: string,
 		isTorrent: boolean
-	) {
+	): InjectData {
 		return [
 			filename,
 			filedump,
@@ -262,36 +314,45 @@ export default class Deluge implements TorrentClient {
 	 * returns information needed to complete/validate injection
 	 */
 	private async getTorrentInfo(searchee: Searchee): Promise<TorrentInfo> {
+		if (!searchee.infoHash) {
+			throw new Error("Can't search a torrent without a infoHash");
+		}
+
+		let torrent: TorrentInfo;
 		try {
-			let torrentLabel: string = undefined;
 			const params = [
 				["state", "progress", "save_path", "label"],
 				{ hash: searchee.infoHash },
 			];
-			const response = await this.call("web.update_ui", params);
-			if (response?.result?.torrents?.[searchee.infoHash] === undefined) {
+
+			const response = await this.call<TorrentStatus>(
+				"web.update_ui",
+				params
+			);
+
+			if (response.result.torrents) {
+				torrent = response.result.torrents?.[searchee.infoHash];
+			} else {
+				throw new Error(
+					"Client returned unexpected response (object missing)"
+				);
+			}
+			if (torrent === undefined) {
 				throw new Error(
 					`Torrent not found in client (${searchee.infoHash})`
 				);
 			}
-			if (
-				this.isLabelEnabled &&
-				response?.result?.torrents?.[searchee.infoHash]?.label
-					?.length != 0
-			) {
-				torrentLabel =
-					response?.result?.torrents?.[searchee.infoHash]?.label;
-			}
 
 			const completedTorrent =
-				response?.result?.torrents?.[searchee.infoHash]?.state ===
-					"Seeding" ||
-				response?.result?.torrents?.[searchee.infoHash]?.progress ===
-					100;
+				torrent.state === "Seeding" || torrent.progress === 100;
+			const torrentLabel =
+				this.isLabelEnabled && torrent.label.length != 0
+					? torrent.label
+					: undefined;
+
 			return {
 				complete: completedTorrent,
-				save_path:
-					response?.result?.torrents?.[searchee.infoHash]?.save_path,
+				save_path: torrent.save_path,
 				label: torrentLabel,
 			};
 		} catch (e) {
@@ -300,7 +361,10 @@ export default class Deluge implements TorrentClient {
 				message: `Failed to fetch torrent data: ${searchee.name} - (${searchee.infoHash})`,
 			});
 			logger.debug(e);
-			return { complete: false, save_path: "missing" };
+			// @ts-expect-error needs es2022 target (tsconfig)
+			throw new Error("web.update_ui: failed to fetch data from client", {
+				cause: e,
+			});
 		}
 	}
 }

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -8,7 +8,7 @@ import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { File, Searchee } from "../searchee.js";
+import { File, Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { extractCredentialsFromUrl, wait } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 
@@ -142,7 +142,7 @@ export default class RTorrent implements TorrentClient {
 	}
 
 	private async checkOriginalTorrent(
-		searchee: Searchee
+		searchee: SearcheeWithInfoHash
 	): Promise<
 		Result<
 			{ directoryBase: string },
@@ -201,7 +201,9 @@ export default class RTorrent implements TorrentClient {
 			const directoryBase = meta.isSingleFileTorrent ? path : basePath;
 			return resultOf({ downloadDir: path, basePath, directoryBase });
 		} else {
-			const result = await this.checkOriginalTorrent(searchee);
+			const result = await this.checkOriginalTorrent(
+				searchee as SearcheeWithInfoHash
+			);
 			return result.mapOk(({ directoryBase }) => ({
 				directoryBase,
 				downloadDir: meta.isSingleFileTorrent

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -5,7 +5,7 @@ import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { Searchee } from "../searchee.js";
+import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { extractCredentialsFromUrl } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 
@@ -73,7 +73,7 @@ export default class Transmission implements TorrentClient {
 		if (response.status === 409) {
 			this.xTransmissionSessionId = response.headers.get(
 				XTransmissionSessionId
-			);
+			)!;
 			return this.request(method, args, retries - 1);
 		}
 		try {
@@ -121,7 +121,7 @@ export default class Transmission implements TorrentClient {
 	}
 
 	async checkOriginalTorrent(
-		searchee: Searchee
+		searchee: SearcheeWithInfoHash
 	): Promise<
 		Result<
 			{ downloadDir: string },
@@ -163,7 +163,9 @@ export default class Transmission implements TorrentClient {
 		if (path) {
 			downloadDir = path;
 		} else {
-			const result = await this.checkOriginalTorrent(searchee);
+			const result = await this.checkOriginalTorrent(
+				searchee as SearcheeWithInfoHash
+			);
 			if (result.isErr()) {
 				return result.unwrapErrOrThrow();
 			}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -53,8 +53,8 @@ export function appDir(): string {
 	return (
 		process.env.CONFIG_DIR ||
 		(process.platform === "win32"
-			? path.resolve(process.env.LOCALAPPDATA, packageDotJson.name)
-			: path.resolve(process.env.HOME, `.${packageDotJson.name}`))
+			? path.resolve(process.env.LOCALAPPDATA!, packageDotJson.name)
+			: path.resolve(process.env.HOME!, `.${packageDotJson.name}`))
 	);
 }
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -179,7 +179,7 @@ async function assessAndSaveResults(
 		assessment.decision === Decision.MATCH ||
 		assessment.decision === Decision.MATCH_SIZE_ONLY
 	) {
-		cacheTorrentFile(assessment.metafile);
+		cacheTorrentFile(assessment.metafile!);
 	}
 
 	await db.transaction(async (trx) => {
@@ -195,7 +195,7 @@ async function assessAndSaveResults(
 			info_hash:
 				assessment.decision === Decision.MATCH ||
 				assessment.decision === Decision.MATCH_SIZE_ONLY
-					? assessment.metafile.infoHash
+					? assessment.metafile!.infoHash
 					: null,
 			last_seen: now,
 			first_seen: now,

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -35,13 +35,13 @@ class Job {
 	}
 }
 
-const getJobs = () => {
+function getJobs(): Job[] {
 	const { rssCadence, searchCadence } = getRuntimeConfig();
-	return [
-		rssCadence && new Job("rss", rssCadence, scanRssFeeds),
-		searchCadence && new Job("search", searchCadence, main),
-	].filter(Boolean);
-};
+	const jobs: Job[] = [];
+	if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
+	if (searchCadence) jobs.push(new Job("search", searchCadence, main));
+	return jobs;
+}
 
 function logNextRun(
 	name: string,

--- a/src/migrations/02-timestamps.ts
+++ b/src/migrations/02-timestamps.ts
@@ -2,7 +2,9 @@ import Knex from "knex";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 
 function sanitizeUrl(url: string | URL): string {
-	url = new URL(url);
+	if (typeof url === "string") {
+		url = new URL(url);
+	}
 	return url.origin + url.pathname;
 }
 

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -32,7 +32,7 @@ function sumLength(sum: number, file: { length: number }): number {
 	return sum + file.length;
 }
 
-function ensure(bool, fieldName) {
+function ensure(bool: unknown, fieldName: string) {
 	if (!bool)
 		throw new Error(`Torrent is missing required field: ${fieldName}`);
 }
@@ -69,18 +69,20 @@ export class Metafile {
 
 		this.raw = raw;
 		this.infoHash = sha1(bencode.encode(raw.info));
-		this.name = fallback(raw.info["name.utf-8"], raw.info.name).toString();
+		this.name = fallback(raw.info["name.utf-8"], raw.info.name)!.toString();
 		this.pieceLength = raw.info["piece length"];
 
 		if (!raw.info.files) {
+			// length exists if files doesn't exist
+			const length = raw.info.length!;
 			this.files = [
 				{
 					name: this.name,
 					path: this.name,
-					length: raw.info.length,
+					length: length,
 				},
 			];
-			this.length = raw.info.length;
+			this.length = length;
 			this.isSingleFileTorrent = true;
 		} else {
 			this.files = raw.info.files
@@ -88,7 +90,7 @@ export class Metafile {
 					const rawPathSegments: Buffer[] = fallback(
 						file["path.utf-8"],
 						file.path
-					);
+					)!;
 					const pathSegments = rawPathSegments.map((buf) => {
 						const seg = buf.toString();
 						// convention for zero-length path segments is to treat them as underscores

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -39,7 +39,7 @@ import {
 	TorrentLocator,
 } from "./torrent.js";
 import { queryRssFeeds, searchTorznab } from "./torznab.js";
-import { filterAsync, stripExtension } from "./utils.js";
+import { filterAsync, isTruthy, stripExtension } from "./utils.js";
 
 export interface Candidate {
 	guid: string;
@@ -114,8 +114,8 @@ async function findOnOtherSites(
 		(acc, cur, idx) => {
 			const candidate = results[idx];
 			if (cur.assessment.decision === Decision.RATE_LIMITED) {
-				acc.rateLimited.add(candidate.indexerId);
-				acc.notRateLimited.delete(candidate.indexerId);
+				acc.rateLimited.add(candidate.indexerId!);
+				acc.notRateLimited.delete(candidate.indexerId!);
 			}
 			return acc;
 		},
@@ -188,7 +188,7 @@ async function findMatchesBatch(
 
 export async function searchForLocalTorrentByCriteria(
 	criteria: TorrentLocator
-): Promise<number> {
+): Promise<number | null> {
 	const { maxDataDepth } = getRuntimeConfig();
 
 	let searchees: Searchee[];
@@ -250,7 +250,7 @@ export async function checkNewCandidateMatch(
 		return null;
 
 	const result = await performAction(
-		assessment.metafile,
+		assessment.metafile!,
 		assessment.decision,
 		searchee,
 		candidate.tracker
@@ -289,7 +289,9 @@ async function findSearchableTorrents() {
 		}
 	}
 
-	const hashesToExclude = allSearchees.map((t) => t.infoHash).filter(Boolean);
+	const hashesToExclude = allSearchees
+		.map((t) => t.infoHash)
+		.filter(isTruthy);
 	let filteredTorrents = await filterAsync(
 		filterDupes(allSearchees).filter(filterByContent),
 		filterTimestamps

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -217,7 +217,7 @@ export async function searchForLocalTorrentByCriteria(
 
 export async function checkNewCandidateMatch(
 	candidate: Candidate
-): Promise<InjectionResult | SaveResult> {
+): Promise<InjectionResult | SaveResult | null> {
 	const meta = await getTorrentByFuzzyName(candidate.name);
 	if (meta === null) {
 		logger.verbose({

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -75,10 +75,15 @@ export function filterDupes(searchees: Searchee[]): Searchee[] {
 	return filtered;
 }
 
+type TimestampDataSql = {
+	first_searched_any: number;
+	last_searched_all: number;
+};
+
 export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 	const { excludeOlder, excludeRecentSearch } = getRuntimeConfig();
 	const enabledIndexers = await getEnabledIndexers();
-	const timestampDataSql = await db("searchee")
+	const timestampDataSql: TimestampDataSql = (await db("searchee")
 		// @ts-expect-error crossJoin supports string
 		.crossJoin("indexer")
 		.leftOuterJoin("timestamp", {
@@ -98,7 +103,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		.min({
 			last_searched_all: db.raw("coalesce(timestamp.last_searched, 0)"),
 		})
-		.first();
+		.first()) as TimestampDataSql;
 
 	const { first_searched_any, last_searched_all } = timestampDataSql;
 	function logReason(reason) {

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -54,7 +54,7 @@ export function sendResultsNotification(
 	if (notableSuccesses.length) {
 		const numTrackers = notableSuccesses.length;
 		const infoHashes = notableSuccesses.map(
-			([assessment]) => assessment.metafile.infoHash
+			([assessment]) => assessment.metafile!.infoHash
 		);
 		const trackers = notableSuccesses.map(([, tracker]) => tracker);
 		const trackersListStr = formatAsList(trackers);
@@ -78,7 +78,7 @@ export function sendResultsNotification(
 	if (failures.length) {
 		const numTrackers = failures.length;
 		const infoHashes = failures.map(
-			([assessment]) => assessment.metafile.infoHash
+			([assessment]) => assessment.metafile!.infoHash
 		);
 		const trackers = failures.map(([, tracker]) => tracker);
 		const trackersListStr = formatAsList(trackers);

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -30,9 +30,9 @@ export interface RuntimeConfig {
 	torrents: string[];
 	port: number | false | null;
 	searchCadence: number;
-	rssCadence: number;
-	snatchTimeout: number;
-	searchTimeout: number;
+	rssCadence?: number;
+	snatchTimeout?: number;
+	searchTimeout?: number;
 	searchLimit: number;
 	apiAuth: boolean;
 }

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -18,8 +18,8 @@ export interface RuntimeConfig {
 	verbose: boolean;
 	includeNonVideos: boolean;
 	fuzzySizeThreshold: number;
-	excludeOlder: number;
-	excludeRecentSearch: number;
+	excludeOlder?: number;
+	excludeRecentSearch?: number;
 	action: Action;
 	rtorrentRpcUrl: string;
 	qbittorrentUrl: string;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -4,6 +4,7 @@ import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { parseTorrentFromFilename } from "./torrent.js";
+import { WithRequired } from "./utils.js";
 
 export interface File {
 	length: number;
@@ -17,6 +18,14 @@ export interface Searchee {
 	files: File[];
 	name: string;
 	length: number;
+}
+
+export type SearcheeWithInfoHash = WithRequired<Searchee, "infoHash">;
+
+export function hasInfoHash(
+	searchee: Searchee
+): searchee is SearcheeWithInfoHash {
+	return searchee.infoHash != null;
 }
 
 function getFileNamesFromRootRec(root: string, isDirHint?: boolean): string[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { indexNewTorrents, TorrentLocator } from "./torrent.js";
 
 function getData(req: IncomingMessage): Promise<string> {
 	return new Promise((resolve) => {
-		const chunks = [];
+		const chunks: string[] = [];
 		req.on("data", (chunk) => {
 			chunks.push(chunk.toString());
 		});
@@ -51,7 +51,7 @@ async function authorize(
 	req: IncomingMessage,
 	res: ServerResponse
 ): Promise<boolean> {
-	const url = new URL(req.url, `http://${req.headers.host}`);
+	const url = new URL(req.url!, `http://${req.headers.host}`);
 	const apiKey =
 		(req.headers["x-api-key"] as string) ?? url.searchParams.get("apikey");
 	const isAuthorized = await checkApiKey(apiKey);
@@ -111,7 +111,7 @@ async function search(
 	await indexNewTorrents();
 
 	try {
-		let numFound = null;
+		let numFound: number | null = null;
 		if (criteria) {
 			numFound = await searchForLocalTorrentByCriteria(criteria);
 		}
@@ -213,7 +213,7 @@ async function handleRequest(
 		return;
 	}
 
-	switch (req.url.split("?")[0]) {
+	switch (req.url!.split("?")[0]) {
 		case "/api/webhook": {
 			logger.verbose({
 				label: Label.SERVER,

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -39,7 +39,6 @@ function isMagnetRedirectError(error: Error): boolean {
 		// node-fetch
 		error.message.includes('URL scheme "magnet" is not supported.') ||
 		// undici
-		// @ts-expect-error error causes "not supported yet"
 		error?.cause.message.includes("URL scheme must be a HTTP(S) scheme")
 	);
 }

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -39,7 +39,7 @@ function isMagnetRedirectError(error: Error): boolean {
 		// node-fetch
 		error.message.includes('URL scheme "magnet" is not supported.') ||
 		// undici
-		error?.cause.message.includes("URL scheme must be a HTTP(S) scheme")
+		error.cause?.message.includes("URL scheme must be a HTTP(S) scheme")
 	);
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -39,7 +39,11 @@ function isMagnetRedirectError(error: Error): boolean {
 		// node-fetch
 		error.message.includes('URL scheme "magnet" is not supported.') ||
 		// undici
-		error.cause?.message.includes("URL scheme must be a HTTP(S) scheme")
+		Boolean(
+			(error.cause as Error | undefined)?.message.includes(
+				"URL scheme must be a HTTP(S) scheme"
+			)
+		)
 	);
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -206,13 +206,15 @@ export async function loadTorrentDirLight(): Promise<Searchee[]> {
 export async function getTorrentByFuzzyName(
 	name: string
 ): Promise<null | Metafile> {
-	const allNames = await db("torrent").select("name", "file_path");
+	const allNames: { name: string; file_path: string }[] = await db(
+		"torrent"
+	).select("name", "file_path");
 	const fullMatch = reformatTitleForSearching(name)
 		.replace(/[^a-z0-9]/gi, "")
 		.toLowerCase();
 
 	// Attempt to filter torrents in DB to match incoming torrent before fuzzy check
-	let filteredNames = [];
+	let filteredNames: typeof allNames = [];
 	if (fullMatch) {
 		filteredNames = allNames.filter((dbName) => {
 			const dbMatch = reformatTitleForSearching(dbName.name)

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -66,7 +66,9 @@ interface TorznabResult {
 type TorznabResults = { rss?: { channel?: [] | [{ item?: TorznabResult[] }] } };
 
 function sanitizeUrl(url: string | URL): string {
-	url = new URL(url);
+	if (typeof url === "string") {
+		url = new URL(url);
+	}
 	return url.origin + url.pathname;
 }
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -108,26 +108,26 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 function createTorznabSearchQuery(name: string, caps: Caps) {
 	const nameWithoutExtension = stripExtension(name);
 	const extractNumber = (str: string): number =>
-		parseInt(str.match(/\d+/)[0]);
+		parseInt(str.match(/\d+/)![0]);
 	const mediaType = getTag(nameWithoutExtension);
 	if (mediaType === MediaType.EPISODE && caps.tvSearch) {
 		const match = nameWithoutExtension.match(EP_REGEX);
 		return {
 			t: "tvsearch",
-			q: cleanseSeparators(match.groups.title),
-			season: match.groups.season
-				? extractNumber(match.groups.season)
-				: match.groups.year,
-			ep: match.groups.episode
-				? extractNumber(match.groups.episode)
-				: `${match.groups.month}/${match.groups.day}`,
+			q: cleanseSeparators(match!.groups!.title),
+			season: match!.groups!.season
+				? extractNumber(match!.groups!.season)
+				: match!.groups!.year,
+			ep: match!.groups!.episode
+				? extractNumber(match!.groups!.episode)
+				: `${match!.groups!.month}/${match!.groups!.day}`,
 		} as const;
 	} else if (mediaType === MediaType.SEASON && caps.tvSearch) {
 		const match = nameWithoutExtension.match(SEASON_REGEX);
 		return {
 			t: "tvsearch",
-			q: cleanseSeparators(match.groups.title),
-			season: extractNumber(match.groups.season),
+			q: cleanseSeparators(match!.groups!.title),
+			season: extractNumber(match!.groups!.season),
 		} as const;
 	} else {
 		return {
@@ -240,7 +240,7 @@ export async function syncWithDb() {
 			) {
 				acc.push({
 					id: dbIndexer.id,
-					apikey: getApikey(configIndexer),
+					apikey: getApikey(configIndexer)!,
 				});
 			}
 			return acc;
@@ -507,7 +507,7 @@ async function makeRequests(
 
 	for (const [indexerId, reason] of rejected) {
 		logger.warn(
-			`Failed to reach ${indexers.find((i) => i.id === indexerId).url}`
+			`Failed to reach ${indexers.find((i) => i.id === indexerId)!.url}`
 		);
 		logger.debug(reason);
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,7 @@ export function formatAsList(strings: string[]) {
 	}).format(strings.sort((a, b) => a.localeCompare(b)));
 }
 
-export function fallback<T>(...args: T[]): T {
+export function fallback<T>(...args: T[]): T | undefined {
 	for (const arg of args) {
 		if (arg !== undefined) return arg;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,14 @@ export enum MediaType {
 	OTHER = "unknown",
 }
 
+type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
+
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+export function isTruthy<T>(value: T): value is Truthy<T> {
+	return Boolean(value);
+}
+
 export function stripExtension(filename: string): string {
 	for (const ext of VIDEO_EXTENSIONS) {
 		if (filename.endsWith(ext)) return basename(filename, ext);
@@ -69,11 +77,6 @@ export const tap = (fn) => (value) => {
 	return value;
 };
 
-type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
-
-export function isTruthy<T>(value: T): value is Truthy<T> {
-	return Boolean(value);
-}
 export async function filterAsync(arr, predicate) {
 	const results = await Promise.all(arr.map(predicate));
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,11 @@ export const tap = (fn) => (value) => {
 	return value;
 };
 
+type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
+
+export function isTruthy<T>(value: T): value is Truthy<T> {
+	return Boolean(value);
+}
 export async function filterAsync(arr, predicate) {
 	const results = await Promise.all(arr.map(predicate));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"allowJs": true,
-		"target": "es2021",
+		"target": "es2022",
 		"module": "nodenext",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
-		"moduleResolution": "nodenext",
 		"sourceMap": true
 	},
 	"include": ["./src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"module": "nodenext",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"strictNullChecks": true
 	},
 	"include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"outDir": "./dist",
 		"allowJs": true,
 		"target": "es2022",
+		"lib": ["es2022"],
 		"module": "nodenext",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
This PR updates our TypeScript configuration to allow ES2022 features, and turns on `strictNullChecks`. 

A few of our existing patterns don't really play nice with `strictNullChecks` and I used the non-null assertion operator `!` pretty liberally to fix the issues. 

## Patterns that don't play nice with `strictNullChecks`

### `ResultAssessment`
The optional property `metafile` is implicitly tied to `decision` having a value of `MATCH` or `MATCH_SIZE_ONLY`. We should make this explicit at some point by making it a union type.
```ts
export interface ResultAssessment {
	decision: Decision;
	metafile?: Metafile;
}
```
### `Searchee`
This has the same problem. The optional property `infoHash` is implicitly tied to `path` not existing. We could make this explicit at some point, though we also might want to support both existing. 
```ts
export interface Searchee {
	infoHash?: string; // if searchee is torrent based
	path?: string; // if searchee is data based
	files: File[];
	name: string;
	length: number;
}
```

