### PR TITLE
add(config/excludeRecentSearch): disclaimer about failed searches

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -216,8 +216,8 @@ module.exports = {
 	excludeOlder: "2 weeks",
 
 	/**
-	 * Exclude torrents which have been searched
-	 * more recently than this long ago.
+	 * Exclude torrents which have been searched more recently than this long ago.
+	 * Doesn't exclude previously failed searches.
 	 * Examples:
 	 * "10min"
 	 * "2w"

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -223,8 +223,8 @@ module.exports = {
 	excludeOlder: "2 weeks",
 
 	/**
-	 * Exclude torrents which have been searched
-	 * more recently than this long ago.
+	 * Exclude torrents which have been searched more recently than this long ago.
+	 * Doesn't exclude previously failed searches.
 	 * Examples:
 	 * "10min"
 	 * "2w"


### PR DESCRIPTION
Minor edit to the config to make it clear that previously failed searches will not be excluded, and hence that the usage of excludeRecentSearch can also be used to search for previously failed searched.