### PR TITLE
feat(decide): release group match prior to snatch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const SEASON_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)[_.\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
-export const GROUP_REGEX = /$(?<=(?:-)(?<group>[\w\040]+)(?:\.\w+)?)/i;
+export const RELEASE_GROUP_REGEX = /(?<=-)[\w ]+(?=(?:\.\w{1,5})?$)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi"];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const SEASON_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)[_.\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
+export const GROUP_REGEX = /$(?<=(?:-)(?<group>[\w\040]+)(?:\.\w+)?)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi"];
 
@@ -46,6 +47,7 @@ export enum Decision {
 	RATE_LIMITED = "RATE_LIMITED",
 	INFO_HASH_ALREADY_EXISTS = "INFO_HASH_ALREADY_EXISTS",
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
+	RELEASE_GROUP_MISMATCH = "RELEASE_GROUP_MISMATCH",
 }
 
 export enum MatchMode {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -3,8 +3,8 @@ import path from "path";
 import { appDir } from "./configuration.js";
 import {
 	Decision,
-	GROUP_REGEX,
 	MatchMode,
+	RELEASE_GROUP_REGEX,
 	TORRENT_CACHE_FOLDER,
 } from "./constants.js";
 import { db } from "./db.js";
@@ -103,19 +103,19 @@ function sizeDoesMatch(resultSize, searchee) {
 }
 
 function releaseGroupDoesMatch(
-	searcheeRelease: string,
-	candidateRelease: string,
-	matchMode: string
+	searcheeName: string,
+	candidateName: string,
+	matchMode: MatchMode
 ) {
-	const searcheeGroup = searcheeRelease.match(GROUP_REGEX)[0].toLowerCase();
-	const candidateGroup = candidateRelease.match(GROUP_REGEX)[0].toLowerCase();
-	if (
-		(searcheeGroup || candidateGroup) &&
-		(!searcheeGroup || !candidateGroup)
-	) {
-		return matchMode === "risky";
+	const searcheeMatch = searcheeName.match(RELEASE_GROUP_REGEX);
+	const candidateMatch = candidateName.match(RELEASE_GROUP_REGEX);
+
+	// if we are unsure, pass in risky mode but fail in safe mode
+	if (!searcheeMatch || !candidateMatch) {
+		return matchMode === MatchMode.RISKY;
 	}
-	return searcheeGroup === candidateGroup;
+
+	return searcheeMatch[0].toLowerCase() === candidateMatch[0].toLowerCase();
 }
 
 async function assessCandidateHelper(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -58,7 +58,7 @@ const createReasonLogger =
 				reason = "it has a different file tree";
 				break;
 			case Decision.RELEASE_GROUP_MISMATCH:
-				reason = "its release group does not match";
+				reason = "it has a different release group";
 				break;
 			default:
 				reason = decision;

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -35,6 +35,8 @@ const createReasonLogger =
 		}
 		let reason;
 		switch (decision) {
+			case Decision.MATCH_SIZE_ONLY:
+				return;
 			case Decision.MATCH:
 				return;
 			case Decision.SIZE_MISMATCH:
@@ -54,6 +56,9 @@ const createReasonLogger =
 				break;
 			case Decision.FILE_TREE_MISMATCH:
 				reason = "it has a different file tree";
+				break;
+			case Decision.RELEASE_GROUP_MISMATCH:
+				reason = "its release group does not match";
 				break;
 			default:
 				reason = decision;


### PR DESCRIPTION
adds to decide.ts the condition that release groups match before snatching the torrent for comparison

# notes
- risky matchMode will not require both groups to be present to snatch
- safe matchMode will require both groups match
- groups are case-insensitive