### PR TITLE
adds support to .env file using native feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # Build Stage
-FROM node:18-alpine AS build-stage
+FROM node:20-alpine AS build-stage
 WORKDIR /usr/src/cross-seed
 COPY package*.json ./
-RUN npm install -g npm@9 \
-    && npm ci
+RUN npm ci
 COPY tsconfig.json tsconfig.json
 COPY src src
 RUN npm run build \
@@ -11,7 +10,7 @@ RUN npm run build \
     && rm -rf src tsconfig.json
 
 # Production Stage
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /usr/src/cross-seed
 COPY --from=build-stage /usr/src/cross-seed .
 RUN npm link

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --env-file=.env
 import chalk from "chalk";
 import { Option, program } from "commander";
 import { getApiKeyFromDatabase, resetApiKey } from "./auth.js";


### PR DESCRIPTION
After node v20.6 we can use native env files. https://nodejs.org/en/blog/release/v20.6.0

- The `.env` file needs to exists in the current dir: 
   - in case of docker is already the /config
   - if installed with npm or anything, the current dir (`pwd`) is considered (it can be changed on many way, eg systemd uses `WorkingDirectory`)
   - if theres no `.env` file, no error or warning, no side-effect

And just use `process.env` as normal