### PR TITLE
bug(client/qbit): Check for subfolder when linking and properly set category

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -372,7 +372,7 @@ export default class QBittorrent implements TorrentClient {
 				flatLinking && searchee.infoHash ? autoTMM.toString() : "false",
 			);
 			formData.append("contentLayout", path ? "Original" : contentLayout);
-			formData.append("category", linkCategory);
+			formData.append("category", category);
 			formData.append("tags", tags);
 			const skipRecheck = determineSkipRecheck(decision);
 			formData.append("skip_checking", skipRecheck.toString());


### PR DESCRIPTION
`isSubfolderContentLayout()` was basically always returning false. Updated the check and is correct from my testing. Also simplified `getDownloadDir()` as it was making unnecessary calls and checks. 