### PR TITLE
update(duplicateCategories): ignores appending cross-seed to dataCategory

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -279,7 +279,7 @@ export default class Deluge implements TorrentClient {
 						? duplicateCategories
 							? torrentInfo!.label.endsWith(
 									this.delugeLabelSuffix
-							  )
+							  ) || torrentInfo!.label === dataCategory
 								? torrentInfo!.label
 								: `${torrentInfo!.label}${
 										this.delugeLabelSuffix

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -165,8 +165,12 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	async setUpCrossSeedCategory(ogCategoryName: string): Promise<string> {
+		const { dataCategory } = getRuntimeConfig();
 		if (!ogCategoryName) return "";
-		if (ogCategoryName.endsWith(TORRENT_CATEGORY_SUFFIX))
+		if (
+			ogCategoryName.endsWith(TORRENT_CATEGORY_SUFFIX) ||
+			ogCategoryName === dataCategory
+		)
 			return ogCategoryName;
 
 		const categoriesStr = await this.request("/torrents/categories", "");


### PR DESCRIPTION
closes #602 

initially had a misunderstanding of the issue...going over some of the older addressable issues I now understand what was said

this addresses #602 by ignoring `dataCategory` when assessing whether to `duplicateCategories` or not

the assumption is, `dataCategory` will never interfere with an import category for an "arr"