### PR TITLE
fix(client/qbittorrent): unhandled branch causing undefined property access

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -234,11 +234,9 @@ export default class QBittorrent implements TorrentClient {
 	> {
 		let torrentInfo: TorrentConfiguration;
 		try {
-			if (await this.isInfoHashInClient(searchee.infoHash!)) {
-				torrentInfo = await this.getTorrentConfiguration(searchee);
-				if (torrentInfo.save_path === undefined) {
-					return resultOfErr("NOT_FOUND");
-				}
+			torrentInfo = await this.getTorrentConfiguration(searchee);
+			if (torrentInfo.save_path === undefined) {
+				return resultOfErr("NOT_FOUND");
 			}
 		} catch (e) {
 			if (e.message.includes("retrieve")) {


### PR DESCRIPTION
The problem stems from the fact that we are using infoHash in searchee. If the torrent in qbit is using infoHashv2, then it won't return any results.

Calling `isInfoHashInClient` was redundant as it was handled in `getTorrentConfiguration`. This reduces the api calls to qbit and handles the case of missing infoHash.