### PR TITLE
fix(client/deluge): defend against deluge timeouts

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -279,6 +279,7 @@ export default class Deluge implements TorrentClient {
 				return InjectionResult.FAILURE;
 			}
 		} catch (injectResult) {
+			console.error(injectResult);
 			if (injectResult.includes("label.set_torrent")) {
 				logger.warning({
 					label: Label.DELUGE,

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -147,7 +147,7 @@ export default class Deluge implements TorrentClient {
 				cause: networkError,
 			});
 		}
-		console.log("JSON RESPONSE", response.clone().text());
+		console.log("JSON RESPONSE", await response.clone().text());
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -147,7 +147,7 @@ export default class Deluge implements TorrentClient {
 				cause: networkError,
 			});
 		}
-		console.log(`JSON RESPONSE: ${response}`);
+		console.log("JSON RESPONSE", response);
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -147,6 +147,7 @@ export default class Deluge implements TorrentClient {
 				cause: networkError,
 			});
 		}
+		console.log(`JSON RESPONSE: ${response}`);
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {
@@ -202,6 +203,7 @@ export default class Deluge implements TorrentClient {
 				infoHash,
 				label,
 			]);
+			console.log(`setResult: ${setResult}`);
 			if (setResult.error?.code === DelugeErrorCode.RPC_FAIL) {
 				await this.call<void>("label.add", [label]);
 				await this.call<void>("label.set_torrent", [infoHash, label]);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -147,10 +147,11 @@ export default class Deluge implements TorrentClient {
 				cause: networkError,
 			});
 		}
-		console.log("JSON RESPONSE", await response.clone().text());
+		const text = await response.clone().text();
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {
+			console.log("JSON RESPONSE:", text);
 			throw new Error(
 				`Deluge method ${method} response was non-JSON ${jsonParseError}`
 			);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -210,7 +210,11 @@ export default class Deluge implements TorrentClient {
 	 * if Label plugin is loaded, adds (if necessary)
 	 * and sets the label based on torrent hash.
 	 */
-	private async setLabel(infoHash: string, label: string): Promise<void> {
+	private async setLabel(
+		name: string,
+		infoHash: string,
+		label: string
+	): Promise<void> {
 		if (!this.isLabelEnabled) return;
 		try {
 			const setResult = await this.call<void>("label.set_torrent", [
@@ -224,7 +228,7 @@ export default class Deluge implements TorrentClient {
 		} catch (e) {
 			logger.warn({
 				label: Label.DELUGE,
-				message: `Failed to label ${infoHash} as ${label}`,
+				message: `Failed to label ${name} (${infoHash}) as ${label}`,
 			});
 		}
 	}
@@ -267,6 +271,7 @@ export default class Deluge implements TorrentClient {
 			if (addResult.result) {
 				const { dataCategory } = getRuntimeConfig();
 				await this.setLabel(
+					newTorrent.name,
 					newTorrent.infoHash,
 					searchee.path
 						? dataCategory

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -147,7 +147,7 @@ export default class Deluge implements TorrentClient {
 				cause: networkError,
 			});
 		}
-		console.log("JSON RESPONSE", response);
+		console.log("JSON RESPONSE", response.clone().text());
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -281,7 +281,7 @@ export default class Deluge implements TorrentClient {
 		} catch (injectResult) {
 			console.error(injectResult);
 			if (injectResult.includes("label.set_torrent")) {
-				logger.warning({
+				logger.warn({
 					label: Label.DELUGE,
 					message: `Labeling failure: ${newTorrent.name} (${newTorrent.infoHash})`,
 				});

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,3 +1,4 @@
+import ms from "ms";
 import {
 	InjectionResult,
 	TORRENT_TAG,
@@ -132,6 +133,13 @@ export default class Deluge implements TorrentClient {
 
 		let response: Response, json: DelugeJSON<ResultType>;
 		const id = Math.floor(Math.random() * 0x7fffffff);
+		const abortController = new AbortController();
+
+		setTimeout(
+			() => void abortController.abort(),
+			ms("10 seconds")
+		).unref();
+
 		try {
 			response = await fetch(href, {
 				body: JSON.stringify({
@@ -141,17 +149,21 @@ export default class Deluge implements TorrentClient {
 				}),
 				method: "POST",
 				headers,
+				signal: abortController.signal,
 			});
 		} catch (networkError) {
+			if (networkError.name === "AbortError") {
+				throw new Error(
+					`Deluge method ${method} timed out after 10 seconds`
+				);
+			}
 			throw new Error(`Failed to connect to Deluge at ${href}`, {
 				cause: networkError,
 			});
 		}
-		const text = await response.clone().text();
 		try {
 			json = (await response.json()) as DelugeJSON<ResultType>;
 		} catch (jsonParseError) {
-			console.log("JSON RESPONSE:", text);
 			throw new Error(
 				`Deluge method ${method} response was non-JSON ${jsonParseError}`
 			);
@@ -282,8 +294,7 @@ export default class Deluge implements TorrentClient {
 				return InjectionResult.FAILURE;
 			}
 		} catch (injectResult) {
-			console.error(injectResult);
-			if (injectResult.includes("label.set_torrent")) {
+			if (injectResult.message.includes("label.set_torrent")) {
 				logger.warn({
 					label: Label.DELUGE,
 					message: `Labeling failure: ${newTorrent.name} (${newTorrent.infoHash})`,


### PR DESCRIPTION
this PR adds a 10 second timeout for all Deluge calls, and also moves error handling for labeling from a global `catch` in `inject` into the `setLabel` method. 