### PR TITLE
fix(client/qbittorrent): missing message property in error.includes

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -232,11 +232,11 @@ export default class QBittorrent implements TorrentClient {
 	): Promise<
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
-		let torrentInfo: TorrentConfiguration;
+		let torrentInfo: TorrentConfiguration | undefined;
 		try {
 			if (await this.isInfoHashInClient(searchee.infoHash!)) {
 				torrentInfo = await this.getTorrentConfiguration(searchee);
-				if (torrentInfo.save_path === undefined) {
+				if (torrentInfo?.save_path === undefined) {
 					return resultOfErr("NOT_FOUND");
 				}
 			}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -241,7 +241,7 @@ export default class QBittorrent implements TorrentClient {
 				}
 			}
 		} catch (e) {
-			if (e.includes("retrieve")) {
+			if (e.message.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
 			return resultOfErr("UNKNOWN_ERROR");


### PR DESCRIPTION
This was called from a feature I'm testing

`2024-04-19 22:01:29 error: TypeError: e.includes is not a function`

This was caused when getting the downloadDir for all searchees without a .path. The error happens when the torrent is not in the client. It could also be that infoHash wasn't defined as I was checking for that.