### PR TITLE
fix(client/deluge): incremental id with json-rpc requests

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -50,6 +50,7 @@ export default class Deluge implements TorrentClient {
 	private delugeLabel = TORRENT_TAG;
 	private delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
 	private isLabelEnabled: boolean;
+	private delugeRequestId: number = 0;
 
 	/**
 	 * validates the login and host for deluge webui
@@ -133,7 +134,6 @@ export default class Deluge implements TorrentClient {
 		if (this.delugeCookie) headers.set("Cookie", this.delugeCookie);
 
 		let response: Response, json: DelugeJSON<ResultType>;
-		const id = Math.floor(Math.random() * 0x7fffffff);
 		const abortController = new AbortController();
 
 		setTimeout(
@@ -146,7 +146,7 @@ export default class Deluge implements TorrentClient {
 				body: JSON.stringify({
 					method,
 					params,
-					id,
+					id: this.delugeRequestId++,
 				}),
 				method: "POST",
 				headers,


### PR DESCRIPTION
since every id is independent to a connection, using random will create the potential for a bad seed to produce duplicates.

starting at 0, we will now increment through the id last used.

this change was due to new information i was previously unaware of (independent per connection) given to me by a developer on the team