### PR TITLE
Reset cached indexer failures on startup

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -276,6 +276,10 @@ export async function syncWithDb() {
 				.where({ id: apikeyUpdate.id })
 				.update({ apikey: apikeyUpdate.apikey });
 		}
+		// drop cached UNKNOWN_ERRORs on startup
+		await trx("indexer")
+			.where({ status: IndexerStatus.UNKNOWN_ERROR })
+			.update({ status: IndexerStatus.OK });
 	});
 }
 


### PR DESCRIPTION
If an indexer failed with a non-429, it may be due to a configuration issue. This is frustrating for new users because they are working on getting their configuration correct and then if something breaks, they have to wait 10 minutes until they can continue.

This PR clears out any saved UNKNOWN_ERRORs on startup, allowing users to freely tinker with their configurations. 