### PR TITLE
enhancement(utils/arr): refactor getTag() and formatTitleForSearching() around MediaTypes

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -245,7 +245,7 @@ function shouldSearchIndexer(mediaType: MediaType, caps: TorznabCats) {
 		case MediaType.BOOK:
 			return caps.book;
 		case MediaType.OTHER:
-			return false;
+			return true;
 	}
 }
 export async function queryRssFeeds(): Promise<Candidate[]> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,7 +63,7 @@ export function getTag(searchee: Searchee): MediaType {
 		? MediaType.EPISODE
 		: SEASON_REGEX.test(stem)
 			? MediaType.SEASON
-			: MOVIE_REGEX.test(stem)
+			: MOVIE_REGEX.test(stem) && hasExt(searchee, VIDEO_EXTENSIONS)
 				? MediaType.MOVIE
 				: hasExt(searchee, VIDEO_EXTENSIONS) && ANIME_REGEX.test(stem)
 					? MediaType.ANIME

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,8 +55,8 @@ export function humanReadableSize(bytes: number) {
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
 export function getTag(searchee: Searchee): MediaType {
-	function hasExt(searchee: Searchee, extensions: string[]) {
-		return extensions.includes(path.extname(searchee.name));
+	function hasExt(searchee: Searchee, exts: string[]) {
+		return searchee.files.some((f) => exts.includes(path.extname(f.name)));
 	}
 	const stem = stripExtension(searchee.name);
 	return EP_REGEX.test(stem)


### PR DESCRIPTION
Requires movies to pass the regex and contain a video file. This prevents audio and books with years in the title from matching. Episodes and seasons do not need the check.

shouldSearchIndexer also updated to search if MediaType is other rather than not. The checked categories are enough of a restriction on useless searches and so we should assume an edge case in this scenario.

Also now checks for extension on file names rather than searchee name.