### PR TITLE
feat(torznab/indexer): filter out indexers without mediatype category

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -21,7 +21,7 @@ import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee, hasVideo } from "./searchee.js";
+import { Searchee } from "./searchee.js";
 import { saveTorrentFile } from "./torrent.js";
 import { getTag } from "./utils.js";
 
@@ -171,10 +171,9 @@ export async function performAction(
 	tracker: string,
 ): Promise<ActionResult> {
 	const { action, linkDir } = getRuntimeConfig();
-	const isVideo = hasVideo(searchee);
 
 	if (action === Action.SAVE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
 		logger.info(
@@ -206,11 +205,7 @@ export async function performAction(
 				newMeta.name,
 				decision,
 			);
-			await saveTorrentFile(
-				tracker,
-				getTag(searchee.name, isVideo),
-				newMeta,
-			);
+			await saveTorrentFile(tracker, getTag(searchee), newMeta);
 			return InjectionResult.FAILURE;
 		}
 	} else if (searchee.path) {
@@ -227,7 +222,7 @@ export async function performAction(
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee), newMeta);
 	}
 	return result;
 }

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -7,10 +7,9 @@ import {
 	getTag,
 	MediaType,
 	sanitizeUrl,
-	stripExtension,
 } from "./utils.js";
 import chalk from "chalk";
-import { hasVideo, Searchee } from "./searchee.js";
+import { Searchee } from "./searchee.js";
 import { Caps, IdSearchParams, TorznabParams } from "./torznab.js";
 
 const keyNames = ["tvdbId", "imdbId", "tmdbId"];
@@ -160,8 +159,7 @@ export async function getRelevantArrIds(
 	ids,
 	caps: Caps,
 ): Promise<IdSearchParams> {
-	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(searchee);
 	const idSearchCaps =
 		mediaType === MediaType.EPISODE || mediaType === MediaType.SEASON
 			? caps.tvIdSearch
@@ -178,8 +176,7 @@ export async function getRelevantArrIds(
 export async function getAvailableArrIds(
 	searchee: Searchee,
 ): Promise<IdSearchParams> {
-	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(searchee);
 	try {
 		const arrIdData = (
 			await grabArrId(searchee.name, mediaType)

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -26,9 +26,10 @@ export interface Indexer {
 	movieSearchCap: boolean;
 	tvIdCaps: string;
 	movieIdCaps: string;
+	categories: string;
 }
 
-export async function getEnabledIndexers() {
+export async function getEnabledIndexers(): Promise<Indexer[]> {
 	return db("indexer")
 		.where({ active: true, search_cap: true, status: null })
 		.orWhere({ active: true, search_cap: true, status: IndexerStatus.OK })

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -49,6 +49,7 @@ export async function getEnabledIndexers() {
 			movieSearchCap: "movie_search_cap",
 			tvIdCaps: "tv_id_caps",
 			movieIdCaps: "movie_id_caps",
+			categories: "cat_caps",
 		});
 }
 

--- a/src/migrations/05-caps.ts
+++ b/src/migrations/05-caps.ts
@@ -4,6 +4,7 @@ async function up(knex: Knex.Knex): Promise<void> {
 	await knex.schema.alterTable("indexer", (table) => {
 		table.json("tv_id_caps");
 		table.json("movie_id_caps");
+		table.json("cat_caps");
 	});
 }
 
@@ -11,6 +12,7 @@ async function down(knex: Knex.Knex): Promise<void> {
 	return knex.schema.table("indexer", function (table) {
 		table.dropColumn("tv_id_caps");
 		table.dropColumn("movie_id_caps");
+		table.json("cat_caps");
 	});
 }
-export default { name: "05-idcaps", up, down };
+export default { name: "05-caps", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -3,7 +3,7 @@ import jobs from "./01-jobs.js";
 import timestamps from "./02-timestamps.js";
 import rateLimits from "./03-rateLimits.js";
 import auth from "./04-auth.js";
-import idcaps from "./05-idcaps.js";
+import caps from "./05-caps.js";
 
 export const migrations = {
 	getMigrations: () =>
@@ -13,7 +13,7 @@ export const migrations = {
 			timestamps,
 			rateLimits,
 			auth,
-			idcaps,
+			caps,
 		]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -13,7 +13,7 @@ import {
 import { Label, logger } from "./logger.js";
 import { Candidate } from "./pipeline.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee, hasVideo } from "./searchee.js";
+import { Searchee } from "./searchee.js";
 import {
 	getAnimeQueries,
 	assembleUrl,
@@ -167,7 +167,7 @@ async function createTorznabSearchQueries(
 	const extractNumber = (str: string): number =>
 		parseInt(str.match(/\d+/)![0]);
 	const relevantIds = await getRelevantArrIds(searchee, ids, caps);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(searchee);
 	if (
 		mediaType === MediaType.EPISODE &&
 		caps.tvSearch &&
@@ -296,7 +296,7 @@ export async function searchTorznab(
 				(!excludeRecentSearch ||
 					entry.lastSearched < nMsAgo(excludeRecentSearch)) &&
 				shouldSearchIndexer(
-					getTag(searchee.name, hasVideo(searchee)),
+					getTag(searchee),
 					JSON.parse(indexer.categories),
 				))
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { IdSearchParams, TorznabParams } from "./torznab.js";
+import { hasVideo, Searchee } from "./searchee.js";
 
 export enum MediaType {
 	EPISODE = "episode",
@@ -47,14 +48,15 @@ export function humanReadableSize(bytes: number) {
 	const coefficient = bytes / Math.pow(k, exponent);
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
-export function getTag(name: string, isVideo: boolean): MediaType {
-	return EP_REGEX.test(name)
+export function getTag(searchee: Searchee): MediaType {
+	const nameWithoutExtension = stripExtension(searchee.name);
+	return EP_REGEX.test(nameWithoutExtension)
 		? MediaType.EPISODE
-		: SEASON_REGEX.test(name)
+		: SEASON_REGEX.test(nameWithoutExtension)
 			? MediaType.SEASON
-			: MOVIE_REGEX.test(name)
+			: MOVIE_REGEX.test(nameWithoutExtension)
 				? MediaType.MOVIE
-				: isVideo && ANIME_REGEX.test(name)
+				: hasVideo(searchee) && ANIME_REGEX.test(nameWithoutExtension)
 					? MediaType.ANIME
 					: MediaType.OTHER;
 }


### PR DESCRIPTION
filters out indexers per search who dont have the media type being searched for, the result ends up requiring dual messaging for timestamp and category filtering. I'm not sure if this matters, i just merged the message.

currently based off id-search branch, so targeting that for now.