### PR TITLE
add(group-match): uses compareLocale for startsWith

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -18,7 +18,7 @@ import {
 	parseTorrentFromURL,
 	SnatchError,
 } from "./torrent.js";
-import { startsWithIgnoreCase } from "./utils.js";
+import { startsWithIgnoringCase } from "./utils.js";
 
 export interface ResultAssessment {
 	decision: Decision;
@@ -122,7 +122,7 @@ function releaseGroupDoesMatch(
 			? searcheeMatch || candidateMatch
 			: !searcheeMatch && !candidateMatch;
 	}
-	return startsWithIgnoreCase(searcheeMatch[0], candidateMatch[0]);
+	return startsWithIgnoringCase(searcheeMatch, candidateMatch);
 }
 
 async function assessCandidateHelper(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -18,6 +18,7 @@ import {
 	parseTorrentFromURL,
 	SnatchError,
 } from "./torrent.js";
+import { startsWithIgnoreCase } from "./utils.js";
 
 export interface ResultAssessment {
 	decision: Decision;
@@ -121,7 +122,7 @@ function releaseGroupDoesMatch(
 			? searcheeMatch || candidateMatch
 			: !searcheeMatch && !candidateMatch;
 	}
-	return searcheeMatch.toLowerCase().startsWith(candidateMatch.toLowerCase());
+	return startsWithIgnoreCase(searcheeMatch[0], candidateMatch[0]);
 }
 
 async function assessCandidateHelper(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,10 +114,10 @@ export function extractCredentialsFromUrl(
 	}
 }
 
-export function startsWithIgnoreCase(a: string, b: string): boolean {
+export function startsWithIgnoringCase(a: string, b: string): boolean {
 	if (a.length < b.length) {
 		return false;
 	}
-	const prefix = a.substring(0, b.length)
-	return prefix.localeCompare(b, undefined, { sensitivity: 'base'}) === 0
+	const prefix = a.substring(0, b.length);
+	return prefix.localeCompare(b, undefined, { sensitivity: "base" }) === 0;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,3 +113,11 @@ export function extractCredentialsFromUrl(
 		return resultOfErr("invalid URL");
 	}
 }
+
+export function startsWithIgnoreCase(a: string, b: string): boolean {
+	if (a.length < b.length) {
+		return false;
+	}
+	const prefix = a.substring(0, b.length)
+	return prefix.localeCompare(b, undefined, { sensitivity: 'base'}) === 0
+}


### PR DESCRIPTION
As discussed using `localeCompare` for case insensitive comparison:
https://stackoverflow.com/questions/2140627/how-to-do-case-insensitive-string-comparison/2140723#2140723