### PR TITLE
feat(git-workflow): add templates and labeling for PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: report a bug
+description:
+    "please be prepared to see us through understanding and troubleshooting
+    steps, providing configurations and verbose log files, and context and
+    behavior experienced."
+labels: ["bug", "triage"]
+body:
+    - type: checkboxes
+      attributes:
+          label:
+              have you checked for any existing open/closed tickets that are the
+              same or similar to your issue?
+          description:
+              use search to see if an open or closed issue already exists for
+              yor bug. if a closed ticket exists, please link to it in your
+              ticket.
+          options:
+              - label: i've searched far and wide!
+                required: true
+    - type: checkboxes
+      attributes:
+          label:
+              i have gone to the Discord server for support and/or acknowledge
+              that this is a bug and not a support issue
+          description:
+              if this behavior is a result of not being able to properly
+              configure something, for example, please visit our Discord
+              (https://discord.gg/jpbUFzS5Wb) prior to making any GitHub Issues.
+              these issues are strictly for bugs and feature requests.
+          options:
+              - label: i've tried to solve this already
+                required: true
+    - type: textarea
+      attributes:
+          label: what's happening surrounding the bug? (context)
+          description:
+              details about your setup, relevant config options, and which
+              clients you are using.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: reproducing the bug
+          description: how can we reliably get the bug to present itself
+          placeholder: |
+              1. deploy to docker
+              2. set these options in config.js
+              3. trigger a 'search'
+      validations:
+          required: false
+    - type: textarea
+      attributes:
+          label: what should be happening?
+          description: tell us the behavior you think should be occurring.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: your setup
+          description: |
+              examples:
+                - Debian 12.5
+                - Torznab via Prowlarr 1.17.0.4440
+                - Docker | node | yarn
+                - more/misc details here
+          value: |
+              - os: 
+              - prowlarr/jackett: 
+              - docker: 
+              - misc:
+          render: markdown
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: config.js (REDACT SENSITIVE INFORMATION)
+          description: |
+              please provide us with the config.js you are using when the bug presented itself. 
+
+              **MAKE SURE YOU REDACT ALL SENSITIVE PASSWORDS, PUBLIC IP ADDRESSES, AND APIKEYS.**
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: verbose logs
+          description: |
+              in order to facilitate fixing your bug, we need the context and logs surrounding the issue
+              Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+              Additionally, any additional info? Screenshots? References? Anything that will give us more context about the issue you are encountering!
+      validations:
+          required: true
+    - type: checkboxes
+      attributes:
+          label:
+              failure or refusal to provide the information we require to
+              address bugs will result in potential closure of the issue.
+          description:
+              we require verbose logs and your config.js in order to get a full
+              picture of the issue. if you are unable to copy paste text and
+              describe what is occurring to resolve it, please do not open a
+              ticket. if you require help with any of this please visit our
+              discord. (https://discord.gg/jpbUFzS5Wb)
+          options:
+              - label:
+                    i acknowledge that i have searched existing issues, read the
+                    documentation and faq, read the logs to see if the answer
+                    was provided in error messaging, and attempted to get
+                    support via the Discord prior to submitting this issue.
+                required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+    - name: reach out to us via Discord
+      url: https://discord.gg/jpbUFzS5Wb
+      about:
+          get live support to resolve install, configuration, and technical
+          issues not related to bugs/errors

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: feature request
+description: "i have an idea for cross-seed"
+labels: ["feature", "triage"]
+body:
+    - type: checkboxes
+      attributes:
+          label: does an existing issue/feature request already exist?
+          description:
+              use the search to see if an open or closed issue already exists
+              for the feature you are requesting. if a request exists and is
+              closed please read the existing issue to see why, and if you still
+              wish to make an issue link to it in your issue.
+          options:
+              - label: i've searched far and wide!
+                required: true
+    - type: textarea
+      attributes:
+          label: does your feature request solve a problem you're facing?
+          description:
+              tell us about the problem or use-case it solves. be sure to
+              include relevant options, version information if relevant (latest
+              is not a version), and any necessary context to the request.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: what would you like for cross-seed to do?
+          description: tell us your desired behavior we should implement
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label:
+              what are you currently doing, if anything, to solve or work around
+              the issue?
+          description:
+              if there are workarounds, even incomplete ones, please tell us
+              what they are.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: additional comments
+          description: |
+              please provide us with any resources or context that may help us understand this situation and the proposed solution better.
+
+              Tip: you can attach images or log files by clicking this area to highlight it and then dragging files in.
+      validations:
+          required: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,45 @@
+"documentation":
+    - "README.md"
+"config":
+    - "src/config.template.cjs"
+    - "src/cmd.ts"
+    - "src/configSchema.ts"
+    - "src/configuration.ts"
+    - "src/runtimeConfig.ts"
+"dependencies":
+    - "package.json"
+    - "package-lock.json"
+    - "Dockerfile"
+    - "tsconfig.json"
+    - "renovate.json"
+    - ".eslintrc.json"
+    - changed-files:
+          - any-glob-to-any-file: ["src/migrations/**"]
+"bt client":
+    - changed-files:
+          - any-glob-to-any-file: ["src/clients/**"]
+"logging":
+    - "src/logger.ts"
+    - "src/pushNotifier.ts"
+"search":
+    - "src/dataFile.ts"
+    - "src/indexers.ts"
+    - "src/parseTorrent.ts"
+    - "src/preFilter.ts"
+    - "src/searchee.ts"
+    - "src/decide.ts"
+    - "src/torznab.ts"
+    - "src/torrent.ts"
+    - "src/action.ts"
+"daemon":
+    - "src/server.ts"
+    - "src/jobs.ts"
+    - "src/cmd.ts"
+    - "src/server.ts"
+    - "src/auth.ts"
+    - "src/decide.ts"
+"security":
+    - "src/auth.ts"
+"workflow":
+    - changed-files:
+          - any-glob-to-any-file: [".github/**"]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: label pr
+
+on:
+    push:
+        branches:
+            - master
+    pull_request_target:
+
+jobs:
+    triage:
+        permissions:
+            contents: read
+            pull-requests: write
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/labeler@v5
+              with:
+                  sync-labels: true


### PR DESCRIPTION
sets up templates for issues with a bunch of requirements, acknowledgements, and questions.

configured a label workflow to automatically assign triage to all PR's based on modified files, as well as relevant labels for files modified.

once someone manually checks the triage'd PRs, removing the triage will signify that it has been labeled by a human

- [x] validate paths in labeler.yml for label application
- [x] approve messaging in templates