### PR TITLE
fix(client/rtorrent): send content-type text/xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docker-compose.yml
 utils.zsh
 test.db
 .idea/discord.xml
+.idea/vcs.xml

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,4 +1,3 @@
-import ms from "ms";
 import {
 	Decision,
 	InjectionResult,
@@ -136,10 +135,7 @@ export default class Deluge implements TorrentClient {
 		const id = Math.floor(Math.random() * 0x7fffffff);
 		const abortController = new AbortController();
 
-		setTimeout(
-			() => void abortController.abort(),
-			ms("10 seconds"),
-		).unref();
+		setTimeout(() => void abortController.abort(), 10000).unref();
 
 		try {
 			response = await fetch(href, {
@@ -176,7 +172,7 @@ export default class Deluge implements TorrentClient {
 				return this.call<ResultType>(method, params, 0);
 			} else {
 				throw new Error(
-					"Connection lost with Deluge. Reauthentication failed.",
+					"Connection lost with Deluge. Re-authentication failed.",
 				);
 			}
 		}
@@ -207,6 +203,29 @@ export default class Deluge implements TorrentClient {
 			: enabledPlugins.result!.includes("Label");
 	}
 
+	// generates the label (string) for injection based on searchee and torrentInfo
+	private calculateLabel(
+		searchee: Searchee,
+		torrentInfo: TorrentInfo,
+	): string {
+		const { linkCategory, duplicateCategories } = getRuntimeConfig();
+		if (!searchee.infoHash || !torrentInfo!.label) {
+			return this.delugeLabel;
+		}
+		const ogLabel = torrentInfo!.label;
+		if (!duplicateCategories) {
+			return ogLabel;
+		}
+		const shouldSuffixLabel =
+			!ogLabel.endsWith(this.delugeLabelSuffix) && // no .cross-seed
+			ogLabel !== linkCategory; // not data
+
+		return searchee.path
+			? linkCategory
+			: shouldSuffixLabel
+				? `${ogLabel}${this.delugeLabelSuffix}`
+				: ogLabel;
+	}
 	/**
 	 * if Label plugin is loaded, adds (if necessary)
 	 * and sets the label based on torrent hash.
@@ -247,7 +266,6 @@ export default class Deluge implements TorrentClient {
 		path?: string,
 	): Promise<InjectionResult> {
 		try {
-			const { duplicateCategories } = getRuntimeConfig();
 			let torrentInfo: TorrentInfo;
 			if (searchee.infoHash) {
 				torrentInfo = await this.getTorrentInfo(searchee);
@@ -272,41 +290,24 @@ export default class Deluge implements TorrentClient {
 				"core.add_torrent_file",
 				params,
 			);
-			if (addResult.result) {
-				const { linkCategory } = getRuntimeConfig();
-				//if webui is desyncd just use linkCat
-				const ogLabel =
-					searchee.infoHash && torrentInfo!.label
-						? torrentInfo!.label
-						: this.delugeLabel;
 
-				const shouldSuffixLabel =
-					searchee.infoHash &&
-					duplicateCategories &&
-					!ogLabel.endsWith(this.delugeLabelSuffix) &&
-					ogLabel !== linkCategory;
-
-				const label = searchee.path
-					? linkCategory
-					: torrentInfo!.label
-						? shouldSuffixLabel
-							? `${torrentInfo!.label}${this.delugeLabelSuffix}`
-							: torrentInfo!.label
-						: ogLabel;
-
+			const addResponse =
+				typeof addResult.result === "string"
+					? addResult.result
+					: addResult.error;
+			if (typeof addResponse === "string") {
 				await this.setLabel(
 					newTorrent.name,
 					newTorrent.infoHash,
-					label,
+					this.calculateLabel(searchee, torrentInfo!),
 				);
-
 				return InjectionResult.SUCCESS;
-			} else if (addResult.error!.message!.includes("already")) {
+			} else if (addResponse?.message!.includes("already")) {
 				return InjectionResult.ALREADY_EXISTS;
-			} else if (addResult.error!.message) {
+			} else if (addResponse) {
 				logger.debug({
 					label: Label.DELUGE,
-					message: `Injection failed: ${addResult.error!.message}`,
+					message: `Injection failed: ${addResponse}`,
 				});
 				return InjectionResult.FAILURE;
 			} else {
@@ -338,19 +339,20 @@ export default class Deluge implements TorrentClient {
 			| Decision.MATCH_SIZE_ONLY
 			| Decision.MATCH_PARTIAL,
 	): InjectData {
+		const skipRecheck = determineSkipRecheck(decision);
 		return [
 			filename,
 			filedump,
 			{
-				add_paused: !determineSkipRecheck(decision),
-				seed_mode: determineSkipRecheck(decision),
+				add_paused: !skipRecheck,
+				seed_mode: skipRecheck,
 				download_location: path,
 			},
 		];
 	}
 
 	/**
-	 * returns directory of a infohash in deluge as a string
+	 * returns directory of an infohash in deluge as a string
 	 */
 	async getDownloadDir(
 		searchee: Searchee,

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -238,13 +238,13 @@ export default class QBittorrent implements TorrentClient {
 			if (torrentInfo.save_path === undefined) {
 				return resultOfErr("NOT_FOUND");
 			}
+			return resultOf(torrentInfo!.save_path);
 		} catch (e) {
 			if (e.message.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
 			return resultOfErr("UNKNOWN_ERROR");
 		}
-		return resultOf(torrentInfo!.save_path);
 	}
 
 	async getTorrentConfiguration(
@@ -356,19 +356,15 @@ export default class QBittorrent implements TorrentClient {
 				formData.append(
 					"tags",
 					searchee.infoHash
-						? TORRENT_TAG
-						: `${TORRENT_TAG},${newCategoryName}`,
+						? `${TORRENT_TAG},${newCategoryName}`
+						: category,
 				);
 			}
 			formData.append("contentLayout", path ? "Original" : contentLayout);
-			formData.append(
-				"skip_checking",
-				determineSkipRecheck(decision).toString(),
-			);
-			formData.append(
-				"paused",
-				!determineSkipRecheck(decision).toString(),
-			);
+
+			const skipRecheck = determineSkipRecheck(decision);
+			formData.append("skip_checking", skipRecheck.toString());
+			formData.append("paused", !skipRecheck.toString());
 			// for some reason the parser parses the last kv pair incorrectly
 			// it concats the value and the sentinel
 			formData.append("foo", "bar");

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -120,7 +120,7 @@ export default class RTorrent implements TorrentClient {
 			basic_auth: shouldUseAuth
 				? { user: username, pass: password }
 				: undefined,
-			headers: headers, // Include headers option
+			headers: headers,
 		});
 	}
 

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -111,11 +111,16 @@ export default class RTorrent implements TorrentClient {
 
 		const shouldUseAuth = Boolean(username && password);
 
+		const headers = {
+			"Content-Type": "text/xml",
+		};
+
 		this.client = clientCreator({
 			url: href,
 			basic_auth: shouldUseAuth
 				? { user: username, pass: password }
 				: undefined,
+			headers: headers, // Include headers option
 		});
 	}
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -121,7 +121,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.makeOptionMandatory(),
 		)
 		.option(
-			"--linking-category <cat>",
+			"--link-category <cat>",
 			"Torrent client category to set on linked torrents",
 			fallback(fileConfig.linkCategory, "cross-seed-link"),
 		)


### PR DESCRIPTION
hotio reported that certain builds of rtorrent (particularly jesec's rflood) requires the text/xml for requests. if not provided, rtorrent will potentially return empty strings

rtorrent is the only client implementation in cross-seed that does not currently provide a content-type in the requests.

this adds the header "Content-Type: text/xml" to the call to clientCreator() to fix this issue.