### PR TITLE
bug(clients/qbit): Properly handle subfolder layout

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -195,6 +195,9 @@ export async function performAction(
 			linkedFilesRootResult.unwrapErrOrThrow() === "MISSING_DATA"
 		) {
 			logger.warn("Falling back to non-linking.");
+			if (searchee.path) {
+				destinationDir = dirname(searchee.path);
+			}
 		} else {
 			logInjectionResult(
 				InjectionResult.FAILURE,

--- a/src/action.ts
+++ b/src/action.ts
@@ -134,13 +134,12 @@ async function linkAllFilesInMetafile(
 				e === "NOT_FOUND" ? "TORRENT_NOT_FOUND" : e,
 			);
 		}
-		sourceRoot =
+		sourceRoot = join(
+			downloadDirResult.unwrapOrThrow(),
 			searchee.files.length === 1
-				? join(
-						downloadDirResult.unwrapOrThrow(),
-						searchee.files[0].path,
-					)
-				: join(downloadDirResult.unwrapOrThrow(), searchee.name);
+				? searchee.files[0].path
+				: searchee.name,
+		);
 	}
 
 	if (!existsSync(sourceRoot)) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -134,7 +134,9 @@ async function linkAllFilesInMetafile(
 				e === "NOT_FOUND" ? "TORRENT_NOT_FOUND" : e,
 			);
 		}
-		sourceRoot = join(downloadDirResult.unwrapOrThrow(), searchee.name);
+		sourceRoot = searchee.files.length === 1
+			? join(downloadDirResult.unwrapOrThrow(), searchee.files[0].path)
+			: join(downloadDirResult.unwrapOrThrow(), searchee.name);
 	}
 
 	if (!existsSync(sourceRoot)) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -134,9 +134,13 @@ async function linkAllFilesInMetafile(
 				e === "NOT_FOUND" ? "TORRENT_NOT_FOUND" : e,
 			);
 		}
-		sourceRoot = searchee.files.length === 1
-			? join(downloadDirResult.unwrapOrThrow(), searchee.files[0].path)
-			: join(downloadDirResult.unwrapOrThrow(), searchee.name);
+		sourceRoot =
+			searchee.files.length === 1
+				? join(
+						downloadDirResult.unwrapOrThrow(),
+						searchee.files[0].path,
+					)
+				: join(downloadDirResult.unwrapOrThrow(), searchee.name);
 	}
 
 	if (!existsSync(sourceRoot)) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -184,14 +184,19 @@ export default class QBittorrent implements TorrentClient {
 			return TORRENT_TAG;
 		}
 		if (category.endsWith(TORRENT_CATEGORY_SUFFIX)) {
-			return `${category},${TORRENT_TAG}`;
+			if (duplicateCategories) {
+				return `${TORRENT_TAG},${category}`;
+			} else {
+				return TORRENT_TAG;
+			}
 		}
 
 		if (searchee.path) {
-			return `${TORRENT_TAG}-data,${TORRENT_TAG}`;
+			return `${TORRENT_TAG},${TORRENT_TAG}-data`;
+		} else if (duplicateCategories) {
+			return `${TORRENT_TAG},${category}${TORRENT_CATEGORY_SUFFIX}`;
 		} else {
-			const suffix = duplicateCategories ? TORRENT_CATEGORY_SUFFIX : "";
-			return `${category}${suffix},${TORRENT_TAG}`;
+			return TORRENT_TAG;
 		}
 	}
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -70,7 +70,7 @@ interface TorrentInfo {
 	uploaded_session: number;
 	upspeed: number;
 }
-
+/* Unused variable - removed for build.
 interface TorrentFiles {
 	availability: number;
 	index: number;
@@ -81,7 +81,7 @@ interface TorrentFiles {
 	progress: number;
 	size: number;
 }
-
+*/
 interface TorrentConfiguration {
 	save_path: string;
 	isComplete: boolean;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -10,10 +10,7 @@ import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import {
-	determineSkipRecheck,
-	extractCredentialsFromUrl,
-} from "../utils.js";
+import { determineSkipRecheck, extractCredentialsFromUrl } from "../utils.js";
 import { TorrentClient } from "./TorrentClient.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { BodyInit } from "undici-types";
@@ -245,8 +242,10 @@ export default class QBittorrent implements TorrentClient {
 		searchee: Searchee,
 		torrentInfo: TorrentInfo,
 	): Promise<string> {
-		const subfolderContentLayout =
-			await this.isSubfolderContentLayout(searchee, torrentInfo);
+		const subfolderContentLayout = await this.isSubfolderContentLayout(
+			searchee,
+			torrentInfo,
+		);
 		if (subfolderContentLayout) {
 			return dirname(torrentInfo.content_path);
 		}
@@ -261,9 +260,11 @@ export default class QBittorrent implements TorrentClient {
 		const responseText = await this.request("/torrents/info", "");
 		const torrents = JSON.parse(responseText);
 		if (hash) {
-			return torrents.filter((torrent) => 
-				hash === torrent.infoHash_v1 ||
-				hash === torrent.infoHash_v2);
+			return torrents.filter(
+				(torrent) =>
+					hash === torrent.infoHash_v1 ||
+					hash === torrent.infoHash_v2,
+			);
 		}
 		return torrents;
 	}
@@ -291,7 +292,10 @@ export default class QBittorrent implements TorrentClient {
 		};
 	}
 
-	async isSubfolderContentLayout(searchee: Searchee, torrentInfo: TorrentInfo): Promise<boolean> {
+	async isSubfolderContentLayout(
+		searchee: Searchee,
+		torrentInfo: TorrentInfo,
+	): Promise<boolean> {
 		if (searchee.files.length > 1) return false;
 		if (dirname(searchee.files[0].path) !== ".") return false;
 		return dirname(torrentInfo.content_path) !== torrentInfo.save_path;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -401,7 +401,7 @@ export default class QBittorrent implements TorrentClient {
 
 			await this.addTorrent(formData);
 			//if we have a linked file and skiprecheck is false
-			if (skipRecheck) {
+			if (!skipRecheck) {
 				await new Promise((resolve) => setTimeout(resolve, 100));
 				await this.recheckTorrent(newTorrent.infoHash);
 			}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -155,7 +155,8 @@ export default class QBittorrent implements TorrentClient {
 			if (response.status === 403 && retries > 0) {
 				logger.verbose({
 					label: Label.QBITTORRENT,
-					message: "Received 403 from API. Logging in again and retrying",
+					message:
+						"Received 403 from API. Logging in again and retrying",
 				});
 				await this.login();
 				return this.request(path, body, headers, retries - 1);
@@ -306,10 +307,18 @@ export default class QBittorrent implements TorrentClient {
 			);
 		}
 
-		const { progress, save_path, auto_tmm, category } = searchResult[0];
+		const { save_path, state, auto_tmm, category } = searchResult[0];
+		const isComplete = [
+			"uploading",
+			"pausedUP",
+			"queuedUP",
+			"stalledUP",
+			"checkingUP",
+			"forcedUP",
+		].includes(state);
 		return {
 			save_path,
-			isComplete: progress === 1,
+			isComplete: isComplete,
 			autoTMM: auto_tmm,
 			category,
 		};

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -311,6 +311,7 @@ export default class QBittorrent implements TorrentClient {
 		const isComplete = [
 			"uploading",
 			"pausedUP",
+			"stoppedUP",
 			"queuedUP",
 			"stalledUP",
 			"checkingUP",

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -268,7 +268,9 @@ export default class QBittorrent implements TorrentClient {
 		const torrents = await this.getAllTorrentInfo();
 		return torrents.filter(
 			(torrent) =>
-				hash === torrent.infohash_v1 || hash === torrent.infohash_v2,
+				hash === torrent.hash ||
+				hash === torrent.infohash_v1 ||
+				hash === torrent.infohash_v2,
 		);
 	}
 


### PR DESCRIPTION
Did some digging into how subfolder layout is handled. It should be completely fixed now. Problem was if a torrent with a single file that naturally had a folder, it would get the incorrect path.

Also getting torrent info in a way that doesn't rely on infohash versions.

Potentially fixed bug with rechecking searchee instead of newTorrent in deluge.