### PR TITLE
feat(torznab/indexer): filter out indexers without audio and book category

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,8 @@ export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
+export const AUDIO_EXTENSIONS = [".wav", ".aiff", ".alac", ".flac", ".ape", ".mp3", ".aac", ".m4a", ".m4b", ".m4p", ".ogg", ".wma", ".aa", ".aax"];
+export const BOOK_EXTENSIONS = [".epub", ".mobi", ".azw", ".azw3", ".azw4", ".pdf", ".djvu", ".html", ".chm", ".cbr", ".cbz", ".cb7", ".cbt", ".cba"];
 
 export const IGNORED_FOLDERS_REGEX =
 	/^(S(eason )?\d{1,4}|((CD|DVD|DISC)\d{1,2}))$/i;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -1,6 +1,5 @@
 import { readdirSync, statSync } from "fs";
-import { basename, extname, join, relative } from "path";
-import { VIDEO_EXTENSIONS } from "./constants.js";
+import { basename, join, relative } from "path";
 import { logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
@@ -29,12 +28,6 @@ export function hasInfoHash(
 	searchee: Searchee,
 ): searchee is SearcheeWithInfoHash {
 	return searchee.infoHash != null;
-}
-
-export function hasVideo(searchee: Searchee): boolean {
-	return searchee.files.some((file) =>
-		VIDEO_EXTENSIONS.includes(extname(file.name)),
-	);
 }
 
 function getFileNamesFromRootRec(root: string, isDirHint?: boolean): string[] {

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -168,11 +168,7 @@ async function createTorznabSearchQueries(
 		parseInt(str.match(/\d+/)![0]);
 	const relevantIds = await getRelevantArrIds(searchee, ids, caps);
 	const mediaType = getTag(searchee);
-	if (
-		mediaType === MediaType.EPISODE &&
-		caps.tvSearch &&
-		shouldSearchIndexer(mediaType, caps.categories)
-	) {
+	if (mediaType === MediaType.EPISODE && caps.tvSearch) {
 		const match = nameWithoutExtension.match(EP_REGEX);
 		return [
 			{
@@ -190,11 +186,7 @@ async function createTorznabSearchQueries(
 				...relevantIds,
 			},
 		] as const;
-	} else if (
-		mediaType === MediaType.SEASON &&
-		caps.tvSearch &&
-		shouldSearchIndexer(mediaType, caps.categories)
-	) {
+	} else if (mediaType === MediaType.SEASON && caps.tvSearch) {
 		const match = nameWithoutExtension.match(SEASON_REGEX);
 		return [
 			{
@@ -207,11 +199,7 @@ async function createTorznabSearchQueries(
 				...relevantIds,
 			},
 		] as const;
-	} else if (
-		mediaType === MediaType.MOVIE &&
-		caps.movieSearch &&
-		shouldSearchIndexer(mediaType, caps.categories)
-	) {
+	} else if (mediaType === MediaType.MOVIE && caps.movieSearch) {
 		return [
 			{
 				t: "movie",
@@ -222,10 +210,7 @@ async function createTorznabSearchQueries(
 				...relevantIds,
 			},
 		] as const;
-	} else if (
-		mediaType === MediaType.ANIME &&
-		shouldSearchIndexer(mediaType, caps.categories)
-	) {
+	} else if (mediaType === MediaType.ANIME) {
 		const animeQueries = getAnimeQueries(nameWithoutExtension);
 		return animeQueries.map((animeQuery) => ({
 			t: "search",

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -30,6 +30,8 @@ export interface TorznabCats {
 	tv: boolean;
 	movie: boolean;
 	anime: boolean;
+	audio: boolean;
+	book: boolean;
 }
 export interface TorznabParams {
 	t: "caps" | "search" | "tvsearch" | "movie";
@@ -129,6 +131,8 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 			movie: checkCategory("movie"),
 			tv: checkCategory("tv"),
 			anime: checkCategory("anime"),
+			audio: checkCategory("audio"),
+			book: checkCategory("book"),
 		};
 	}
 
@@ -234,6 +238,10 @@ function shouldSearchIndexer(mediaType: MediaType, caps: TorznabCats) {
 			return caps.movie;
 		case MediaType.ANIME:
 			return caps.anime;
+		case MediaType.AUDIO:
+			return caps.audio;
+		case MediaType.BOOK:
+			return caps.book;
 		case MediaType.OTHER:
 			return true;
 	}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -243,7 +243,7 @@ function shouldSearchIndexer(mediaType: MediaType, caps: TorznabCats) {
 		case MediaType.BOOK:
 			return caps.book;
 		case MediaType.OTHER:
-			return true;
+			return false;
 	}
 }
 export async function queryRssFeeds(): Promise<Candidate[]> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,16 +5,20 @@ import {
 	SEASON_REGEX,
 	ANIME_REGEX,
 	VIDEO_EXTENSIONS,
+	AUDIO_EXTENSIONS,
+	BOOK_EXTENSIONS,
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { IdSearchParams, TorznabParams } from "./torznab.js";
-import { hasVideo, Searchee } from "./searchee.js";
+import { Searchee } from "./searchee.js";
 
 export enum MediaType {
 	EPISODE = "episode",
 	SEASON = "pack",
 	MOVIE = "movie",
 	ANIME = "anime",
+	AUDIO = "audio",
+	BOOK = "book",
 	OTHER = "unknown",
 }
 
@@ -49,16 +53,23 @@ export function humanReadableSize(bytes: number) {
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
 export function getTag(searchee: Searchee): MediaType {
-	const nameWithoutExtension = stripExtension(searchee.name);
-	return EP_REGEX.test(nameWithoutExtension)
+	function hasExt(searchee: Searchee, extensions: string[]) {
+		return extensions.includes(path.extname(searchee.name));
+	}
+	const stem = stripExtension(searchee.name);
+	return EP_REGEX.test(stem)
 		? MediaType.EPISODE
-		: SEASON_REGEX.test(nameWithoutExtension)
+		: SEASON_REGEX.test(stem)
 			? MediaType.SEASON
-			: MOVIE_REGEX.test(nameWithoutExtension)
+			: MOVIE_REGEX.test(stem)
 				? MediaType.MOVIE
-				: hasVideo(searchee) && ANIME_REGEX.test(nameWithoutExtension)
+				: hasExt(searchee, VIDEO_EXTENSIONS) && ANIME_REGEX.test(stem)
 					? MediaType.ANIME
-					: MediaType.OTHER;
+					: hasExt(searchee, AUDIO_EXTENSIONS)
+						? MediaType.AUDIO
+						: hasExt(searchee, BOOK_EXTENSIONS)
+							? MediaType.BOOK
+							: MediaType.OTHER;
 }
 
 export async function time<R>(cb: () => R, times: number[]) {


### PR DESCRIPTION
Since we are restricting searches based on category, we might as well add these in to further limit. Not official support for searching (not even sure if we can make improvements).

I put music and audiobooks into audio since they have the exact same extensions. I also preferred audio over book so if a release contains a book and audio book, it gets marked as audio.

I also put comic/manga with books. As there is some overlap in .pdf but mainly just to reduce clutter.

getTag now just takes a searchee rather than isVideo as the extension checking is done for all media. Should we put getTag in searchee.js? Only uses are with searchees and causes imports to utils.js.