### PR TITLE
fix(client/qbittorrent): missing message property in error.includes

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -241,7 +241,7 @@ export default class QBittorrent implements TorrentClient {
 				}
 			}
 		} catch (e) {
-			if (e.includes("retrieve")) {
+			if (e.message.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
 			return resultOfErr("UNKNOWN_ERROR");


### PR DESCRIPTION
This was called from a feature I'm testing

`2024-04-19 22:01:29 error: TypeError: e.includes is not a function`

This was caused when getting the downloadDir for all searchees without a .path.

It successfully finds the info hash in client via `isInfoHashInClient` but fails when getting torrentInfo from `getTorrentConfiguration`. The root cause seems to be the /torrents/info from getTorrentConfiguration sometimes failing:

`error: TypeError: fetch failed
at node:internal/deps/undici/undici:12618:11
at async QBittorrent.request (file:///usr/src/cross-seed/dist/clients/QBittorrent.js:47:26)
at async QBittorrent.getTorrentConfiguration (file:///usr/src/cross-seed/dist/clients/QBittorrent.js:122:30)
at async QBittorrent.getDownloadDir (file:///usr/src/cross-seed/dist/clients/QBittorrent.js:105:23)
at async findSearchableTorrents (file:///usr/src/cross-seed/dist/pipeline.js:178:39)
at async Job.main [as exec] (file:///usr/src/cross-seed/dist/pipeline.js:202:42)
at async Job.run (file:///usr/src/cross-seed/dist/jobs.js:26:17)`

Qbit requests failing is nothing new even in v5 so I think .includes just needs to be updated to be on e.message.
