### PR TITLE
feat(decide): adds subsequent releases by same group filtering

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,8 +18,9 @@ export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[([~/|-]\s?(?!\d{4})(?<altTitle>.+?)[)\]~-]?\s?)?[_.\s-]?(?:\(?(?<year>(?:19|20)\d{2})\)?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})(?:v\d)?[\])_.\s-]/i;
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
+
 export const RP_REGEX =
-	/\b(?<type>(REPACK|PROPER)\d?)|(?<arrtype>(Proper)\d?)\b/;
+	/(\b(?<type>(REPACK|PROPER|\d\v\d)\d?))|(?<arrtype>(Proper|v\d))\b/;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,8 @@ export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[([~/|-]\s?(?!\d{4})(?<altTitle>.+?)[)\]~-]?\s?)?[_.\s-]?(?:\(?(?<year>(?:19|20)\d{2})\)?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})(?:v\d)?[\])_.\s-]/i;
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
-export const RP_REGEX = /\b(?<type>(REPACK|PROPER)\d?)\b/i;
+export const RP_REGEX =
+	/\b(?<type>(REPACK|PROPER)\d?)|(?<arrtype>(Proper)\d?)\b/;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[([~/|-]\s?(?!\d{4})(?<altTitle>.+?)[)\]~-]?\s?)?[_.\s-]?(?:\(?(?<year>(?:19|20)\d{2})\)?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})(?:v\d)?[\])_.\s-]/i;
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
+export const RP_REGEX = /\b(?<type>(REPACK|PROPER)\d?)\b/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 
@@ -56,6 +57,7 @@ export enum Decision {
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
 	RELEASE_GROUP_MISMATCH = "RELEASE_GROUP_MISMATCH",
 	BLOCKED_RELEASE = "BLOCKED_RELEASE",
+	PROPER_REPACK_MISMATCH = "PROPER_REPACK_MISMATCH",
 }
 
 export enum MatchMode {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -187,7 +187,7 @@ function releaseVersionDoesMatch(
 	if (
 		searcheeVersionType?.[0].toLowerCase() !==
 			candidateVersionType?.[0].toLowerCase() ||
-		searcheeVersionType?.groups?.arrtype
+		(searcheeVersionType?.groups?.arrtype && candidateVersionType)
 	) {
 		return matchMode !== MatchMode.SAFE;
 	}

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -180,16 +180,18 @@ function releaseVersionDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode,
 ) {
-	const searcheeVersionType = searcheeName.match(RP_REGEX)?.[0];
-	const candidateVersionType = candidateName.match(RP_REGEX)?.[0];
-	if (!searcheeVersionType || !candidateVersionType) {
+	const searcheeVersionType = searcheeName.match(RP_REGEX);
+	const candidateVersionType = candidateName.match(RP_REGEX);
+	//sets either match arrtype or type to corresponding VersionType
+
+	if (
+		searcheeVersionType?.[0].toLowerCase() !==
+			candidateVersionType?.[0].toLowerCase() ||
+		searcheeVersionType?.groups?.arrtype
+	) {
 		return matchMode !== MatchMode.SAFE;
 	}
-	return (
-		searcheeVersionType === candidateVersionType ||
-		(matchMode !== MatchMode.SAFE &&
-			searcheeVersionType !== candidateVersionType)
-	);
+	return searcheeVersionType === candidateVersionType;
 }
 function releaseGroupDoesMatch(
 	searcheeName: string,


### PR DESCRIPTION
if the release group does a repack or propers, this release is certainly not the same as the previous and not cross-seedable.

this filters (last in the chain of filtering) whether the searchee and candidate are of the same "type" - repack and proper as well as repack# are supported.

considered adding internal, but not all trackers tag internals as such and could result in false-negatives

risky/partial will still operate on the basis of if there is a proper or repack in the name it returns true regardless of if they match to work with their aggregating of REPACK and PROPER into a PROPER.

if searchee matches arr's naming then it will act based on risky/partial being set.
