### PR TITLE
fix(ci): add python dependency to build-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,20 @@
 FROM node:20-alpine AS build-stage
 WORKDIR /usr/src/cross-seed
 COPY package*.json ./
-RUN npm ci
-COPY tsconfig.json tsconfig.json
+RUN apk add --no-cache build-base python3 && \
+    npm ci
+COPY tsconfig.json ./
 COPY src src
-RUN npm run build \
-    && npm prune --production \
-    && rm -rf src tsconfig.json
+RUN npm run build && \
+    npm prune --production && \
+    rm -rf src tsconfig.json
 
 # Production Stage
 FROM node:20-alpine
 WORKDIR /usr/src/cross-seed
-COPY --from=build-stage /usr/src/cross-seed .
-RUN npm link
-RUN apk add --no-cache curl
+COPY --from=build-stage /usr/src/cross-seed ./
+RUN apk add --no-cache curl && \
+    npm link
 ENV CONFIG_DIR=/config
 ENV DOCKER_ENV=true
 EXPOSE 2468


### PR DESCRIPTION
the docker image node:20 does not come with python
seems we use node-gyp and that needs somes build dependency

```
#11 8.269 npm ERR! code 1
#11 8.270 npm ERR! path /usr/src/cross-seed/node_modules/better-sqlite3
#11 8.271 npm ERR! command failed
#11 8.272 npm ERR! command sh -c prebuild-install || node-gyp rebuild --release
#11 8.272 npm ERR! prebuild-install warn install No prebuilt binaries found (target=20.11.0 runtime=node arch=x64 libc=musl platform=linux)
#11 8.272 npm ERR! gyp info it worked if it ends with ok
#11 8.272 npm ERR! gyp info using node-gyp@10.0.1
#11 8.272 npm ERR! gyp info using node@20.11.0 | linux | x64
#11 8.272 npm ERR! gyp ERR! find Python 
#11 8.273 npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
#11 8.273 npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
#11 8.273 npm ERR! gyp ERR! find Python checking if "python3" can be used
#11 8.273 npm ERR! gyp ERR! find Python - executable path is ""
#11 8.274 npm ERR! gyp ERR! find Python - "" could not be run
#11 8.274 npm ERR! gyp ERR! find Python checking if "python" can be used
#11 8.274 npm ERR! gyp ERR! find Python - executable path is ""
#11 8.275 npm ERR! gyp ERR! find Python - "" could not be run
#11 8.275 npm ERR! gyp ERR! find Python 
#11 8.275 npm ERR! gyp ERR! find Python **********************************************************
#11 8.275 npm ERR! gyp ERR! find Python You need to install the latest version of Python.
#11 8.276 npm ERR! gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
#11 8.276 npm ERR! gyp ERR! find Python you can try one of the following options:
#11 8.276 npm ERR! gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
#11 8.277 npm ERR! gyp ERR! find Python (accepted by both node-gyp and npm)
#11 8.277 npm ERR! gyp ERR! find Python - Set the environment variable PYTHON
#11 8.277 npm ERR! gyp ERR! find Python - Set the npm configuration variable python:
#11 8.277 npm ERR! gyp ERR! find Python npm config set python "/path/to/pythonexecutable"
#11 8.278 npm ERR! gyp ERR! find Python For more information consult the documentation at:
#11 8.278 npm ERR! gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
#11 8.278 npm ERR! gyp ERR! find Python **********************************************************
#11 8.279 npm ERR! gyp ERR! find Python 
#11 8.279 npm ERR! gyp ERR! configure error 
#11 8.279 npm ERR! gyp ERR! stack Error: Could not find any Python installation to use
```