### PR TITLE
update(group-matching): use startswith for group matching

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -119,8 +119,9 @@ function releaseGroupDoesMatch(
 	if (!searcheeMatch || !candidateMatch) {
 		return matchMode === MatchMode.RISKY;
 	}
-
-	return searcheeMatch[0].toLowerCase() === candidateMatch[0].toLowerCase();
+	return searcheeMatch[0]
+		.toLowerCase()
+		.startsWith(candidateMatch[0].toLowerCase());
 }
 
 async function assessCandidateHelper(


### PR DESCRIPTION
a few trackers truncate release names after certain lengths, leaving the possibility (although needs to be the right length) for groups to be truncated and partial groupnames returned from Torznab.

While the truncation will not always be mid-groupname - this will provide a marginal amount of matches that otherwise would not be snatched.

Potentially could use a "blacklist" for producing no-match when group name evaluates to something like "-DL" or something, to catch WEB-DL when truncated prior to the group name start, however this is a bit iffy too.