### PR TITLE
dep(env): change from native to dotenv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"better-sqlite3": "^9.4.0",
 				"chalk": "^5.0.0",
 				"commander": "^8.3.0",
+				"dotenv": "^16.4.5",
 				"fuse.js": "^6.6.2",
 				"knex": "^2.4.2",
 				"lodash-es": "^4.17.21",
@@ -947,6 +948,17 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.4.5",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+			"integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"better-sqlite3": "^9.4.0",
 		"chalk": "^5.0.0",
 		"commander": "^8.3.0",
+		"dotenv": "^16.4.5",
 		"fuse.js": "^6.6.2",
 		"knex": "^2.4.2",
 		"lodash-es": "^4.17.21",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "dotenv/config";
 import chalk from "chalk";
 import { Option, program } from "commander";
 import { getApiKey, resetApiKey } from "./auth.js";


### PR DESCRIPTION
Nodejs have changed the behaviour of --env-file https://github.com/nodejs/node/pull/50588 and this broke our app.

The .env should never be mandatory and environment variables can comes from outside of scope of the app on many ways. There is no reasons to stop the app because of missing this optional file.

Setting up the dotenv package, as it would not break the app when missing .env file.

