### PR TITLE
fix(qbit/injection): correctly assign categories and autotmm

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -296,7 +296,7 @@ export default class QBittorrent implements TorrentClient {
 			| Decision.MATCH_PARTIAL,
 		path?: string,
 	): Promise<InjectionResult> {
-		const { duplicateCategories, skipRecheck, dataCategory } =
+		const { duplicateCategories, skipRecheck, dataCategory, linkDir } =
 			getRuntimeConfig();
 		try {
 			if (await this.isInfoHashInClient(newTorrent.infoHash)) {
@@ -338,10 +338,8 @@ export default class QBittorrent implements TorrentClient {
 			formData.append("tags", TORRENT_TAG);
 			formData.append("category", newCategoryName);
 
-			if (autoTMM) {
-				formData.append("autoTMM", "true");
-			} else {
-				formData.append("autoTMM", "false");
+			formData.append("autoTMM", linkDir ? "false" : autoTMM);
+			if (linkDir) {
 				formData.append("savepath", save_path);
 			}
 			if (path) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -307,21 +307,24 @@ export default class QBittorrent implements TorrentClient {
 			const buffer = new Blob([newTorrent.encode()], {
 				type: "application/x-bittorrent",
 			});
-			const { save_path, isComplete, autoTMM, category } = path
-				? {
-						save_path: path,
-						isComplete: true,
-						autoTMM: false,
-						category: dataCategory,
-					}
-				: await this.getTorrentConfiguration(searchee);
+			const qbitParams = {
+				save_path: path,
+				isComplete: true,
+				autoTMM: false,
+				category:
+					linkDir || searchee.infoHash
+						? (await this.getTorrentConfiguration(searchee))
+								.category
+						: dataCategory,
+			};
 
 			const newCategoryName =
 				duplicateCategories && searchee.infoHash
-					? await this.setUpCrossSeedCategory(category)
-					: category;
+					? await this.setUpCrossSeedCategory(qbitParams.category)
+					: qbitParams.category;
 
-			if (!isComplete) return InjectionResult.TORRENT_NOT_COMPLETE;
+			if (!qbitParams.isComplete)
+				return InjectionResult.TORRENT_NOT_COMPLETE;
 
 			const contentLayout =
 				!path &&
@@ -338,9 +341,9 @@ export default class QBittorrent implements TorrentClient {
 			formData.append("tags", TORRENT_TAG);
 			formData.append("category", newCategoryName);
 
-			formData.append("autoTMM", linkDir ? "false" : autoTMM);
+			formData.append("autoTMM", linkDir ? "false" : qbitParams.autoTMM);
 			if (linkDir) {
-				formData.append("savepath", save_path);
+				formData.append("savepath", qbitParams.save_path);
 			}
 			if (path) {
 				formData.append("contentLayout", "Original");

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -342,7 +342,7 @@ export default class QBittorrent implements TorrentClient {
 			formData.append("category", newCategoryName);
 
 			formData.append("autoTMM", linkDir ? "false" : qbitParams.autoTMM);
-			if (linkDir) {
+			if (linkDir || !qbitParams.autoTMM) {
 				formData.append("savepath", qbitParams.save_path);
 			}
 			if (path) {

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -142,8 +142,7 @@ module.exports = {
 
 	/**
 	 * Enabling this will link files using v5's flat folder style. This option
-	 * is necessary if you prefer flat folders of files or use qBittorrent and
-	 * Automatic Torrent Management.
+	 * is necessary if you prefer flat folders of files.
 	 *
 	 * Otherwise each individual Torznab tracker's cross-seeds will have it's
 	 * own folder with the tracker's name and it's links within it.


### PR DESCRIPTION
After the update to the linking, there's now an issue with the logic used in qbittorrent inject() function which leaves dataCategory being assigned for all torrents if linking is enabled.

This addresses that, and fixes autotmm assignment as well.

After this is merged, both `legacyLinking` as true and false will operate with qbit as we intend, and even if qbitmanage is set `force_auto_tmm: true` and forces `autotmm` on - it won't change the path unless the category or savepath is changed (this could be done by cat_change in qbitmanage and needs to be addressed in qbitmanage. there is nothing more we can do from our side)

- [x] test changing cat with autotmm disabled after injection 
- [ ] see if @StuffAnThings can do `cat_change` operations before enabling `autotmm` via `force_autotmm` for torrents that have a save_path in `linkDir` by having `linkDir` path provided in qbm yaml config