### PR TITLE
feat(torznab/indexer): filter out indexers without audio and book category

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -173,7 +173,7 @@ export async function performAction(
 	const { action, linkDir } = getRuntimeConfig();
 
 	if (action === Action.SAVE) {
-		await saveTorrentFile(tracker, getTag(searchee, searchee), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
 		logger.info(
@@ -207,7 +207,7 @@ export async function performAction(
 			);
 			await saveTorrentFile(
 				tracker,
-				getTag(searchee, searchee),
+				getTag(searchee),
 				newMeta,
 			);
 			return InjectionResult.FAILURE;
@@ -226,7 +226,7 @@ export async function performAction(
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
-		await saveTorrentFile(tracker, getTag(searchee, searchee), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee), newMeta);
 	}
 	return result;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -173,7 +173,7 @@ export async function performAction(
 	const { action, linkDir } = getRuntimeConfig();
 
 	if (action === Action.SAVE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, searchee), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee, searchee), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
 		logger.info(
@@ -207,7 +207,7 @@ export async function performAction(
 			);
 			await saveTorrentFile(
 				tracker,
-				getTag(searchee.name, searchee),
+				getTag(searchee, searchee),
 				newMeta,
 			);
 			return InjectionResult.FAILURE;
@@ -226,7 +226,7 @@ export async function performAction(
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, searchee), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee, searchee), newMeta);
 	}
 	return result;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -171,10 +171,9 @@ export async function performAction(
 	tracker: string,
 ): Promise<ActionResult> {
 	const { action, linkDir } = getRuntimeConfig();
-	const isVideo = hasVideo(searchee);
 
 	if (action === Action.SAVE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee.name, searchee), newMeta);
 		const styledName = chalk.green.bold(newMeta.name);
 		const styledTracker = chalk.bold(tracker);
 		logger.info(
@@ -208,7 +207,7 @@ export async function performAction(
 			);
 			await saveTorrentFile(
 				tracker,
-				getTag(searchee.name, isVideo),
+				getTag(searchee.name, searchee),
 				newMeta,
 			);
 			return InjectionResult.FAILURE;
@@ -227,7 +226,7 @@ export async function performAction(
 
 	logInjectionResult(result, tracker, newMeta.name, decision);
 	if (result === InjectionResult.FAILURE) {
-		await saveTorrentFile(tracker, getTag(searchee.name, isVideo), newMeta);
+		await saveTorrentFile(tracker, getTag(searchee.name, searchee), newMeta);
 	}
 	return result;
 }

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -161,7 +161,7 @@ export async function getRelevantArrIds(
 	caps: Caps,
 ): Promise<IdSearchParams> {
 	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(nameWithoutExtension, searchee);
 	const idSearchCaps =
 		mediaType === MediaType.EPISODE || mediaType === MediaType.SEASON
 			? caps.tvIdSearch
@@ -179,7 +179,7 @@ export async function getAvailableArrIds(
 	searchee: Searchee,
 ): Promise<IdSearchParams> {
 	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(nameWithoutExtension, searchee);
 	try {
 		const arrIdData = (
 			await grabArrId(searchee.name, mediaType)

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -161,7 +161,7 @@ export async function getRelevantArrIds(
 	caps: Caps,
 ): Promise<IdSearchParams> {
 	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, searchee);
+	const mediaType = getTag(searchee);
 	const idSearchCaps =
 		mediaType === MediaType.EPISODE || mediaType === MediaType.SEASON
 			? caps.tvIdSearch
@@ -179,7 +179,7 @@ export async function getAvailableArrIds(
 	searchee: Searchee,
 ): Promise<IdSearchParams> {
 	const nameWithoutExtension = stripExtension(searchee.name);
-	const mediaType = getTag(nameWithoutExtension, searchee);
+	const mediaType = getTag(searchee);
 	try {
 		const arrIdData = (
 			await grabArrId(searchee.name, mediaType)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,8 @@ export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
+export const AUDIO_EXTENSIONS = [".wav", ".aiff", ".flac", ".mp3", ".aac", ".m4a", ".m4b", ".ogg", ".wma"];
+export const BOOK_EXTENSIONS = [".epub", ".mobi", ".azw", ".azw3", ".azw4", ".pdf", ".djvu", ".html", ".chm", ".cbr", ".cbz", ".cb7"];
 
 export const IGNORED_FOLDERS_REGEX =
 	/^(S(eason )?\d{1,4}|((CD|DVD|DISC)\d{1,2}))$/i;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -1,6 +1,10 @@
 import { readdirSync, statSync } from "fs";
 import { basename, extname, join, relative } from "path";
-import { VIDEO_EXTENSIONS } from "./constants.js";
+import { 
+	AUDIO_EXTENSIONS,
+	BOOK_EXTENSIONS,
+	VIDEO_EXTENSIONS,
+} from "./constants.js";
 import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
@@ -29,6 +33,18 @@ export function hasInfoHash(
 	searchee: Searchee,
 ): searchee is SearcheeWithInfoHash {
 	return searchee.infoHash != null;
+}
+
+export function hasAudio(searchee: Searchee): boolean {
+	return searchee.files.some((file) =>
+		AUDIO_EXTENSIONS.includes(extname(file.name)),
+	);
+}
+
+export function hasBook(searchee: Searchee): boolean {
+	return searchee.files.some((file) =>
+		BOOK_EXTENSIONS.includes(extname(file.name)),
+	);
 }
 
 export function hasVideo(searchee: Searchee): boolean {

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -171,7 +171,7 @@ async function createTorznabSearchQueries(
 	const extractNumber = (str: string): number =>
 		parseInt(str.match(/\d+/)![0]);
 	const relevantIds = await getRelevantArrIds(searchee, ids, caps);
-	const mediaType = getTag(nameWithoutExtension, searchee);
+	const mediaType = getTag(searchee);
 	if (
 		mediaType === MediaType.EPISODE &&
 		caps.tvSearch &&
@@ -304,7 +304,7 @@ export async function searchTorznab(
 				(!excludeRecentSearch ||
 					entry.lastSearched < nMsAgo(excludeRecentSearch)) &&
 				shouldSearchIndexer(
-					getTag(searchee.name, searchee),
+					getTag(searchee),
 					JSON.parse(indexer.categories),
 				))
 		);

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -13,7 +13,7 @@ import {
 import { Label, logger } from "./logger.js";
 import { Candidate } from "./pipeline.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee, hasVideo } from "./searchee.js";
+import { Searchee } from "./searchee.js";
 import {
 	getAnimeQueries,
 	assembleUrl,
@@ -30,6 +30,8 @@ export interface TorznabCats {
 	tv: boolean;
 	movie: boolean;
 	anime: boolean;
+	audio: boolean;
+	book: boolean;
 }
 export interface TorznabParams {
 	t: "caps" | "search" | "tvsearch" | "movie";
@@ -129,6 +131,8 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 			movie: checkCategory("movie"),
 			tv: checkCategory("tv"),
 			anime: checkCategory("anime"),
+			audio: checkCategory("audio"),
+			book: checkCategory("book"),
 		};
 	}
 
@@ -167,7 +171,7 @@ async function createTorznabSearchQueries(
 	const extractNumber = (str: string): number =>
 		parseInt(str.match(/\d+/)![0]);
 	const relevantIds = await getRelevantArrIds(searchee, ids, caps);
-	const mediaType = getTag(nameWithoutExtension, hasVideo(searchee));
+	const mediaType = getTag(nameWithoutExtension, searchee);
 	if (
 		mediaType === MediaType.EPISODE &&
 		caps.tvSearch &&
@@ -249,6 +253,10 @@ function shouldSearchIndexer(mediaType: MediaType, caps: TorznabCats) {
 			return caps.movie;
 		case MediaType.ANIME:
 			return caps.anime;
+		case MediaType.AUDIO:
+			return caps.audio;
+		case MediaType.BOOK:
+			return caps.book;
 		case MediaType.OTHER:
 			return true;
 	}
@@ -296,7 +304,7 @@ export async function searchTorznab(
 				(!excludeRecentSearch ||
 					entry.lastSearched < nMsAgo(excludeRecentSearch)) &&
 				shouldSearchIndexer(
-					getTag(searchee.name, hasVideo(searchee)),
+					getTag(searchee.name, searchee),
 					JSON.parse(indexer.categories),
 				))
 		);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,12 +8,20 @@ import {
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { IdSearchParams, TorznabParams } from "./torznab.js";
+import {
+	hasAudio,
+	hasBook,
+	hasVideo,
+	Searchee
+} from "./searchee.js";
 
 export enum MediaType {
 	EPISODE = "episode",
 	SEASON = "pack",
 	MOVIE = "movie",
 	ANIME = "anime",
+	AUDIO = "audio",
+	BOOK = "book",
 	OTHER = "unknown",
 }
 
@@ -47,16 +55,20 @@ export function humanReadableSize(bytes: number) {
 	const coefficient = bytes / Math.pow(k, exponent);
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
-export function getTag(name: string, isVideo: boolean): MediaType {
+export function getTag(name: string, searchee: Searchee): MediaType {
 	return EP_REGEX.test(name)
 		? MediaType.EPISODE
 		: SEASON_REGEX.test(name)
 			? MediaType.SEASON
 			: MOVIE_REGEX.test(name)
 				? MediaType.MOVIE
-				: isVideo && ANIME_REGEX.test(name)
+				: hasVideo(searchee) && ANIME_REGEX.test(name)
 					? MediaType.ANIME
-					: MediaType.OTHER;
+					: hasAudio(searchee)
+						? MediaType.AUDIO
+						: hasBook(searchee)
+							? MediaType.BOOK
+							: MediaType.OTHER;
 }
 
 export async function time<R>(cb: () => R, times: number[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,14 +55,15 @@ export function humanReadableSize(bytes: number) {
 	const coefficient = bytes / Math.pow(k, exponent);
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
-export function getTag(name: string, searchee: Searchee): MediaType {
-	return EP_REGEX.test(name)
+export function getTag(searchee: Searchee): MediaType {
+	const nameWithoutExtension = stripExtension(searchee.name);
+	return EP_REGEX.test(nameWithoutExtension)
 		? MediaType.EPISODE
-		: SEASON_REGEX.test(name)
+		: SEASON_REGEX.test(nameWithoutExtension)
 			? MediaType.SEASON
-			: MOVIE_REGEX.test(name)
+			: MOVIE_REGEX.test(nameWithoutExtension)
 				? MediaType.MOVIE
-				: hasVideo(searchee) && ANIME_REGEX.test(name)
+				: hasVideo(searchee) && ANIME_REGEX.test(nameWithoutExtension)
 					? MediaType.ANIME
 					: hasAudio(searchee)
 						? MediaType.AUDIO


### PR DESCRIPTION
Since we are restricting searches based on category, we might as well add these in to further limit. Not official support for searching (not even sure if we can make improvements).

I put music and audiobooks into audio since they have the exact same extensions. I also preferred audio over book so if a release contains a book and audio book, it gets marked as audio.

I also put comic/manga with books. As there is some overlap in .pdf but mainly just to reduce clutter.

getTag now just takes a searchee rather than isVideo as the extension checking is done for all media. Should we put getTag in searchee.js? Only uses are with searchees and causes imports to utils.js.
