### PR TITLE
feat(daemon/announce): daemon functionality without torznab defined

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -100,7 +100,7 @@ export const VALIDATION_SCHEMA = z
 		delay: z.number().nonnegative({
 			message: ZodErrorMessages.delay,
 		}),
-		torznab: z.array(z.string().url()).nullish(),
+		torznab: z.array(z.string().url()),
 		dataDirs: z
 			.array(
 				z

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -100,7 +100,7 @@ export const VALIDATION_SCHEMA = z
 		delay: z.number().nonnegative({
 			message: ZodErrorMessages.delay,
 		}),
-		torznab: z.array(z.string().url()),
+		torznab: z.array(z.string().url()).nullish(),
 		dataDirs: z
 			.array(
 				z

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -36,10 +36,12 @@ class Job {
 }
 
 function getJobs(): Job[] {
-	const { rssCadence, searchCadence } = getRuntimeConfig();
+	const { rssCadence, searchCadence, torznab } = getRuntimeConfig();
 	const jobs: Job[] = [];
-	if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
-	if (searchCadence) jobs.push(new Job("search", searchCadence, main));
+	if (torznab.length > 0) {
+		if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
+		if (searchCadence) jobs.push(new Job("search", searchCadence, main));
+	}
 	return jobs;
 }
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -437,7 +437,7 @@ export async function validateTorznabUrls() {
 	const indexersWithSearch = await getEnabledIndexers();
 
 	if (indexersWithSearch.length === 0) {
-		throw new CrossSeedError("no working indexers available");
+		logger.warn("no working indexers available");
 	}
 }
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -149,8 +149,10 @@ export async function queryRssFeeds(): Promise<Candidate[]> {
 export async function searchTorznab(
 	name: string
 ): Promise<{ indexerId: number; candidates: Candidate[] }[]> {
-	const { excludeRecentSearch, excludeOlder } = getRuntimeConfig();
-
+	const { excludeRecentSearch, excludeOlder, torznab } = getRuntimeConfig();
+	if (torznab.length === 0) {
+		throw new Error("no working indexers available");
+	}
 	const enabledIndexers = await getEnabledIndexers();
 
 	// search history for name across all indexers


### PR DESCRIPTION
I use autobrr to send announcements to cross-seed and do not need any indexers defined in the config as I don't use the search functionality. It would be nice if this warned the user instead of throwing an error.