### PR TITLE
Rename flatLinking and linkingCategory options

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -122,8 +122,8 @@ async function linkAllFilesInMetafile(
 		| "UNKNOWN_ERROR"
 	>
 > {
-	const { linkDir, legacyLinking } = getRuntimeConfig();
-	const fullLinkDir = legacyLinking ? linkDir : join(linkDir, tracker);
+	const { linkDir, flatLinking } = getRuntimeConfig();
+	const fullLinkDir = flatLinking ? linkDir : join(linkDir, tracker);
 	let sourceRoot: string;
 	if (searchee.path) {
 		sourceRoot = searchee.path;

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -275,17 +275,17 @@ export default class Deluge implements TorrentClient {
 				params,
 			);
 			if (addResult.result) {
-				const { dataCategory } = getRuntimeConfig();
+				const { linkingCategory } = getRuntimeConfig();
 				await this.setLabel(
 					newTorrent.name,
 					newTorrent.infoHash,
 					searchee.path
-						? dataCategory
+						? linkingCategory
 						: torrentInfo!.label
 							? duplicateCategories
 								? torrentInfo!.label.endsWith(
 										this.delugeLabelSuffix,
-									) || torrentInfo!.label === dataCategory
+									) || torrentInfo!.label === linkingCategory
 									? torrentInfo!.label
 									: `${torrentInfo!.label}${
 											this.delugeLabelSuffix

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -166,11 +166,11 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	async setUpCrossSeedCategory(ogCategoryName: string): Promise<string> {
-		const { dataCategory } = getRuntimeConfig();
+		const { linkingCategory } = getRuntimeConfig();
 		if (!ogCategoryName) return "";
 		if (
 			ogCategoryName.endsWith(TORRENT_CATEGORY_SUFFIX) ||
-			ogCategoryName === dataCategory
+			ogCategoryName === linkingCategory
 		)
 			return ogCategoryName;
 
@@ -296,7 +296,7 @@ export default class QBittorrent implements TorrentClient {
 			| Decision.MATCH_PARTIAL,
 		path?: string,
 	): Promise<InjectionResult> {
-		const { duplicateCategories, skipRecheck, dataCategory } =
+		const { duplicateCategories, skipRecheck, linkingCategory } =
 			getRuntimeConfig();
 		try {
 			if (await this.isInfoHashInClient(newTorrent.infoHash)) {
@@ -312,7 +312,7 @@ export default class QBittorrent implements TorrentClient {
 						save_path: path,
 						isComplete: true,
 						autoTMM: false,
-						category: dataCategory,
+						category: linkingCategory,
 					}
 				: await this.getTorrentConfiguration(searchee);
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -122,8 +122,8 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		)
 		.option(
 			"--linking-category <cat>",
-			"Category to assign torrents from data-based matching",
-			fallback(fileConfig.linkingCategory, "cross-seed-data"),
+			"Torrent client category to set on linked torrents",
+			fallback(fileConfig.linkingCategory, "cross-seed-link"),
 		)
 		.option(
 			"--link-dir <dir>",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -121,9 +121,9 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.makeOptionMandatory(),
 		)
 		.option(
-			"--data-category <cat>",
+			"--linking-category <cat>",
 			"Category to assign torrents from data-based matching",
-			fallback(fileConfig.dataCategory, "cross-seed-data"),
+			fallback(fileConfig.linkingCategory, "cross-seed-data"),
 		)
 		.option(
 			"--link-dir <dir>",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -131,9 +131,9 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			fileConfig.linkDir,
 		)
 		.option(
-			"--legacy-linking",
+			"--flat-linking",
 			"Use flat linking directory structure (without individual tracker folders)",
-			fallback(fileConfig.legacyLinking, false),
+			fallback(fileConfig.flatLinking, false),
 		)
 		.addOption(
 			new Option(

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -150,7 +150,7 @@ module.exports = {
 	 *
 	 * Default: false.
 	 */
-	legacyLinking: false,
+	flatLinking: false,
 
 	/**
 	 * Whether to skip recheck in qBittorrent or Deluge. Not supported in rTorrent/Transmission.

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -112,11 +112,10 @@ module.exports = {
 	matchMode: "safe",
 
 	/**
-	 * Defines what category torrents injected by data-based matching should
-	 * use.
-	 * Default is "cross-seed-data".
+	 * Defines what qBittorrent or Deluge category to set on linked torrents
+	 * Default is "cross-seed-link".
 	 */
-	linkingCategory: undefined,
+	linkingCategory: "cross-seed-link",
 
 	/**
 	 * If this is specified, cross-seed will create links to matched files in

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -116,7 +116,7 @@ module.exports = {
 	 * use.
 	 * Default is "cross-seed-data".
 	 */
-	dataCategory: undefined,
+	linkingCategory: undefined,
 
 	/**
 	 * If this is specified, cross-seed will create links to matched files in

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -115,7 +115,7 @@ export const VALIDATION_SCHEMA = z
 
 			.nullish(),
 		matchMode: z.nativeEnum(MatchMode),
-		dataCategory: z.string().nullish(),
+		linkingCategory: z.string().nullish(),
 		linkDir: z.string().transform(checkValidPathFormat).nullish(),
 		linkType: z.nativeEnum(LinkType),
 		legacyLinking: z

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -18,7 +18,7 @@ const ZodErrorMessages = {
 	recheckWarn:
 		"It is strongly recommended to not skip rechecking for risky or partial matching mode.",
 	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
-	qBitLegacyLinking:
+	qBitFlatLinking:
 		"Using Automatic Torrent Management in qBittorrent without flatLinking enabled can result in injection path failures.",
 	needsLinkDir:
 		"You need to set a linkDir for risky or partial matching to work.",
@@ -193,7 +193,7 @@ export const VALIDATION_SCHEMA = z
 			!config.flatLinking &&
 			config.linkDir
 		) {
-			logger.warn(ZodErrorMessages.qBitLegacyLinking);
+			logger.warn(ZodErrorMessages.qBitFlatLinking);
 		}
 		return true;
 	})

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -19,7 +19,7 @@ const ZodErrorMessages = {
 		"It is strongly recommended to not skip rechecking for risky or partial matching mode.",
 	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
 	qBitLegacyLinking:
-		"Using Automatic Torrent Management in qBittorrent without legacyLinking enabled can result in injection path failures.",
+		"Using Automatic Torrent Management in qBittorrent without flatLinking enabled can result in injection path failures.",
 	needsLinkDir:
 		"You need to set a linkDir for risky or partial matching to work.",
 };
@@ -118,7 +118,7 @@ export const VALIDATION_SCHEMA = z
 		linkingCategory: z.string().nullish(),
 		linkDir: z.string().transform(checkValidPathFormat).nullish(),
 		linkType: z.nativeEnum(LinkType),
-		legacyLinking: z
+		flatLinking: z
 			.boolean()
 			.nullish()
 			.transform((value) => (typeof value === "boolean" ? value : false)),
@@ -190,7 +190,7 @@ export const VALIDATION_SCHEMA = z
 		if (
 			config.action === Action.INJECT &&
 			config.qbittorrentUrl &&
-			!config.legacyLinking &&
+			!config.flatLinking &&
 			config.linkDir
 		) {
 			logger.warn(ZodErrorMessages.qBitLegacyLinking);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -28,7 +28,7 @@ export interface FileConfig {
 	legacyLinking?: boolean;
 	skipRecheck?: boolean;
 	maxDataDepth?: number;
-	dataCategory?: string;
+	linkingCategory?: string;
 	torrentDir?: string;
 	torznab?: string[];
 	qbittorrentUrl?: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,7 +25,7 @@ export interface FileConfig {
 	matchMode?: MatchMode;
 	linkDir?: string;
 	linkType?: string;
-	legacyLinking?: boolean;
+	flatLinking?: boolean;
 	skipRecheck?: boolean;
 	maxDataDepth?: number;
 	linkingCategory?: string;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -7,7 +7,7 @@ export interface RuntimeConfig {
 	matchMode: MatchMode;
 	linkDir: string;
 	linkType: LinkType;
-	legacyLinking: boolean;
+	flatLinking: boolean;
 	skipRecheck: boolean;
 	maxDataDepth: number;
 	linkingCategory: string;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -10,7 +10,7 @@ export interface RuntimeConfig {
 	legacyLinking: boolean;
 	skipRecheck: boolean;
 	maxDataDepth: number;
-	dataCategory: string;
+	linkingCategory: string;
 	torrentDir?: string;
 	outputDir: string;
 	includeEpisodes: boolean;


### PR DESCRIPTION
This PR renames the `dataCategory` option to `linkingCategory`, renames the `legacyLinking` option to `flatLinking`, and updates a couple surrounding things (changing the default value of linkingCategory to `cross-seed-link` instead of `cross-seed-data` and some small copy updates.