### PR TITLE
feat(config/logging): error messaging on invalid syntax in config file

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -38,6 +38,7 @@ try {
 		console.error(e.message);
 		process.exit(1);
 	}
+	throw e;
 }
 
 /**

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { Option, program } from "commander";
 import { getApiKeyFromDatabase, resetApiKey } from "./auth.js";
 import { VALIDATION_SCHEMA, zodErrorMap } from "./configSchema.js";
-import { generateConfig, getFileConfig } from "./configuration.js";
+import { FileConfig, generateConfig, getFileConfig } from "./configuration.js";
 import {
 	Action,
 	LinkType,
@@ -30,7 +30,15 @@ import { parseTorrentFromFilename } from "./torrent.js";
 import { fallback } from "./utils.js";
 import { inspect } from "util";
 
-const fileConfig = await getFileConfig();
+let fileConfig: FileConfig;
+try {
+	fileConfig = await getFileConfig();
+} catch (e) {
+	if (e instanceof CrossSeedError) {
+		console.error(e.message);
+		process.exit(1);
+	}
+}
 
 /**
  * validates and sets RuntimeConfig

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { pathToFileURL } from "url";
 import { Action, MatchMode } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
+
 const require = createRequire(import.meta.url);
 const packageDotJson = require("../package.json");
 
@@ -49,12 +50,12 @@ interface GenerateConfigParams {
 }
 
 export const UNPARSABLE_CONFIG_MESSAGE = `
-Your config file is improperly formatted.
+Your config file is improperly formatted. The location of the error is above, \
+but you may have to look backwards to see the root cause.
 Make sure that
   - strings (words, URLs, etc) are wrapped in "quotation marks"
   - any arrays (lists of things, even one thing) are wrapped in [square brackets]
   - every entry has a comma after it, including inside arrays
-The location of the error is above, but you may have to look backwards to see where the root cause is. 
 `.trim();
 
 export function appDir(): string {
@@ -103,10 +104,9 @@ export async function getFileConfig(): Promise<FileConfig> {
 			return {};
 		} else if (e instanceof SyntaxError) {
 			const location = e.stack!.split("\n").slice(0, 3).join("\n");
-			const error = new CrossSeedError(
-				`${chalk.red(location)}\n\n${UNPARSABLE_CONFIG_MESSAGE}`
+			throw new CrossSeedError(
+				`\n${chalk.red(location)}\n\n${UNPARSABLE_CONFIG_MESSAGE}`
 			);
-			throw error;
 		} else {
 			throw e;
 		}


### PR DESCRIPTION
If a user's config file has invalid syntax, cross-seed throws the raw `SyntaxError` from node trying to `require` the file. This PR adds some error handling to catch-and-rethrow a friendlier, more actionable error message than what the SyntaxError showed. 