### PR TITLE
feat(logging): mismatch decisions note searchee-candidate differences

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -316,9 +316,8 @@ function makeDecisionNote(
 	switch (decision) {
 		case Decision.SIZE_MISMATCH:
 			return ` - (${humanReadableSize(
-				searchee.length,
-				2
-			)} -> ${humanReadableSize(candidate.size, 2)})`;
+				searchee.length
+			)} -> ${humanReadableSize(candidate.size)})`;
 		case Decision.RELEASE_GROUP_MISMATCH:
 			return ` - (${searchee.name
 				.match(RELEASE_GROUP_REGEX)?.[0]

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -11,7 +11,7 @@ import { db } from "./db.js";
 import { Label, logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Candidate } from "./pipeline.js";
-import { releaseInBlockList } from "./preFilter.js";
+import { findBlockedStringInReleaseMaybe } from "./preFilter.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 import {
@@ -77,7 +77,7 @@ const createReasonLogger =
 					?.trim()})`;
 				break;
 			case Decision.BLOCKED_RELEASE:
-				reason = `it matches the blocklist - ("${releaseInBlockList(
+				reason = `it matches the blocklist - ("${findBlockedStringInReleaseMaybe(
 					searchee,
 					getRuntimeConfig().blockList
 				)}")`;
@@ -199,7 +199,7 @@ async function assessCandidateHelper(
 	hashesToExclude: string[],
 ): Promise<ResultAssessment> {
 	const { matchMode, blockList } = getRuntimeConfig();
-	if (releaseInBlockList(searchee, blockList)) {
+	if (findBlockedStringInReleaseMaybe(searchee, blockList)) {
 		return { decision: Decision.BLOCKED_RELEASE };
 	}
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -1,6 +1,6 @@
 import { db } from "./db.js";
 import { Label, logger } from "./logger.js";
-import { humanReadable } from "./utils.js";
+import { humanReadableDate } from "./utils.js";
 
 export enum IndexerStatus {
 	/**
@@ -56,7 +56,7 @@ export async function updateIndexerStatus(
 	if (indexerIds.length > 0) {
 		logger.verbose({
 			label: Label.TORZNAB,
-			message: `Snoozing indexers ${indexerIds} with ${status} until ${humanReadable(
+			message: `Snoozing indexers ${indexerIds} with ${status} until ${humanReadableDate(
 				retryAfter,
 			)}`,
 		});

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -65,12 +65,12 @@ export function filterByContent(searchee: Searchee): boolean {
 export function releaseInBlockList(
 	searchee: Searchee,
 	blockList: string[],
-): boolean {
+): string | boolean {
 	return blockList.some((blockedStr) => {
-		return (
-			searchee.name.includes(blockedStr) ||
+		return searchee.name.includes(blockedStr) ||
 			blockedStr === searchee.infoHash
-		);
+			? blockedStr
+			: false;
 	});
 }
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -23,7 +23,7 @@ export function filterByContent(searchee: Searchee): boolean {
 			message: `Torrent ${searchee.name} was not selected for searching because ${reason}`,
 		});
 	}
-	const blockedNote = releaseInBlockList(searchee, blockList);
+	const blockedNote = findBlockedStringInReleaseMaybe(searchee, blockList);
 	if (blockedNote) {
 		logReason(`it matched the blocklist - ("${blockedNote}")`);
 		return false;
@@ -62,7 +62,7 @@ export function filterByContent(searchee: Searchee): boolean {
 	return true;
 }
 
-export function releaseInBlockList(
+export function findBlockedStringInReleaseMaybe(
 	searchee: Searchee,
 	blockList: string[],
 ): string | undefined {

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -23,9 +23,9 @@ export function filterByContent(searchee: Searchee): boolean {
 			message: `Torrent ${searchee.name} was not selected for searching because ${reason}`,
 		});
 	}
-
-	if (releaseInBlockList(searchee, blockList)) {
-		logReason("it matched the blocklist");
+	const blockedNote = releaseInBlockList(searchee, blockList);
+	if (blockedNote) {
+		logReason(`it matched the blocklist - ("${blockedNote}")`);
 		return false;
 	}
 
@@ -65,12 +65,12 @@ export function filterByContent(searchee: Searchee): boolean {
 export function releaseInBlockList(
 	searchee: Searchee,
 	blockList: string[],
-): string | boolean {
-	return blockList.some((blockedStr) => {
-		return searchee.name.includes(blockedStr) ||
+): string | undefined {
+	return blockList.find((blockedStr) => {
+		return (
+			searchee.name.includes(blockedStr) ||
 			blockedStr === searchee.infoHash
-			? blockedStr
-			: false;
+		);
 	});
 }
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -6,7 +6,7 @@ import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
-import { humanReadable, nMsAgo } from "./utils.js";
+import { humanReadableDate, nMsAgo } from "./utils.js";
 import path from "path";
 
 export function filterByContent(searchee: Searchee): boolean {
@@ -140,7 +140,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		first_searched_any < nMsAgo(excludeOlder)
 	) {
 		logReason(
-			`its first search timestamp ${humanReadable(
+			`its first search timestamp ${humanReadableDate(
 				first_searched_any,
 			)} is older than ${ms(excludeOlder, { long: true })} ago`,
 		);
@@ -153,7 +153,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		last_searched_all > nMsAgo(excludeRecentSearch)
 	) {
 		logReason(
-			`its last search timestamp ${humanReadable(
+			`its last search timestamp ${humanReadableDate(
 				last_searched_all,
 			)} is newer than ${ms(excludeRecentSearch, { long: true })} ago`,
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function wait(n: number): Promise<void> {
 }
 export function humanReadableSize(
 	bytes: number,
-	dm: number,
+	dm: number = 2,
 	ibi: boolean = false
 ) {
 	const k = ibi ? 1024 : 1000;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,19 +38,13 @@ export function nMsAgo(n: number): number {
 export function wait(n: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, n));
 }
-export function humanReadableSize(
-	bytes: number,
-	dm: number = 2,
-	ibi: boolean = false
-) {
-	const k = ibi ? 1024 : 1000;
-	const sizes = ibi
-		? ["B", "kiB", "MiB", "GiB", "TiB"]
-		: ["B", "kB", "MB", "GB", "TB"];
-
-	const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+export function humanReadableSize(bytes: number) {
+	const k = 1000;
+	const sizes = ["B", "kB", "MB", "GB", "TB"];
+	// engineering notation: (coefficient) * 1000 ^ (exponent)
+	const exponent = Math.floor(Math.log(bytes) / Math.log(k));
+	const coefficient = bytes / Math.pow(k, exponent);
+	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
 export function getTag(name: string, isVideo: boolean): MediaType {
 	return EP_REGEX.test(name)
@@ -114,7 +108,7 @@ export async function filterAsync(arr, predicate) {
 	return arr.filter((_, index) => results[index]);
 }
 
-export function humanReadable(timestamp: number): string {
+export function humanReadableDate(timestamp: number): string {
 	// swedish conventions roughly follow the iso format!
 	return new Date(timestamp).toLocaleString("sv");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,20 @@ export function nMsAgo(n: number): number {
 export function wait(n: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, n));
 }
+export function humanReadableSize(
+	bytes: number,
+	dm: number,
+	ibi: boolean = false
+) {
+	const k = ibi ? 1024 : 1000;
+	const sizes = ibi
+		? ["B", "kiB", "MiB", "GiB", "TiB"]
+		: ["B", "kB", "MB", "GB", "TB"];
 
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}
 export function getTag(name: string, isVideo: boolean): MediaType {
 	return EP_REGEX.test(name)
 		? MediaType.EPISODE


### PR DESCRIPTION
closes #578 

this adds verbose logging for the local size and candidate cross-seed size and release group mismatches appended to the `[decide]` line as well as the matching string for blockList when a release is blocked

formatting appended to reason: `(<local> -> <candidate>)`

ex: `2024-04-18 02:34:54 verbose: [decide] Show.S01.1080p.BluRay.x264-GRP- no match for tracker torrent  Show.S01.1080p.BluRay.Remux.DTS-HD.MA5.1.H.264-GRP - its size does not match - (42.6GB -> 103.8GB)`