### PR TITLE
feat(client/transmission):  only start added torrents if they are complete

### DIFF
--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -44,8 +44,6 @@ type TorrentDuplicateResponse = { "torrent-duplicate": TorrentMetadata };
 type TorrentAddedResponse = { "torrent-added": TorrentMetadata };
 type TorrentAddResponse = TorrentAddedResponse | TorrentDuplicateResponse;
 
-type TorrentStartResponse = {};
-
 function doesAlreadyExist(
 	args: TorrentAddResponse
 ): args is TorrentDuplicateResponse {
@@ -54,7 +52,6 @@ function doesAlreadyExist(
 
 export default class Transmission implements TorrentClient {
 	xTransmissionSessionId: string;
-
 	private async request<T>(
 		method: Method,
 		args: unknown = {},
@@ -162,7 +159,7 @@ export default class Transmission implements TorrentClient {
 		const [{ downloadDir, percentDone }] = queryResponse.torrents;
 
 		if (downloadDir == undefined || percentDone === undefined) {
-			return resultOfErr(InjectionResult.FAILURE)
+			return resultOfErr(InjectionResult.FAILURE);
 		}
 		if (percentDone < 1) {
 			return resultOfErr(InjectionResult.TORRENT_NOT_COMPLETE);
@@ -232,7 +229,7 @@ export default class Transmission implements TorrentClient {
 
 			const [{ percentDone, status }] = getResponse.torrents;
 			if (status === TorrentStatus.Stopped && percentDone === 1) {
-				await this.request<TorrentStartResponse>("torrent-start", {
+				await this.request<unknown>("torrent-start", {
 					ids: [torrentId],
 				});
 				return InjectionResult.SUCCESS;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -161,6 +161,9 @@ export default class Transmission implements TorrentClient {
 
 		const [{ downloadDir, percentDone }] = queryResponse.torrents;
 
+		if (downloadDir == undefined || percentDone === undefined) {
+			return resultOfErr(InjectionResult.FAILURE)
+		}
 		if (percentDone < 1) {
 			return resultOfErr(InjectionResult.TORRENT_NOT_COMPLETE);
 		}


### PR DESCRIPTION
This PR is created on the back of [this conversation](https://github.com/cross-seed/cross-seed/issues/570). It is an implementation of what is called _Solution 3_ there.

### Background

When [adding a torrent](https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#34-adding-a-torrent) in Transmission (`torrent-add`), an optional field `paused` can be specified, to the effect that:
- if `false`, the torrent is started when added
- if `true`, the torrent is added paused
- if not specifed, the `start-added-torrents` property of the [Transmission configuration](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md#files-and-locations) is used to determine if the torrent should be started when added

Also when adding a torrent, Transmission makes a decision regarding verification based on the `torrent-added-verify-mode` property of the [Transmission configuration](https://github.com/transmission/transmission/blob/main/docs/Editing-Configuration-Files.md#misc):
- if `full`, the torrent data will always be verified
- if `fast`, the torrent data verification will be skipped under a [certain set of conditions](https://github.com/transmission/transmission/pull/2626).

_Note:_ This behaviour cannot be controlled in the `torrent-add` request body.

### Bug

The way Transmission works, when all of the following conditions are met:
- a torrent is added for the purpose of cross-seeding (i.e. the torrent data already exists)
- the torrent is started when added (i.e. `paused` is set to `false` in the `torrent-add` request **or** `paused` is not set in the `torrent-add` request **and**  `start-added-torrents` is set to `true` in the Transmission configuration)
- the torrent verification is triggered (i.e. `torrent-added-verify-mode` is set to `full` in the Transmission configuration **or** Transmission decides to trigger it based on the criteria described in the [above linked PR](https://github.com/transmission/transmission/pull/2626)
- the torrent verification fails (i.e. the torrent data was corrupted, i.e. the torrents are actually different between two different trackers)

Then Transmission will start the torrent and overwrite whichever data pre-existed in the torrent files.
There is no way to tell Transmission, when adding a torrent, that **it should be started if and only if torrent verification is skipped or succeeds**.

### Solution

cross-seed aims to minimize user interaction as much as possible by starting torrents when added, but in this case a user interaction will always be required: when two different trackers have torrents with the same structure but where the data is different, the user must decide which of the torrents they would like to keep.

### Implementation

This PR implements a strategy to start torrents only when safe. Instead of a single request to Transmission to add a torrent with `paused` set to `false`, we instead perform three successive requests:
- add the torrent paused (`paused` set to `true`)
- retrieve the torrent status and completion percentage
- if the torrent is "safe" (i.e., **only if the torrent status is stopped and the torrent is complete**), then start the torrent

### Limitations

- With this behaviour in place, it would be recommended that the `torrent-added-verify-mode` property of the Transmission configuration be set to `fast` (which is the default). If set to `full`, then in practice all torrents will always be added paused (since there's no way the verification will have completed by the time the second call described above retrieves the torrent we just added).