### PR TITLE
feat(decide/match): partial file tree match mode

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -192,7 +192,7 @@ export async function performAction(
 		destinationDir = dirname(searchee.path);
 	}
 
-	const result = await getClient().inject(newMeta, searchee, destinationDir);
+	const result = await getClient().inject(newMeta, searchee, decision, destinationDir);
 
 	logInjectionResult(result, tracker, newMeta.name);
 	if (result === InjectionResult.FAILURE) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -35,10 +35,14 @@ function logInjectionResult(
 	const styledTracker = chalk.bold(tracker);
 	switch (result) {
 		case InjectionResult.SUCCESS:
-			logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - injected`);
+			logger.info(
+				`Found ${styledName} on ${styledTracker} by ${decision} - injected`
+			);
 			break;
 		case InjectionResult.ALREADY_EXISTS:
-			logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - exists`);
+			logger.info(
+				`Found ${styledName} on ${styledTracker} by ${decision} - exists`
+			);
 			break;
 		case InjectionResult.TORRENT_NOT_COMPLETE:
 			logger.warn(
@@ -90,10 +94,9 @@ function fuzzyLinkPartial(
 			);
 		}
 		if (matchedSearcheeFiles.length) {
-			const srcFilePath =
-				statSync(sourceRoot).isFile()
-					? sourceRoot
-					: join(dirname(sourceRoot), matchedSearcheeFiles[0].path);
+			const srcFilePath = statSync(sourceRoot).isFile()
+				? sourceRoot
+				: join(dirname(sourceRoot), matchedSearcheeFiles[0].path);
 			const destFilePath = join(destinationDir, newFile.path);
 			mkdirSync(dirname(destFilePath), { recursive: true });
 			linkFile(srcFilePath, destFilePath);
@@ -153,7 +156,10 @@ async function linkAllFilesInMetafile(
 
 export async function performAction(
 	newMeta: Metafile,
-	decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+	decision:
+		| Decision.MATCH
+		| Decision.MATCH_SIZE_ONLY
+		| Decision.MATCH_PARTIAL,
 	searchee: Searchee,
 	tracker: string
 ): Promise<ActionResult> {
@@ -163,7 +169,9 @@ export async function performAction(
 		await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
-		logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - saved`);
+		logger.info(
+			`Found ${styledName} on ${styledTracker} by ${decision} - saved`
+		);
 		return SaveResult.SAVED;
 	}
 
@@ -184,7 +192,12 @@ export async function performAction(
 		) {
 			logger.warn("Falling back to non-linking.");
 		} else {
-			logInjectionResult(InjectionResult.FAILURE, tracker, newMeta.name, decision);
+			logInjectionResult(
+				InjectionResult.FAILURE,
+				tracker,
+				newMeta.name,
+				decision
+			);
 			await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
 			return InjectionResult.FAILURE;
 		}
@@ -193,7 +206,12 @@ export async function performAction(
 		destinationDir = dirname(searchee.path);
 	}
 
-	const result = await getClient().inject(newMeta, searchee, decision, destinationDir);
+	const result = await getClient().inject(
+		newMeta,
+		searchee,
+		decision,
+		destinationDir
+	);
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -28,26 +28,27 @@ import { getTag } from "./utils.js";
 function logInjectionResult(
 	result: InjectionResult,
 	tracker: string,
-	name: string
+	name: string,
+	decision: Decision
 ) {
 	const styledName = chalk.green.bold(name);
 	const styledTracker = chalk.bold(tracker);
 	switch (result) {
 		case InjectionResult.SUCCESS:
-			logger.info(`Found ${styledName} on ${styledTracker} - injected`);
+			logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - injected`);
 			break;
 		case InjectionResult.ALREADY_EXISTS:
-			logger.info(`Found ${styledName} on ${styledTracker} - exists`);
+			logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - exists`);
 			break;
 		case InjectionResult.TORRENT_NOT_COMPLETE:
 			logger.warn(
-				`Found ${styledName} on ${styledTracker} - skipping incomplete torrent`
+				`Found ${styledName} on ${styledTracker} by ${decision} - skipping incomplete torrent`
 			);
 			break;
 		case InjectionResult.FAILURE:
 		default:
 			logger.error(
-				`Found ${styledName} on ${styledTracker} - failed to inject, saving instead`
+				`Found ${styledName} on ${styledTracker} by ${decision} - failed to inject, saving instead`
 			);
 			break;
 	}
@@ -162,7 +163,7 @@ export async function performAction(
 		await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
-		logger.info(`Found ${styledName} on ${styledTracker} - saved`);
+		logger.info(`Found ${styledName} on ${styledTracker} by ${decision} - saved`);
 		return SaveResult.SAVED;
 	}
 
@@ -183,7 +184,7 @@ export async function performAction(
 		) {
 			logger.warn("Falling back to non-linking.");
 		} else {
-			logInjectionResult(InjectionResult.FAILURE, tracker, newMeta.name);
+			logInjectionResult(InjectionResult.FAILURE, tracker, newMeta.name, decision);
 			await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
 			return InjectionResult.FAILURE;
 		}
@@ -194,7 +195,7 @@ export async function performAction(
 
 	const result = await getClient().inject(newMeta, searchee, decision, destinationDir);
 
-	logInjectionResult(result, tracker, newMeta.name);
+	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
 		await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
 	}

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -240,7 +240,10 @@ export default class Deluge implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL,
 		path?: string
 	): Promise<InjectionResult> {
 		try {
@@ -324,13 +327,14 @@ export default class Deluge implements TorrentClient {
 		filedump: string,
 		path: string,
 		isTorrent: boolean,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL
 	): InjectData {
 		const { skipRecheck } = getRuntimeConfig();
 		const skipRecheckTorrent =
-			decision === Decision.MATCH_PARTIAL
-				? skipRecheck
-				: true;
+			decision === Decision.MATCH_PARTIAL ? skipRecheck : true;
 		return [
 			filename,
 			filedump,

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -290,7 +290,10 @@ export default class QBittorrent implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL,
 		path?: string
 	): Promise<InjectionResult> {
 		const { duplicateCategories, skipRecheck, dataCategory } =
@@ -326,11 +329,9 @@ export default class QBittorrent implements TorrentClient {
 				(await this.isSubfolderContentLayout(searchee))
 					? "Subfolder"
 					: "Original";
-			
+
 			const skipRecheckTorrent =
-				decision === Decision.MATCH_PARTIAL
-				  	? skipRecheck
-					: true;
+				decision === Decision.MATCH_PARTIAL ? skipRecheck : true;
 
 			const formData = new FormData();
 			formData.append("torrents", buffer, filename);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -1,5 +1,6 @@
 import { posix } from "path";
 import {
+	Decision,
 	InjectionResult,
 	TORRENT_TAG,
 	TORRENT_CATEGORY_SUFFIX,
@@ -289,6 +290,7 @@ export default class QBittorrent implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
+		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
 		path?: string
 	): Promise<InjectionResult> {
 		const { duplicateCategories, skipRecheck, dataCategory } =
@@ -324,6 +326,11 @@ export default class QBittorrent implements TorrentClient {
 				(await this.isSubfolderContentLayout(searchee))
 					? "Subfolder"
 					: "Original";
+			
+			const skipRecheckTorrent =
+				decision === Decision.MATCH_PARTIAL
+				  	? skipRecheck
+					: true;
 
 			const formData = new FormData();
 			formData.append("torrents", buffer, filename);
@@ -342,8 +349,8 @@ export default class QBittorrent implements TorrentClient {
 				formData.append("paused", (!skipRecheck).toString());
 			} else {
 				formData.append("contentLayout", contentLayout);
-				formData.append("skip_checking", "true");
-				formData.append("paused", "false");
+				formData.append("skip_checking", skipRecheckTorrent.toString());
+				formData.append("paused", (!skipRecheckTorrent).toString());
 			}
 
 			// for some reason the parser parses the last kv pair incorrectly

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -276,7 +276,10 @@ export default class RTorrent implements TorrentClient {
 	async inject(
 		meta: Metafile,
 		searchee: Searchee,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL,
 		path?: string
 	): Promise<InjectionResult> {
 		const { outputDir, skipRecheck } = getRuntimeConfig();
@@ -307,7 +310,9 @@ export default class RTorrent implements TorrentClient {
 
 		const loadType =
 			decision === Decision.MATCH_PARTIAL
-				? skipRecheck ? "load.start" : "load"
+				? skipRecheck
+					? "load.start"
+					: "load"
 				: "load.start";
 
 		for (let i = 0; i < 5; i++) {

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -305,20 +305,19 @@ export default class RTorrent implements TorrentClient {
 
 		await saveWithLibTorrentResume(meta, torrentFilePath, basePath);
 
-		const paused =
+		const loadType =
 			decision === Decision.MATCH_PARTIAL
-				? skipRecheck ? 0 : 1
-				: 0;
+				? skipRecheck ? "load.start" : "load"
+				: "load.start";
 
 		for (let i = 0; i < 5; i++) {
 			try {
-				await this.methodCallP<void>("load.start", [
+				await this.methodCallP<void>(loadType, [
 					"",
 					torrentFilePath,
 					`d.directory_base.set="${directoryBase}"`,
 					`d.custom1.set="${TORRENT_TAG}"`,
 					`d.custom.set=addtime,${Math.round(Date.now() / 1000)}`,
-					`d.custom2.set=paused,${paused}`,
 				]);
 				break;
 			} catch (e) {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -1,5 +1,5 @@
 import { Metafile } from "../parseTorrent.js";
-import { InjectionResult } from "../constants.js";
+import { Decision, InjectionResult } from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import QBittorrent from "./QBittorrent.js";
@@ -19,6 +19,7 @@ export interface TorrentClient {
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,
+		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
 		path?: string
 	) => Promise<InjectionResult>;
 	validateConfig: () => Promise<void>;

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -19,7 +19,10 @@ export interface TorrentClient {
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL,
 		path?: string
 	) => Promise<InjectionResult>;
 	validateConfig: () => Promise<void>;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -168,7 +168,10 @@ export default class Transmission implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision: Decision.MATCH | Decision.MATCH_SIZE_ONLY | Decision.MATCH_PARTIAL,
+		decision:
+			| Decision.MATCH
+			| Decision.MATCH_SIZE_ONLY
+			| Decision.MATCH_PARTIAL,
 		path?: string
 	): Promise<InjectionResult> {
 		const { skipRecheck } = getRuntimeConfig();
@@ -190,9 +193,7 @@ export default class Transmission implements TorrentClient {
 		let addResponse: TorrentAddResponse;
 
 		const skipRecheckTorrent =
-			decision === Decision.MATCH_PARTIAL
-				? skipRecheck
-				: true;
+			decision === Decision.MATCH_PARTIAL ? skipRecheck : true;
 
 		try {
 			addResponse = await this.request<TorrentAddResponse>(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -114,7 +114,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		.addOption(
 			new Option(
 				"--match-mode <mode>",
-				"Safe will only download torrents with perfect matches. Risky will allow for renames and more matches, but might cause false positives"
+				"Safe will only download torrents with perfect matches. Risky will allow for renames and more matches, but might cause false positives. Partial is like risky but it ignores small files like .nfo/.srt if missing."
 			)
 				.default(fallback(fileConfig.matchMode, MatchMode.SAFE))
 				.choices(Object.values(MatchMode))

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -105,7 +105,9 @@ module.exports = {
 	 * "safe" will allow only perfect name/size matches using the standard
 	 * matching algorithm.
 	 * "risky" uses filesize as its only comparison point.
-	 * Options: "safe", "risky".
+	 * "partial" is like risky but allows matches if they are missing small
+	 * files like .nfo/.srt.
+	 * Options: "safe", "risky", "partial".
 	 */
 	matchMode: "safe",
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -20,7 +20,8 @@ const ZodErrorMessages = {
 	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
 	qBitLegacyLinking:
 		"Using Automatic Torrent Management in qBittorrent without legacyLinking enabled can result in injection path failures.",
-	needsLinkDir: "You need to set a linkDir for risky or partial matching to work.",
+	needsLinkDir:
+		"You need to set a linkDir for risky or partial matching to work.",
 };
 
 /**

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -15,12 +15,12 @@ const ZodErrorMessages = {
 	fuzzySizeThreshold: "fuzzySizeThreshold must be between 0 and 1.",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
-	riskyRecheckWarn:
-		"It is strongly recommended to not skip rechecking for risky matching mode.",
+	recheckWarn:
+		"It is strongly recommended to not skip rechecking for risky or partial matching mode.",
 	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
 	qBitLegacyLinking:
 		"Using Automatic Torrent Management in qBittorrent without legacyLinking enabled can result in injection path failures.",
-	riskyNeedsLinkDir: "You need to set a linkDir for risky matching to work.",
+	needsLinkDir: "You need to set a linkDir for risky or partial matching to work.",
 };
 
 /**
@@ -208,12 +208,12 @@ export const VALIDATION_SCHEMA = z
 		ZodErrorMessages.injectUrl
 	)
 	.refine((config) => {
-		if (config.skipRecheck && config.matchMode === MatchMode.RISKY) {
-			logger.warn(ZodErrorMessages.riskyRecheckWarn);
+		if (config.skipRecheck && config.matchMode !== MatchMode.SAFE) {
+			logger.warn(ZodErrorMessages.recheckWarn);
 		}
 		return true;
 	})
 	.refine(
-		(config) => config.matchMode !== MatchMode.RISKY || config.linkDir,
-		ZodErrorMessages.riskyNeedsLinkDir
+		(config) => config.matchMode === MatchMode.SAFE || config.linkDir,
+		ZodErrorMessages.needsLinkDir
 	);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export type ActionResult = InjectionResult | SaveResult;
 export enum Decision {
 	MATCH = "MATCH",
 	MATCH_SIZE_ONLY = "MATCH_SIZE_ONLY",
+	MATCH_PARTIAL = "MATCH_PARTIAL",
 	SIZE_MISMATCH = "SIZE_MISMATCH",
 	NO_DOWNLOAD_LINK = "NO_DOWNLOAD_LINK",
 	DOWNLOAD_FAILED = "DOWNLOAD_FAILED",
@@ -58,6 +59,7 @@ export enum Decision {
 export enum MatchMode {
 	SAFE = "safe",
 	RISKY = "risky",
+	PARTIAL = "partial",
 }
 
 export enum LinkType {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -141,8 +141,8 @@ export function compareFileTreesPartial(
 		}
 	}
 	const totalPieces = Math.ceil(candidate.length / candidate.pieceLength);
-	const missingPieces = Math.ceil(matchedSizes / candidate.pieceLength);
-	return missingPieces / totalPieces <= fuzzySizeThreshold;
+	const availablePieces = Math.ceil(matchedSizes / candidate.pieceLength);
+	return availablePieces / totalPieces >= 1 - fuzzySizeThreshold;
 }
 
 function sizeDoesMatch(resultSize, searchee) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -118,7 +118,7 @@ export function compareFileTreesPartialIgnoringNames(
 			matchedSizes += candidateFile.length;
 		}
 	}
-	return matchedSizes / candidate.length >= 1-fuzzySizeThreshold;
+	return matchedSizes / candidate.length >= 1 - fuzzySizeThreshold;
 }
 
 export function compareFileTreesPartial(
@@ -143,7 +143,7 @@ export function compareFileTreesPartial(
 			matchedSizes += candidateFile.length;
 		}
 	}
-	return matchedSizes / candidate.length >= 1-fuzzySizeThreshold;
+	return matchedSizes / candidate.length >= 1 - fuzzySizeThreshold;
 }
 
 function sizeDoesMatch(resultSize, searchee) {
@@ -211,7 +211,10 @@ async function assessCandidateHelper(
 		return { decision: Decision.INFO_HASH_ALREADY_EXISTS };
 	}
 
-	const partialSizeMatch = compareFileTreesPartialIgnoringNames(candidateMeta, searchee);
+	const partialSizeMatch = compareFileTreesPartialIgnoringNames(
+		candidateMeta,
+		searchee
+	);
 	if (!partialSizeMatch && matchMode === MatchMode.PARTIAL) {
 		return { decision: Decision.SIZE_MISMATCH };
 	}
@@ -224,7 +227,11 @@ async function assessCandidateHelper(
 	if (perfectMatch) {
 		return { decision: Decision.MATCH, metafile: candidateMeta };
 	}
-	if (sizeMatch && matchMode !== MatchMode.SAFE && searchee.files.length === 1) {
+	if (
+		sizeMatch &&
+		matchMode !== MatchMode.SAFE &&
+		searchee.files.length === 1
+	) {
 		return { decision: Decision.MATCH_SIZE_ONLY, metafile: candidateMeta };
 	}
 	const partialMatch = compareFileTreesPartial(candidateMeta, searchee);

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -111,10 +111,10 @@ export function compareFileTreesPartialIgnoringNames(
 	const { fuzzySizeThreshold } = getRuntimeConfig();
 	let matchedSizes = 0;
 	for (const candidateFile of candidate.files) {
-		let matchedSearcheeFiles = searchee.files.filter(
+		let searcheeHasFileSize = searchee.files.some(
 			(searcheeFile) => searcheeFile.length === candidateFile.length
 		);
-		if (matchedSearcheeFiles.length) {
+		if (searcheeHasFileSize) {
 			matchedSizes += candidateFile.length;
 		}
 	}

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -118,13 +118,16 @@ export function compareFileTreesPartialIgnoringNames(
 			matchedSizes += candidateFile.length;
 		}
 	}
-	return matchedSizes / candidate.length >= 1 - fuzzySizeThreshold;
+	return matchedSizes / candidate.length >= 1-fuzzySizeThreshold;
 }
 
 export function compareFileTreesPartial(
 	candidate: Metafile,
 	searchee: Searchee
 ): boolean {
+	if (candidate.length < candidate.pieceLength) {
+		return false;
+	}
 	const { fuzzySizeThreshold } = getRuntimeConfig();
 	let matchedSizes = 0;
 	for (const candidateFile of candidate.files) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -111,7 +111,7 @@ export function compareFileTreesPartialIgnoringNames(
 	const { fuzzySizeThreshold } = getRuntimeConfig();
 	let matchedSizes = 0;
 	for (const candidateFile of candidate.files) {
-		let searcheeHasFileSize = searchee.files.some(
+		const searcheeHasFileSize = searchee.files.some(
 			(searcheeFile) => searcheeFile.length === candidateFile.length
 		);
 		if (searcheeHasFileSize) {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -125,7 +125,7 @@ export function compareFileTreesPartial(
 	candidate: Metafile,
 	searchee: Searchee
 ): boolean {
-	if (candidate.length < candidate.pieceLength) {
+	if (candidate.length <= candidate.pieceLength) {
 		return false;
 	}
 	const { fuzzySizeThreshold } = getRuntimeConfig();

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -141,7 +141,7 @@ export function compareFileTreesPartial(
 		}
 	}
 	const totalPieces = Math.ceil(candidate.length / candidate.pieceLength);
-	const availablePieces = Math.ceil(matchedSizes / candidate.pieceLength);
+	const availablePieces = Math.floor(matchedSizes / candidate.pieceLength);
 	return availablePieces / totalPieces >= 1 - fuzzySizeThreshold;
 }
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -125,9 +125,6 @@ export function compareFileTreesPartial(
 	candidate: Metafile,
 	searchee: Searchee
 ): boolean {
-	if (candidate.length <= candidate.pieceLength) {
-		return false;
-	}
 	const { fuzzySizeThreshold } = getRuntimeConfig();
 	let matchedSizes = 0;
 	for (const candidateFile of candidate.files) {
@@ -143,7 +140,9 @@ export function compareFileTreesPartial(
 			matchedSizes += candidateFile.length;
 		}
 	}
-	return matchedSizes / candidate.length >= 1 - fuzzySizeThreshold;
+	const totalPieces = Math.ceil(candidate.length / candidate.pieceLength);
+	const missingPieces = Math.ceil(matchedSizes / candidate.pieceLength);
+	return missingPieces / totalPieces <= fuzzySizeThreshold;
 }
 
 function sizeDoesMatch(resultSize, searchee) {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -128,7 +128,8 @@ async function findOnOtherSites(
 	const matches = assessments.filter(
 		(e) =>
 			e.assessment.decision === Decision.MATCH ||
-			e.assessment.decision === Decision.MATCH_SIZE_ONLY
+			e.assessment.decision === Decision.MATCH_SIZE_ONLY ||
+			e.assessment.decision === Decision.MATCH_PARTIAL
 	);
 	const actionResults = await performActions(searchee, matches);
 	if (actionResults.includes(InjectionResult.TORRENT_NOT_COMPLETE)) {
@@ -245,7 +246,8 @@ export async function checkNewCandidateMatch(
 
 	if (
 		assessment.decision !== Decision.MATCH &&
-		assessment.decision !== Decision.MATCH_SIZE_ONLY
+		assessment.decision !== Decision.MATCH_SIZE_ONLY &&
+		assessment.decision !== Decision.MATCH_PARTIAL
 	) {
 		return null;
 	}


### PR DESCRIPTION
Replacement for #614 as the previous base branch was deleted and it can no longer be updated. Apologies for the complications.

Implements #610 and all changes in comments and review of previous PR. Also ensuring torrents are added in paused state if skipRecheck is false for partial matching and reporting FILE_TREE_MISMATCH there are duplicate sizes without a name match.