### PR TITLE
chore: move category and tag to constants

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,4 +1,4 @@
-import { InjectionResult } from "../constants.js";
+import { InjectionResult, TORRENT_TAG } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -41,7 +41,7 @@ type DelugeJSON<ResultType> = {
 
 export default class Deluge implements TorrentClient {
 	private delugeCookie: string | null = null;
-	private delugeLabel = "cross-seed";
+	private delugeLabel = TORRENT_TAG;
 	private isLabelEnabled: boolean;
 
 	/**

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,4 +1,4 @@
-import { InjectionResult, TORRENT_TAG } from "../constants.js";
+import { InjectionResult, TORRENT_TAG, TORRENT_CATEGORY_SUFFIX } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -42,6 +42,7 @@ type DelugeJSON<ResultType> = {
 export default class Deluge implements TorrentClient {
 	private delugeCookie: string | null = null;
 	private delugeLabel = TORRENT_TAG;
+	private delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
 	private isLabelEnabled: boolean;
 
 	/**
@@ -247,9 +248,9 @@ export default class Deluge implements TorrentClient {
 						? dataCategory
 						: torrentInfo!.label
 						? duplicateCategories
-							? torrentInfo!.label.endsWith(".cross-seed")
+							? torrentInfo!.label.endsWith(this.delugeLabelSuffix)
 								? torrentInfo!.label
-								: `${torrentInfo!.label}.cross-seed`
+								: `${torrentInfo!.label}${this.delugeLabelSuffix}`
 							: torrentInfo!.label
 						: this.delugeLabel
 				);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -1,5 +1,5 @@
 import { posix } from "path";
-import { InjectionResult } from "../constants.js";
+import { InjectionResult, TORRENT_TAG } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger, logOnce } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -192,7 +192,7 @@ export default class QBittorrent implements TorrentClient {
 	async createTag(): Promise<void> {
 		await this.request(
 			"/torrents/createTags",
-			"tags=cross-seed",
+			`tags=${TORRENT_TAG}`,
 			X_WWW_FORM_URLENCODED
 		);
 	}
@@ -294,7 +294,7 @@ export default class QBittorrent implements TorrentClient {
 
 			const formData = new FormData();
 			formData.append("torrents", buffer, filename);
-			formData.append("tags", "cross-seed");
+			formData.append("tags", TORRENT_TAG);
 			formData.append("category", newCategoryName);
 
 			if (autoTMM) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -1,5 +1,5 @@
 import { posix } from "path";
-import { InjectionResult, TORRENT_TAG } from "../constants.js";
+import { InjectionResult, TORRENT_TAG, TORRENT_CATEGORY_SUFFIX } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger, logOnce } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -155,12 +155,12 @@ export default class QBittorrent implements TorrentClient {
 
 	async setUpCrossSeedCategory(ogCategoryName: string): Promise<string> {
 		if (!ogCategoryName) return "";
-		if (ogCategoryName.endsWith(".cross-seed")) return ogCategoryName;
+		if (ogCategoryName.endsWith(TORRENT_CATEGORY_SUFFIX)) return ogCategoryName;
 
 		const categoriesStr = await this.request("/torrents/categories", "");
 		const categories: Record<string, Category> = JSON.parse(categoriesStr);
 		const ogCategory = categories[ogCategoryName];
-		const newCategoryName = `${ogCategoryName}.cross-seed`;
+		const newCategoryName = `${ogCategoryName}${TORRENT_CATEGORY_SUFFIX}`;
 		const maybeNewCategory = categories[newCategoryName];
 
 		if (!ogCategory.savePath) {
@@ -275,7 +275,7 @@ export default class QBittorrent implements TorrentClient {
 						isComplete: true,
 						autoTMM: false,
 						category: dataCategory,
-				  }
+					}
 				: await this.getTorrentConfiguration(searchee);
 
 			const newCategoryName =

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -2,7 +2,7 @@ import { promises as fs, Stats } from "fs";
 import { dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
 import xmlrpc, { Client } from "xmlrpc";
-import { InjectionResult } from "../constants.js";
+import { InjectionResult, TORRENT_TAG } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -259,7 +259,7 @@ export default class RTorrent implements TorrentClient {
 					"",
 					torrentFilePath,
 					`d.directory_base.set="${directoryBase}"`,
-					`d.custom1.set="cross-seed"`,
+					`d.custom1.set="${TORRENT_TAG}"`,
 					`d.custom.set=addtime,${Math.round(Date.now() / 1000)}`,
 				]);
 				break;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -1,4 +1,4 @@
-import { InjectionResult } from "../constants.js";
+import { InjectionResult, TORRENT_TAG } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -180,7 +180,7 @@ export default class Transmission implements TorrentClient {
 					"download-dir": downloadDir,
 					metainfo: newTorrent.encode().toString("base64"),
 					paused: false,
-					labels: ["cross-seed"],
+					labels: [TORRENT_TAG],
 				}
 			);
 		} catch (e) {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -249,7 +249,7 @@ function createCommandWithSharedOptions(name, description) {
 }
 
 program.name(PROGRAM_NAME);
-program.description(chalk.yellow.bold("cross-seed"));
+program.description(chalk.yellow.bold(`${PROGRAM_NAME} v${PROGRAM_VERSION}`));
 program.version(PROGRAM_VERSION, "-V, --version", "output the current version");
 
 program

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -45,12 +45,12 @@ export async function validateAndSetRuntimeConfig(options: RuntimeConfig) {
 		options = VALIDATION_SCHEMA.parse(options, {
 			errorMap: zodErrorMap,
 		}) as RuntimeConfig;
-	} catch (error) {
+	} catch ({ errors }) {
 		logger.verbose({
 			label: Label.CONFIGDUMP,
 			message: inspect(options),
 		});
-		error.errors.forEach(({ path, message }) => {
+		errors?.forEach(({ path, message }) => {
 			const urlPath = path[0];
 			const optionLine =
 				path.length === 2
@@ -66,10 +66,10 @@ export async function validateAndSetRuntimeConfig(options: RuntimeConfig) {
 				})\n`
 			);
 		});
-		if (error.errors.length > 0) {
+		if (errors?.length > 0) {
 			throw new CrossSeedError(
 				`\tYour configuration is invalid, please see the ${
-					error.errors.length > 1 ? "errors" : "error"
+					errors.length > 1 ? "errors" : "error"
 				} above for details.`
 			);
 		}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,8 +5,8 @@ const packageDotJson = require("../package.json");
 export const PROGRAM_NAME = packageDotJson.name;
 export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
-export const TORRENT_TAG = PROGRAM_NAME;
-export const TORRENT_CATEGORY_SUFFIX = `.${PROGRAM_NAME}`;
+export const TORRENT_TAG = 'cross-seed';
+export const TORRENT_CATEGORY_SUFFIX = `.cross-seed`;
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[\s-]?E?\d+)?(?![ip]))(?!\d+[ip])|(?<date>(?<year>\d{4})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const PROGRAM_NAME = packageDotJson.name;
 export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
 export const TORRENT_TAG = PROGRAM_NAME;
+export const TORRENT_CATEGORY_SUFFIX = `.${PROGRAM_NAME}`;
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[\s-]?E?\d+)?(?![ip]))(?!\d+[ip])|(?<date>(?<year>\d{4})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ const packageDotJson = require("../package.json");
 export const PROGRAM_NAME = packageDotJson.name;
 export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
+export const TORRENT_TAG = PROGRAM_NAME;
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[\s-]?E?\d+)?(?![ip]))(?!\d+[ip])|(?<date>(?<year>\d{4})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -2,6 +2,7 @@ import {
 	ActionResult,
 	InjectionResult,
 	SaveResult,
+	PROGRAM_NAME,
 	USER_AGENT,
 } from "./constants.js";
 import { ResultAssessment } from "./decide.js";
@@ -29,7 +30,7 @@ export class PushNotifier {
 	}
 
 	async notify({
-		title = "cross-seed",
+		title = PROGRAM_NAME,
 		body,
 		...rest
 	}: PushNotification): Promise<void> {


### PR DESCRIPTION
Moving the tag and category to `constants.ts`

This would make it easy to patch and also reduce magic const.

There is also one fix on `cmd.ts`, it was breaking on me due missing array errors, so I just made an safe type there.