### PR TITLE
update(group-match): fixes matching conditions in safemode and tracker compatibility

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,8 @@ export const SEASON_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)[_.\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
-export const RELEASE_GROUP_REGEX = /(?<=-)[\w ]+(?=(?:\.\w{1,5})?$)/i;
+export const RELEASE_GROUP_REGEX =
+	/(?<=-)(?<group>[\w ]+)(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi"];
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -112,8 +112,8 @@ function releaseGroupDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode
 ) {
-	const searcheeMatch = searcheeName.match(RELEASE_GROUP_REGEX);
-	const candidateMatch = candidateName.match(RELEASE_GROUP_REGEX);
+	const searcheeMatch = searcheeName.match(RELEASE_GROUP_REGEX)[0]?.trim();
+	const candidateMatch = candidateName.match(RELEASE_GROUP_REGEX)[0]?.trim();
 
 	// if we are unsure, pass in risky mode but fail in safe mode
 	if (!searcheeMatch || !candidateMatch) {
@@ -121,9 +121,7 @@ function releaseGroupDoesMatch(
 			? searcheeMatch || candidateMatch
 			: !searcheeMatch && !candidateMatch;
 	}
-	return searcheeMatch[0]
-		.toLowerCase()
-		.startsWith(candidateMatch[0].toLowerCase());
+	return searcheeMatch.toLowerCase().startsWith(candidateMatch.toLowerCase());
 }
 
 async function assessCandidateHelper(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -112,16 +112,22 @@ function releaseGroupDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode
 ) {
-	const searcheeMatch = searcheeName.match(RELEASE_GROUP_REGEX)[0]?.trim();
-	const candidateMatch = candidateName.match(RELEASE_GROUP_REGEX)[0]?.trim();
-
-	// if we are unsure, pass in risky mode but fail in safe mode
-	if (!searcheeMatch || !candidateMatch) {
-		return matchMode === MatchMode.RISKY
-			? searcheeMatch || candidateMatch
-			: !searcheeMatch && !candidateMatch;
+	const searcheeReleaseGroup = searcheeName
+		.match(RELEASE_GROUP_REGEX)?.[0]
+		?.trim()
+		?.toLowerCase();
+	const candidateReleaseGroup = candidateName
+		.match(RELEASE_GROUP_REGEX)?.[0]
+		?.trim()
+		?.toLowerCase();
+	if (searcheeReleaseGroup === candidateReleaseGroup) {
+		return true;
 	}
-	return searcheeMatch.toLowerCase().startsWith(candidateMatch.toLowerCase());
+	// if we are unsure, pass in risky mode but fail in safe mode
+	if (!searcheeReleaseGroup || !candidateReleaseGroup) {
+		return matchMode === MatchMode.RISKY;
+	}
+	return searcheeReleaseGroup.startsWith(candidateReleaseGroup);
 }
 
 async function assessCandidateHelper(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -117,7 +117,9 @@ function releaseGroupDoesMatch(
 
 	// if we are unsure, pass in risky mode but fail in safe mode
 	if (!searcheeMatch || !candidateMatch) {
-		return matchMode === MatchMode.RISKY;
+		return matchMode === MatchMode.RISKY
+			? searcheeMatch || candidateMatch
+			: !searcheeMatch && !candidateMatch;
 	}
 	return searcheeMatch[0]
 		.toLowerCase()


### PR DESCRIPTION
fixes a failure to match on both missing groups when matchmode is safe

addresses huno's renaming scheme and matches properly with other trackers

- [x] look into parsing huno