### PR TITLE
feat(regex): Improving anime matching

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -21,7 +21,7 @@ import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee } from "./searchee.js";
+import { Searchee, hasVideo } from "./searchee.js";
 import { saveTorrentFile } from "./torrent.js";
 import { getTag } from "./utils.js";
 
@@ -164,9 +164,10 @@ export async function performAction(
 	tracker: string
 ): Promise<ActionResult> {
 	const { action, linkDir } = getRuntimeConfig();
+	const isVideo = hasVideo(searchee);
 
 	if (action === Action.SAVE) {
-		await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
 		logger.info(
@@ -198,7 +199,7 @@ export async function performAction(
 				newMeta.name,
 				decision
 			);
-			await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
+			await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
 			return InjectionResult.FAILURE;
 		}
 	} else if (searchee.path) {
@@ -215,7 +216,7 @@ export async function performAction(
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
-		await saveTorrentFile(tracker, getTag(searchee.name), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
 	}
 	return result;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,13 +9,15 @@ export const TORRENT_TAG = "cross-seed";
 export const TORRENT_CATEGORY_SUFFIX = `.cross-seed`;
 
 export const EP_REGEX =
-	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s]?(?<episode>E\d+(?:[\s-]?E?\d+)?(?![ip]))(?!\d+[ip])|(?<date>(?<year>\d{4})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
+	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?<episode>(?:E|(?<=S\d+[_.\s-]{1,3}))\d+(?:[\s-]?E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const SEASON_REGEX =
-	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
+	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
-	/^(?<title>.+?)[_.\s][[(]?(?<year>\d{4})[)\]]?(?![pi])/i;
+	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:19|20)\d{2})[)\]]?(?![pix])/i;
+export const ANIME_REGEX =
+	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[\(\[~/|-]\s?(?!\d{4})(?<altTitle>.+?)[\)\]~-]?\s?)?[_.\s-]?(?:\(?(?<year>(?:19|20)\d{2})\)?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})(?:v\d)?[\])_.\s-]/i;
 export const RELEASE_GROUP_REGEX =
-	/(?<=-)(?<group>[\w ]+)(?:\))?(?=(?:\.\w{1,5})?$)/i;
+	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const EP_REGEX =
 export const SEASON_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
-	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:19|20)\d{2})[)\]]?(?![pix])/i;
+	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:18|19|20)\d{2})[)\]]?(?![pix])/i;
 export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[\(\[~/|-]\s?(?!\d{4})(?<altTitle>.+?)[\)\]~-]?\s?)?[_.\s-]?(?:\(?(?<year>(?:19|20)\d{2})\)?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})(?:v\d)?[\])_.\s-]/i;
 export const RELEASE_GROUP_REGEX =

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -89,8 +89,8 @@ async function findOnOtherSites(
 		.ignore();
 
 	let response: { indexerId: number; candidates: Candidate[] }[];
-	try {
-		response = await searchTorznab(searchee.name);
+	try {		
+		response = await searchTorznab(searchee);
 	} catch (e) {
 		logger.error(`error searching for ${searchee.name}`);
 		logger.debug(e);

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -1,5 +1,6 @@
 import { readdirSync, statSync } from "fs";
-import { basename, join, relative } from "path";
+import { basename, extname, join, relative } from "path";
+import { VIDEO_EXTENSIONS } from "./constants.js";
 import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
@@ -28,6 +29,12 @@ export function hasInfoHash(
 	searchee: Searchee
 ): searchee is SearcheeWithInfoHash {
 	return searchee.infoHash != null;
+}
+
+export function hasVideo(searchee: Searchee): boolean {
+	return searchee.files.some((file) =>
+		VIDEO_EXTENSIONS.includes(extname(file.name))
+	);
 }
 
 function getFileNamesFromRootRec(root: string, isDirHint?: boolean): string[] {

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -106,8 +106,9 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 	};
 }
 
-function createTorznabSearchQuery(name: string, caps: Caps, isVideo: boolean) {
-	const nameWithoutExtension = stripExtension(name);
+function createTorznabSearchQuery(searchee: Searchee, caps: Caps) {
+	const nameWithoutExtension = stripExtension(searchee.name);
+	const isVideo = hasVideo(searchee);
 	const extractNumber = (str: string): number =>
 		parseInt(str.match(/\d+/)![0]);
 	const mediaType = getTag(nameWithoutExtension, isVideo);
@@ -140,7 +141,6 @@ function createTorznabSearchQuery(name: string, caps: Caps, isVideo: boolean) {
 
 export async function queryRssFeeds(): Promise<Candidate[]> {
 	const candidatesByUrl = await makeRequests(
-		"",
 		await getEnabledIndexers(),
 		() => ({ t: "search", q: "" })
 	);
@@ -194,12 +194,12 @@ export async function searchTorznab(
 		}`,
 	});
 
-	return makeRequests(name, indexersToUse, (indexer) =>
-		createTorznabSearchQuery(name, {
+	return makeRequests(indexersToUse, (indexer) =>
+		createTorznabSearchQuery(searchee, {
 			search: indexer.searchCap,
 			tvSearch: indexer.tvSearchCap,
 			movieSearch: indexer.movieSearchCap,
-		}, hasVideo(searchee))
+		})
 	);
 }
 
@@ -447,7 +447,6 @@ export async function validateTorznabUrls() {
 }
 
 async function makeRequests(
-	name: string,
 	indexers: Indexer[],
 	getQuery: (indexer: Indexer) => TorznabParams
 ): Promise<{ indexerId: number; candidates: Candidate[] }[]> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export function wait(n: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, n));
 }
 
-export function getTag(name: string, isVideo?: boolean): MediaType {
+export function getTag(name: string, isVideo: boolean): MediaType {
 	return EP_REGEX.test(name)
 		? MediaType.EPISODE
 		: SEASON_REGEX.test(name)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,18 +68,22 @@ export function cleanseSeparators(str: string): string {
 		.trim();
 }
 
+function getAnimeQuery(name: string, isVideo: boolean | undefined): string | null {
+	// Must be done after episode, season, and movie regex to be accurate
+	if (!isVideo) return null;
+	const { title, altTitle, release } = name.match(ANIME_REGEX)?.groups ?? {};
+	if (title) {
+		const animeQuery = altTitle && altTitle.length ? Math.random() > 0.5 ? title : altTitle : title;
+		return `${animeQuery} ${release}`;
+	}
+	return null;
+}
+
 export function reformatTitleForSearching(name: string, isVideo?: boolean): string {
 	const seasonMatch = name.match(SEASON_REGEX);
 	const movieMatch = name.match(MOVIE_REGEX);
 	const episodeMatch = name.match(EP_REGEX);
-	let animeQuery: string | undefined = undefined;
-	if (isVideo) {
-		const { title, altTitle, release } = name.match(ANIME_REGEX)?.groups ?? {};
-		if (title) {
-			animeQuery = altTitle && altTitle.length ? Math.random() > 0.5 ? title : altTitle : title;
-			animeQuery += ` ${release}`;
-		}
-	}
+	const animeQuery = getAnimeQuery(name, isVideo);
 	const fullMatch =
 		episodeMatch?.[0] ?? seasonMatch?.[0] ?? movieMatch?.[0] ?? animeQuery ?? name;
 	return cleanseSeparators(fullMatch);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,24 +68,25 @@ export function cleanseSeparators(str: string): string {
 		.trim();
 }
 
-function getAnimeQuery(name: string, isVideo: boolean | undefined): string | null {
-	// Must be done after episode, season, and movie regex to be accurate
-	if (!isVideo) return null;
+export function getAnimeQueries(name: string): string[] {
+	// Only use if getTag returns anime as it's conditional on a few factors
+	let animeQueries: string[] = [];
 	const { title, altTitle, release } = name.match(ANIME_REGEX)?.groups ?? {};
 	if (title) {
-		const animeQuery = altTitle && altTitle.length ? Math.random() > 0.5 ? title : altTitle : title;
-		return `${animeQuery} ${release}`;
+		animeQueries.push(cleanseSeparators(`${title} ${release}`));
 	}
-	return null;
+	if (altTitle) {
+		animeQueries.push(cleanseSeparators(`${altTitle} ${release}`));
+	}
+	return animeQueries;
 }
 
-export function reformatTitleForSearching(name: string, isVideo?: boolean): string {
+export function reformatTitleForSearching(name: string): string {
 	const seasonMatch = name.match(SEASON_REGEX);
 	const movieMatch = name.match(MOVIE_REGEX);
 	const episodeMatch = name.match(EP_REGEX);
-	const animeQuery = getAnimeQuery(name, isVideo);
 	const fullMatch =
-		episodeMatch?.[0] ?? seasonMatch?.[0] ?? movieMatch?.[0] ?? animeQuery ?? name;
+		episodeMatch?.[0] ?? seasonMatch?.[0] ?? movieMatch?.[0] ?? name;
 	return cleanseSeparators(fullMatch);
 }
 


### PR DESCRIPTION
Implements: #631

To summarize, this feature has zero effect on anything non-anime and correctly parses the vast majority.

---

Did a lot of digging into anime and the best way to match correctly. My goal for this PR is to do it right from the start, it should not be possible to make a meaningfully better regex for anime. I avoided covering edge cases but there is like 5 common formats used and more information to track like [tags] and altTitle, so the regex ended up being long anyways.

I got ~35,000 unique titles from nyaa dating back to 2019 in both English and non-English translated anime. Ran these data progressively through the regex in order (ep, season, movie, anime) noting any improvements that can be made to the existing regex. Each time I would remove what matched to simulate what could reach the next regex.

Due to the nature of anime titles, the regex will get false positives with pretty much anything. However since it will only be used after the other regex fails, it will have zero effect on movies, seasons, and episode matches. It would still match books and music though (which I know is not officially supported). So I opted to add another test in code, to check if the searchee contains at least one video file. Since movies, seasons, and episodes would have already matched, this guarantees whatever remains is an anime. This limits the regex to only being used when searching and tagging saveTorrentFile, but the only other use case is for a db lookup fast path so doesn't really matter.

---

Modifications to existing functionality:
1. Years are only allowed to be between 1800-2099 to reduce false positives (Let's set a reminder to update in 2100)
2. Using trailing [pix] instead of [pi] to detect resolution for cases like 1920x1080 (Didn't update for release group regex)
3. Movie titles can't end with trailing -
4. SEASON_REGEX now supports ~ between season and seasonmax. https://regex101.com/r/eLspOa/2
5. Updated release group regex to one discussed in #629 with added restriction of not all numbers. Lots of anime titles end with ` - ep` or ` - ep.mkv`.
6. Cleansing square brackets (and Japanese brackets) along with separators as they don't contain useful information in the title
7. EP_REGEX supports the common anime format `SXX - E?YY` where the E is optional when SXX is present. The problem is that SEASON_REGEX picks this up where SXX is season and YY is seasonmax when E is missing. Causing a huge number of anime episode matches to be reported as seasons. Out of all the unique anime titles tested, ~10% had this issue. Considering the standard for multi season releases is `SXX-SYY`, sonarr only allows single season releases and most? private trackers ban multi-season releases, I think we should assume anime style over multi season pack in this ambiguous case. https://regex101.com/r/i0igR5/5

Additions:
1. ANIME_REGEX to create queries in format `title episode` parsed from common anime release formatting. The regex is quite long as there a many parts that could be present and need to be handled. I limited the use of * and + to just group, title, and altTitle and used {} to bound the length else where. Most releases contain a [group] tag at the start which often gets renamed to -group at the end on some trackers. Releases will also often contain both the English and Japanese title which either one could be used on other trackers. This is stored into altTitle and is randomly chosen from when deciding to search (either can be English or Japanese). Unless we want to make two simultaneous searches or store the last title used in the db, this is the best compromise.  https://regex101.com/r/F9uPn0/14
2. Only applying anime regex if at least one file is a video. This guarantees the regex won't match music or books. So the anime regex can only be used when searchee is present, which limits it to search queries and tagging .torrents in outputDir (Other use case was querying database which wouldn't change anything).

Shortcomings:
1. Existing regex don't handle alternate titles which helps a lot with anime though I didn't want to change them too much
2. Some anime series release have years which gets match as movies. Nothing can be done but it gets a decent query.
3. Anime can't be matched in safe mode since the release group is at the start and the group regex doesn't look for it (nor should it). Risky would be needed anyways considering how often anime gets renamed between trackers.
