### PR TITLE
ci(docker): add catatonit and tzdata to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN npm run build && \
 FROM node:20-alpine
 WORKDIR /usr/src/cross-seed
 COPY --from=build-stage /usr/src/cross-seed ./
-RUN apk add --no-cache curl && \
-    catatonit npm link tzdata
+RUN apk add --no-cache catatonit curl tzdata && \
+    npm link
 ENV CONFIG_DIR=/config
 ENV DOCKER_ENV=true
 EXPOSE 2468

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ FROM node:20-alpine
 WORKDIR /usr/src/cross-seed
 COPY --from=build-stage /usr/src/cross-seed ./
 RUN apk add --no-cache curl && \
-    npm link
+    catatonit npm link tzdata
 ENV CONFIG_DIR=/config
 ENV DOCKER_ENV=true
 EXPOSE 2468
 WORKDIR /config
-ENTRYPOINT ["cross-seed"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
+CMD ["/usr/local/bin/cross-seed"]

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --env-file=.env
 import chalk from "chalk";
 import { Option, program } from "commander";
 import { getApiKey, resetApiKey } from "./auth.js";

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --env-file=.env
+#!/usr/bin/env node
 import chalk from "chalk";
 import { Option, program } from "commander";
 import { getApiKey, resetApiKey } from "./auth.js";


### PR DESCRIPTION
Small change here, tzdata lets users set TZ env with their timezone and [catatonic](https://github.com/openSUSE/catatonit) is a tiny init manager which won't cause problems.