### PR TITLE
feat(clear-indexer): adds cli argument for clearing indexer stats

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -301,6 +301,14 @@ program
 	.command("clear-indexer-failures")
 	.description("Clear the cached details of indexers (failures and caps)")
 	.action(async () => {
+		console.log(
+			"\nIf you've received a '429' (rate-limiting), continuing to hammer",
+			"your indexers may result in negative consequences.",
+		);
+		console.log(
+			"If you have to do this more than once in a short",
+			"period of time, you have bigger issue that need to be addressed.",
+		);
 		await db("indexer").update({
 			active: true,
 			status: null,

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -297,7 +297,20 @@ program
 		});
 		await db.destroy();
 	});
-
+program
+	.command("clear-indexer-failures")
+	.description("Clear the cached details of indexers (failures and caps)")
+	.action(async () => {
+		await db("indexer").update({
+			active: true,
+			status: null,
+			retry_after: null,
+			search_cap: null,
+			tv_search_cap: null,
+			movie_search_cap: null,
+		});
+		await db.destroy();
+	});
 program
 	.command("test-notification")
 	.description("Send a test notification")

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -307,7 +307,7 @@ program
 		);
 		console.log(
 			"If you have to do this more than once in a short",
-			"period of time, you have bigger issue that need to be addressed.",
+			"period of time, you have bigger issues that need to be addressed.",
 		);
 		await db("indexer").update({
 			status: null,

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -302,7 +302,7 @@ program
 	.description("Clear the cached details of indexers (failures and caps)")
 	.action(async () => {
 		console.log(
-			"\nIf you've received a '429' (rate-limiting), continuing to hammer",
+			"If you've received a '429' (rate-limiting), continuing to hammer",
 			"your indexers may result in negative consequences.",
 		);
 		console.log(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -310,12 +310,8 @@ program
 			"period of time, you have bigger issue that need to be addressed.",
 		);
 		await db("indexer").update({
-			active: true,
 			status: null,
 			retry_after: null,
-			search_cap: null,
-			tv_search_cap: null,
-			movie_search_cap: null,
 		});
 		await db.destroy();
 	});


### PR DESCRIPTION
this clears all values in the indexer table relevant to enabling the indexer.

i don't think we should advertise this command in docs, but i think it would benefit support when a user doesn't have to clear their entire db to get around a rate limiting from torznab that would otherwise last 24hours but was really only necessary to back-off for an hour.

has happened enough times that i wish it was available for support.