### PR TITLE
feat(decide/match): Added partial matching

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -102,7 +102,7 @@ function createCommandWithSharedOptions(name, description) {
 		.addOption(
 			new Option(
 				"--match-mode <mode>",
-				"Safe will only download torrents with perfect matches. Risky will allow for renames and more matches, but might cause false positives"
+				"Safe will only download torrents with perfect matches. Risky will allow for renames and more matches, but might cause false positives. Partial is like risky but it ignores small files like .nfo/.srt if missing."
 			)
 				.default(fallback(fileConfig.matchMode, MatchMode.SAFE))
 				.choices(Object.values(MatchMode))

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -99,7 +99,8 @@ module.exports = {
 	/**
 	 * Determines flexibility of naming during matching. "safe" will allow only perfect name/size matches
 	 * using the standard matching algorithm. "risky" uses filesize as its only comparison point.
-	 * Options: "safe", "risky"
+	 * "partial" is like risky but allows matches if they are missing small files like .nfo/.srt
+	 * Options: "safe", "risky", "partial"
 	 */
 	matchMode: "safe",
 
@@ -138,7 +139,7 @@ module.exports = {
 	legacyLinking: false,
 
 	/**
-	 * Whether to skip recheck in Qbittorrent. If using "risky" matchMode it is HIGHLY
+	 * Whether to skip recheck in Qbittorrent. If using "risky" or "partial" matchMode it is HIGHLY
 	 * recommended to set this to false.
 	 * Only applies to data based matches.
 	 */

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -99,7 +99,8 @@ module.exports = {
 	/**
 	 * Determines flexibility of naming during matching. "safe" will allow only perfect name/size matches
 	 * using the standard matching algorithm. "risky" uses filesize as its only comparison point.
-	 * Options: "safe", "risky"
+	 * "partial" is like risky but allows matches if they are missing small files like .nfo/.srt
+	 * Options: "safe", "risky", "partial"
 	 */
 	matchMode: "safe",
 
@@ -140,7 +141,7 @@ module.exports = {
 	legacyLinking: false,
 
 	/**
-	 * Whether to skip recheck in Qbittorrent. If using "risky" matchMode it is HIGHLY
+	 * Whether to skip recheck in Qbittorrent. If using "risky" or "partial" matchMode it is HIGHLY
 	 * recommended to set this to false.
 	 * Only applies to data based matches.
 	 */

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -202,7 +202,8 @@ export const VALIDATION_SCHEMA = z
 		})
 	)
 	.refine((config) => {
-		if (config.skipRecheck && config.matchMode == MatchMode.RISKY) {
+		if (config.skipRecheck && (config.matchMode == MatchMode.RISKY ||
+			config.matchMode == MatchMode.PARTIAL)) {
 			logger.warn(ZodErrorMessages.riskyRecheckWarn);
 		}
 		return true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export type ActionResult = InjectionResult | SaveResult;
 export enum Decision {
 	MATCH = "MATCH",
 	MATCH_SIZE_ONLY = "MATCH_SIZE_ONLY",
+	MATCH_PARTIAL = "MATCH_PARTIAL",
 	SIZE_MISMATCH = "SIZE_MISMATCH",
 	NO_DOWNLOAD_LINK = "NO_DOWNLOAD_LINK",
 	DOWNLOAD_FAILED = "DOWNLOAD_FAILED",
@@ -58,6 +59,7 @@ export enum Decision {
 export enum MatchMode {
 	SAFE = "safe",
 	RISKY = "risky",
+	PARTIAL = "partial",
 }
 
 export enum LinkType {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -128,7 +128,8 @@ async function findOnOtherSites(
 	const matches = assessments.filter(
 		(e) =>
 			e.assessment.decision === Decision.MATCH ||
-			e.assessment.decision === Decision.MATCH_SIZE_ONLY
+			e.assessment.decision === Decision.MATCH_SIZE_ONLY ||
+			e.assessment.decision === Decision.MATCH_PARTIAL
 	);
 	const actionResults = await performActions(searchee, matches);
 	if (actionResults.includes(InjectionResult.TORRENT_NOT_COMPLETE)) {
@@ -245,7 +246,8 @@ export async function checkNewCandidateMatch(
 
 	if (
 		assessment.decision !== Decision.MATCH &&
-		assessment.decision !== Decision.MATCH_SIZE_ONLY
+		assessment.decision !== Decision.MATCH_SIZE_ONLY &&
+		assessment.decision !== Decision.MATCH_PARTIAL
 	) {
 		return null;
 	}


### PR DESCRIPTION
Solves: #610

After running this across all my torrents, it doubled the number of cross seeds I had. I was previously using dataDir risky with includeEpisodes and includeNonVideos.

This implementation creates a new match mode called "partial". It uses ```1 - fuzzySizeThreshold``` to determine minPartialMatch as creating a new option is redundant.

The only thing missing is to always recheck and pause if we don't want cross-seed to ever download anything. It requires passing Decision to inject() so all the clients can handle MATCH_PARTIAL as a special case. I opted not to include it now so the main part is easier to review.

I have not tested it on this branch but I've been using it on a branch from master for the past few weeks with qBittorrent.