### PR TITLE
migration(v6/qbit): refactor and migrate to v6 category and tagging

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -161,13 +161,9 @@ async function linkAllFilesInMetafile(
 	}
 
 	if (decision === Decision.MATCH) {
-		return resultOf(
-			linkExactTree(newMeta, fullLinkDir, sourceRoot)
-		);
+		return resultOf(linkExactTree(newMeta, fullLinkDir, sourceRoot));
 	} else if (decision === Decision.MATCH_SIZE_ONLY) {
-		return resultOf(
-			fuzzyLinkOneFile(newMeta, fullLinkDir, sourceRoot),
-		);
+		return resultOf(fuzzyLinkOneFile(newMeta, fullLinkDir, sourceRoot));
 	} else {
 		return resultOf(
 			fuzzyLinkPartial(searchee, newMeta, fullLinkDir, sourceRoot),

--- a/src/action.ts
+++ b/src/action.ts
@@ -134,7 +134,12 @@ async function linkAllFilesInMetafile(
 				e === "NOT_FOUND" ? "TORRENT_NOT_FOUND" : e,
 			);
 		}
-		sourceRoot = join(downloadDirResult.unwrapOrThrow(), searchee.name);
+		sourceRoot = join(
+			downloadDirResult.unwrapOrThrow(),
+			searchee.files.length === 1
+				? searchee.files[0].path
+				: searchee.name,
+		);
 	}
 
 	if (!existsSync(sourceRoot)) {
@@ -195,6 +200,9 @@ export async function performAction(
 			linkedFilesRootResult.unwrapErrOrThrow() === "MISSING_DATA"
 		) {
 			logger.warn("Falling back to non-linking.");
+			if (searchee.path) {
+				destinationDir = dirname(searchee.path);
+			}
 		} else {
 			logInjectionResult(
 				InjectionResult.FAILURE,

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,13 +1,6 @@
 import chalk from "chalk";
-import {
-	existsSync,
-	linkSync,
-	mkdirSync,
-	readdirSync,
-	statSync,
-	symlinkSync,
-} from "fs";
-import { basename, dirname, join, relative, resolve } from "path";
+import { existsSync, linkSync, mkdirSync, statSync, symlinkSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { getClient } from "./clients/TorrentClient.js";
 import {
 	Action,
@@ -59,25 +52,43 @@ function logInjectionResult(
 }
 
 /**
- * this may not work with subfolder content layout
- * @return the root of linked file. most likely "destinationDir/name". Not necessarily a file, it can be a directory
+ * @return the root of linked files.
  */
-function fuzzyLinkOneFile(
-	searchee: Searchee,
+function linkExactTree(
 	newMeta: Metafile,
 	destinationDir: string,
 	sourceRoot: string,
 ): string {
-	const srcFilePath = join(
-		sourceRoot,
-		relative(searchee.name, searchee.files[0].path),
-	);
+	if (newMeta.files.length === 1) {
+		return fuzzyLinkOneFile(newMeta, destinationDir, sourceRoot);
+	}
+	for (const newFile of newMeta.files) {
+		const srcFilePath = join(dirname(sourceRoot), newFile.path);
+		const destFilePath = join(destinationDir, newFile.path);
+		mkdirSync(dirname(destFilePath), { recursive: true });
+		linkFile(srcFilePath, destFilePath);
+	}
+	return join(destinationDir, newMeta.name);
+}
+
+/**
+ * @return the root of linked file.
+ */
+function fuzzyLinkOneFile(
+	newMeta: Metafile,
+	destinationDir: string,
+	sourceRoot: string,
+): string {
+	const srcFilePath = sourceRoot;
 	const destFilePath = join(destinationDir, newMeta.files[0].path);
 	mkdirSync(dirname(destFilePath), { recursive: true });
 	linkFile(srcFilePath, destFilePath);
 	return join(destinationDir, newMeta.name);
 }
 
+/**
+ * @return the root of linked files.
+ */
 function fuzzyLinkPartial(
 	searchee: Searchee,
 	newMeta: Metafile,
@@ -150,10 +161,12 @@ async function linkAllFilesInMetafile(
 	}
 
 	if (decision === Decision.MATCH) {
-		return resultOf(linkExactTree(sourceRoot, fullLinkDir));
+		return resultOf(
+			linkExactTree(newMeta, fullLinkDir, sourceRoot)
+		);
 	} else if (decision === Decision.MATCH_SIZE_ONLY) {
 		return resultOf(
-			fuzzyLinkOneFile(searchee, newMeta, fullLinkDir, sourceRoot),
+			fuzzyLinkOneFile(newMeta, fullLinkDir, sourceRoot),
 		);
 	} else {
 		return resultOf(
@@ -248,24 +261,6 @@ export async function performActions(searchee, matches) {
 		if (result === InjectionResult.TORRENT_NOT_COMPLETE) break;
 	}
 	return results;
-}
-
-/**
- * @return the root of linked files.
- */
-
-function linkExactTree(oldPath: string, dest: string): string {
-	const newPath = join(dest, basename(oldPath));
-	if (statSync(oldPath).isFile()) {
-		mkdirSync(dirname(newPath), { recursive: true });
-		linkFile(oldPath, newPath);
-	} else {
-		mkdirSync(newPath, { recursive: true });
-		for (const dirent of readdirSync(oldPath)) {
-			linkExactTree(join(oldPath, dirent), newPath);
-		}
-	}
-	return newPath;
 }
 
 function linkFile(oldPath: string, newPath: string) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -284,27 +284,41 @@ export default class Deluge implements TorrentClient {
 				});
 				return InjectionResult.FAILURE;
 			}
+
+			const torrentFileName = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
+			const encodedTorrentData = newTorrent.encode().toString("base64");
+			const torrentPath = path ? path : torrentInfo!.save_path;
 			const params = this.formatData(
-				`${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`,
-				newTorrent.encode().toString("base64"),
-				path ? path : torrentInfo!.save_path,
+				torrentFileName,
+				encodedTorrentData,
+				torrentPath,
 				decision,
 			);
+
 			const addResult = await this.call<string>(
 				"core.add_torrent_file",
 				params,
 			);
 
 			const addResponse =
-				typeof addResult.result === "string"
-					? addResult.result
-					: addResult.error;
+				typeof addResult.error?.message === "string"
+					? addResult.error
+					: addResult.result;
+
 			if (typeof addResponse === "string") {
 				await this.setLabel(
 					newTorrent.name,
 					newTorrent.infoHash,
 					this.calculateLabel(searchee, torrentInfo!),
 				);
+
+				if (!determineSkipRecheck(decision)) {
+					// when paused, libtorrent doesnt start rechecking
+					// leaves torrent ready to download - ~99%
+					await this.call<string>("core.force_recheck", [
+						searchee.infoHash,
+					]);
+				}
 				return InjectionResult.SUCCESS;
 			} else if (addResponse?.message!.includes("already")) {
 				return InjectionResult.ALREADY_EXISTS;

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -315,6 +315,7 @@ export default class Deluge implements TorrentClient {
 				if (!determineSkipRecheck(decision)) {
 					// when paused, libtorrent doesnt start rechecking
 					// leaves torrent ready to download - ~99%
+					await new Promise((resolve) => setTimeout(resolve, 1000));
 					await this.call<string>("core.force_recheck", [
 						newTorrent.infoHash,
 					]);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -316,7 +316,7 @@ export default class Deluge implements TorrentClient {
 					// when paused, libtorrent doesnt start rechecking
 					// leaves torrent ready to download - ~99%
 					await this.call<string>("core.force_recheck", [
-						searchee.infoHash,
+						newTorrent.infoHash,
 					]);
 				}
 				return InjectionResult.SUCCESS;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -169,20 +169,22 @@ export default class QBittorrent implements TorrentClient {
 		searchee: Searchee,
 		injectionConfiguration: TorrentConfiguration,
 	): string {
-		const { linkCategory, duplicateCategories } = getRuntimeConfig();
+		const { duplicateCategories } = getRuntimeConfig();
 		const { category } = injectionConfiguration;
 
 		if (!category) {
 			return TORRENT_TAG;
 		}
-		if (category === linkCategory) {
-			return `${TORRENT_TAG}-data,${TORRENT_TAG}`;
-		}
 		if (category.endsWith(TORRENT_CATEGORY_SUFFIX)) {
 			return `${category},${TORRENT_TAG}`;
 		}
-		const suffix = duplicateCategories ? TORRENT_CATEGORY_SUFFIX : "";
-		return `${category}${suffix},${TORRENT_TAG}`;
+
+		if (searchee.path) {
+			return `${TORRENT_TAG}-data,${TORRENT_TAG}`;
+		} else {
+			const suffix = duplicateCategories ? TORRENT_CATEGORY_SUFFIX : "";
+			return `${category}${suffix},${TORRENT_TAG}`;
+		}
 	}
 
 	async createTag(): Promise<void> {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -142,7 +142,7 @@ export default class QBittorrent implements TorrentClient {
 	): Promise<string> {
 		logger.verbose({
 			label: Label.QBITTORRENT,
-			message: `Making request (${retries}) to ${path} with body ${body!.toString()}`,
+			message: `Making request (${retries}) to ${path} with body ${JSON.stringify(body)}`,
 		});
 
 		let response: Response = new Response();
@@ -408,7 +408,7 @@ export default class QBittorrent implements TorrentClient {
 			await this.addTorrent(formData);
 			//if we have a linked file and skiprecheck is false
 			if (!skipRecheck) {
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 1000));
 				await this.recheckTorrent(newTorrent.infoHash);
 			}
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -360,7 +360,7 @@ export default class QBittorrent implements TorrentClient {
 
 			await this.request("/torrents/add", formData);
 			//if we have a linked file and skiprecheck is false
-			if (determineSkipRecheck(decision)) {
+			if (skipRecheck) {
 				await new Promise((resolve) => setTimeout(resolve, 100));
 				await this.request(
 					"/torrents/recheck",

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -224,15 +224,10 @@ export default class QBittorrent implements TorrentClient {
 			if (torrentInfo.save_path === undefined) {
 				return resultOfErr("NOT_FOUND");
 			}
-
-			if (await this.isSubfolderContentLayout(searchee)) {
-				// because both previous calls succeeded at this point
-				// we can assume that this will also succeed
-				torrentInfo = await this.generateCorrectSavePath(
-					searchee,
-					torrentInfo,
-				);
-			}
+			torrentInfo = await this.generateCorrectSavePath(
+				searchee,
+				torrentInfo,
+			);
 			return resultOf(torrentInfo.save_path);
 		} catch (e) {
 			if (e.message.includes("retrieve")) {
@@ -251,23 +246,8 @@ export default class QBittorrent implements TorrentClient {
 		searchee: Searchee,
 		{ save_path },
 	): Promise<{ save_path: string }> {
-		const response = await this.request(
-			"/torrents/files",
-			`hash=${searchee.infoHash}`,
-			X_WWW_FORM_URLENCODED,
-		);
-		const files: TorrentFiles[] = JSON.parse(response);
-		const [{ name }] = files;
 		const subfolderContentLayout =
-			files.length === 1 &&
-			stripExtension(searchee.name) === posix.basename(name);
-		if (!save_path) {
-			//two previous calls in parent function who called generate
-			// worked but this call failed
-			//should have been less than a second ago
-			throw new Error("UNKNOWN_ERROR");
-		}
-		// unwrap the gift
+			await this.isSubfolderContentLayout(searchee);
 		if (subfolderContentLayout) {
 			return {
 				save_path: join(save_path, stripExtension(searchee.name)),
@@ -314,10 +294,7 @@ export default class QBittorrent implements TorrentClient {
 
 		const files: TorrentFiles[] = JSON.parse(response);
 		const [{ name }] = files;
-		return (
-			files.length === 1 &&
-			stripExtension(searchee.name) === posix.basename(name)
-		);
+		return files.length === 1 && posix.dirname(name) !== ".";
 	}
 
 	async inject(
@@ -372,7 +349,7 @@ export default class QBittorrent implements TorrentClient {
 				flatLinking && searchee.infoHash ? autoTMM.toString() : "false",
 			);
 			formData.append("contentLayout", path ? "Original" : contentLayout);
-			formData.append("category", linkCategory);
+			formData.append("category", category);
 			formData.append("tags", tags);
 			const skipRecheck = determineSkipRecheck(decision);
 			formData.append("skip_checking", skipRecheck.toString());

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -74,7 +74,7 @@ export async function validateAndSetRuntimeConfig(options: RuntimeConfig) {
 				`${
 					path.length > 0 ? `Option: ${optionLine}` : "Configuration:"
 				}\n\t\t\t\t${message}\n\t\t\t\t(https://www.cross-seed.org/docs/basics/options${
-					urlPath ? `#${urlPath.toLower}` : ""
+					urlPath ? `#${urlPath.toLowerCase()}` : ""
 				})\n`,
 			);
 		});

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -74,7 +74,7 @@ export async function validateAndSetRuntimeConfig(options: RuntimeConfig) {
 				`${
 					path.length > 0 ? `Option: ${optionLine}` : "Configuration:"
 				}\n\t\t\t\t${message}\n\t\t\t\t(https://www.cross-seed.org/docs/basics/options${
-					urlPath ? `#${urlPath}` : ""
+					urlPath ? `#${urlPath.toLower}` : ""
 				})\n`,
 			);
 		});

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -129,6 +129,8 @@ module.exports = {
 	 *
 	 * Unlike dataDirs, this is just a quoted string WITHOUT []'s around it.
 	 *
+	 * If you are a Windows user you need to put double '\' (e.g. "C:\\links")
+	 *
 	 * IF YOU ARE USING HARDLINKS, THIS MUST BE UNDER THE SAME VOLUME AS YOUR
 	 * DATADIRS. THIS PATH MUST ALSO BE ACCESSIBLE VIA YOUR TORRENT CLIENT
 	 * USING THE SAME PATH.
@@ -187,11 +189,15 @@ module.exports = {
 	 * .rtorrent.rc file.
 	 * For Deluge, this is ~/.config/deluge/state.
 	 * For Transmission, this would be ~/.config/transmission/torrents.
+	 *
+	 * If you are a Windows user you need to put double '\' (e.g. "C:\\torrents")
 	 */
 	torrentDir: "/path/to/torrent/file/dir",
 
 	/**
 	 * Where to save the torrent files that cross-seed finds for you.
+	 *
+	 * If you are a Windows user you need to put double '\' (e.g. "C:\\output")
 	 */
 	outputDir: ".",
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -117,10 +117,7 @@ export const VALIDATION_SCHEMA = z
 			.nullish(),
 		matchMode: z.nativeEnum(MatchMode),
 		linkCategory: z.string().nullish(),
-		linkDir: z
-			.string()
-			.transform(await checkValidPathFormat)
-			.nullish(),
+		linkDir: z.string().transform(checkValidPathFormat).nullish(),
 		linkType: z.nativeEnum(LinkType),
 		flatLinking: z
 			.boolean()
@@ -128,10 +125,7 @@ export const VALIDATION_SCHEMA = z
 			.transform((value) => (typeof value === "boolean" ? value : false)),
 		skipRecheck: z.boolean(),
 		maxDataDepth: z.number().gte(1),
-		torrentDir: z
-			.string()
-			.transform(await checkValidPathFormat)
-			.nullish(),
+		torrentDir: z.string().transform(checkValidPathFormat).nullish(),
 		outputDir: z.string(),
 		includeEpisodes: z.boolean(),
 		includeSingleEpisodes: z.boolean(),

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -42,7 +42,6 @@ export function customizeErrorMessage(
 				message: error.unionErrors
 					.reduce<string[]>((acc, error) => {
 						error.errors.forEach((x) => acc.push(x.message));
-						console.log(acc);
 						return acc;
 					}, [])
 					.join("; "),

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -17,7 +17,9 @@ const ZodErrorMessages = {
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	recheckWarn:
 		"It is strongly recommended to not skip rechecking for risky or partial matching mode.",
-	windowsPath: `Your path is not formatted properly for Windows. Please use "\\\\" or "/" for directory separators.`,
+	//TODO for some reason this is not tabbed right? needs \t to align. - I think it's because its refined outside of a primitive
+	// I KNOW YOU HATE THIS IM SORRY MG :(
+	windowsPath: `\t\t\tYour path is not formatted properly for Windows. \n\t\t\t\tPlease use "\\\\" or "/" for directory separators.`,
 	qBitAutoTMM:
 		"Using Automatic Torrent Management in qBittorrent without flatLinking enabled can result in unintended behavior.",
 	needsLinkDir:
@@ -86,7 +88,10 @@ function transformDurationString(durationStr: string, ctx: RefinementCtx) {
  * @return path if valid formatting
  */
 function checkValidPathFormat(path: string, ctx: RefinementCtx) {
-	if (!path.includes(sep)) {
+	if (
+		(sep === "\\" && !path.includes(`\x5C`) && !path.includes("/")) ||
+		path === "."
+	) {
 		addZodIssue(path, ZodErrorMessages.windowsPath, ctx);
 	}
 	return path;
@@ -125,8 +130,8 @@ export const VALIDATION_SCHEMA = z
 			.transform((value) => (typeof value === "boolean" ? value : false)),
 		skipRecheck: z.boolean(),
 		maxDataDepth: z.number().gte(1),
-		torrentDir: z.string().transform(checkValidPathFormat).nullish(),
-		outputDir: z.string(),
+		torrentDir: z.string().transform(checkValidPathFormat),
+		outputDir: z.string().transform(checkValidPathFormat),
 		includeEpisodes: z.boolean(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,9 @@ export const ANIME_REGEX =
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
+export const RP_REGEX =
+	/(\b(?<type>(REPACK|PROPER|\d\v\d)\d?))|(?<arrtype>(Proper|v\d))\b/;
+
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 
 export const IGNORED_FOLDERS_REGEX =
@@ -56,6 +59,7 @@ export enum Decision {
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
 	RELEASE_GROUP_MISMATCH = "RELEASE_GROUP_MISMATCH",
 	BLOCKED_RELEASE = "BLOCKED_RELEASE",
+	PROPER_REPACK_MISMATCH = "PROPER_REPACK_MISMATCH",
 }
 
 export enum MatchMode {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,7 @@ export const ANIME_REGEX =
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 
-export const RP_REGEX =
+export const REPACK_PROPER_REGEX =
 	/(\b(?<type>(REPACK|PROPER|\d\v\d)\d?))|(?<arrtype>(Proper|v\d))\b/;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -5,7 +5,7 @@ import {
 	Decision,
 	MatchMode,
 	RELEASE_GROUP_REGEX,
-	RP_REGEX,
+	REPACK_PROPER_REGEX,
 	TORRENT_CACHE_FOLDER,
 } from "./constants.js";
 import { db } from "./db.js";
@@ -79,8 +79,9 @@ const createReasonLogger =
 				break;
 			case Decision.PROPER_REPACK_MISMATCH:
 				reason = `one is a different subsequent release - (${
-					searchee.name.match(RP_REGEX)?.groups?.type ?? "INITIAL"
-				} -> ${candidate.name.match(RP_REGEX)?.groups?.type ?? "INITIAL"})`;
+					searchee.name.match(REPACK_PROPER_REGEX)?.groups?.type ??
+					"INITIAL"
+				} -> ${candidate.name.match(REPACK_PROPER_REGEX)?.groups?.type ?? "INITIAL"})`;
 				break;
 			case Decision.BLOCKED_RELEASE:
 				reason = `it matches the blocklist - ("${findBlockedStringInReleaseMaybe(
@@ -180,8 +181,8 @@ function releaseVersionDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode,
 ) {
-	const searcheeVersionType = searcheeName.match(RP_REGEX);
-	const candidateVersionType = candidateName.match(RP_REGEX);
+	const searcheeVersionType = searcheeName.match(REPACK_PROPER_REGEX);
+	const candidateVersionType = candidateName.match(REPACK_PROPER_REGEX);
 	//sets either match arrtype or type to corresponding VersionType
 
 	if (

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -5,6 +5,7 @@ import {
 	Decision,
 	MatchMode,
 	RELEASE_GROUP_REGEX,
+	RP_REGEX,
 	TORRENT_CACHE_FOLDER,
 } from "./constants.js";
 import { db } from "./db.js";
@@ -75,6 +76,11 @@ const createReasonLogger =
 					?.trim()} -> ${candidate.name
 					.match(RELEASE_GROUP_REGEX)?.[0]
 					?.trim()})`;
+				break;
+			case Decision.PROPER_REPACK_MISMATCH:
+				reason = `one is a different subsequent release - (${
+					searchee.name.match(RP_REGEX)?.groups?.type ?? "INITIAL"
+				} -> ${candidate.name.match(RP_REGEX)?.groups?.type ?? "INITIAL"})`;
 				break;
 			case Decision.BLOCKED_RELEASE:
 				reason = `it matches the blocklist - ("${findBlockedStringInReleaseMaybe(
@@ -169,7 +175,24 @@ function sizeDoesMatch(resultSize, searchee) {
 	const upperBound = length + fuzzySizeThreshold * length;
 	return resultSize >= lowerBound && resultSize <= upperBound;
 }
+function releaseVersionDoesMatch(
+	searcheeName: string,
+	candidateName: string,
+	matchMode: MatchMode,
+) {
+	const searcheeVersionType = searcheeName.match(RP_REGEX);
+	const candidateVersionType = candidateName.match(RP_REGEX);
+	//sets either match arrtype or type to corresponding VersionType
 
+	if (
+		searcheeVersionType?.[0].toLowerCase() !==
+			candidateVersionType?.[0].toLowerCase() ||
+		(searcheeVersionType?.groups?.arrtype && candidateVersionType)
+	) {
+		return matchMode !== MatchMode.SAFE;
+	}
+	return searcheeVersionType === candidateVersionType;
+}
 function releaseGroupDoesMatch(
 	searcheeName: string,
 	candidateName: string,
@@ -212,7 +235,9 @@ async function assessCandidateHelper(
 	if (!releaseGroupDoesMatch(searchee.name, name, matchMode)) {
 		return { decision: Decision.RELEASE_GROUP_MISMATCH };
 	}
-
+	if (!releaseVersionDoesMatch(searchee.name, name, matchMode)) {
+		return { decision: Decision.PROPER_REPACK_MISMATCH };
+	}
 	const result = await parseTorrentFromURL(link);
 
 	if (result.isErr()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,11 +61,15 @@ export function getTag(name: string, isVideo: boolean): MediaType {
 }
 export function determineSkipRecheck(decision: Decision): boolean {
 	const { skipRecheck } = getRuntimeConfig();
-	return decision === Decision.MATCH_PARTIAL
-		? false
-		: decision === Decision.MATCH
-			? true
-			: skipRecheck;
+	switch (decision) {
+		case Decision.MATCH:
+			return true;
+		case Decision.MATCH_SIZE_ONLY:
+			return skipRecheck;
+		case Decision.MATCH_PARTIAL:
+		default:
+			return false;
+	}
 }
 export async function time<R>(cb: () => R, times: number[]) {
 	const before = performance.now();


### PR DESCRIPTION
- [x] this refactor removes all category references in variable names and functions.
- [x] we dont worry about setting up any categories, we always use linkCategory.
- [x] added determineTags() for returning the string to pass for tagging. things to note is that 'cross-seed-data' is used in addition to cross-seed for data matches.
- [x] refactored the logic surrounding isSubfolderContentLayout() - i think this will work now almost all the time.
- [x] removed unused Category interface and unused imports
- [x] extracted all the values for the keys send in formData for injection into the helpers (except for save_path obviously)
- [x] flatLinking && searchee.infoHash still seems to me the best means of validating forcing autoTMM to off.


### TODO
- [x] initial testing
