### PR TITLE
bug(action/linking): Linking dest files properly

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -1,13 +1,6 @@
 import chalk from "chalk";
-import {
-	existsSync,
-	linkSync,
-	mkdirSync,
-	readdirSync,
-	statSync,
-	symlinkSync,
-} from "fs";
-import { basename, dirname, join, relative, resolve } from "path";
+import { existsSync, linkSync, mkdirSync, statSync, symlinkSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { getClient } from "./clients/TorrentClient.js";
 import {
 	Action,
@@ -61,7 +54,6 @@ function logInjectionResult(
 /**
  * @return the root of linked files.
  */
-
 function linkExactTree(
 	newMeta: Metafile,
 	destinationDir: string,

--- a/src/action.ts
+++ b/src/action.ts
@@ -59,6 +59,9 @@ function linkExactTree(
 	destinationDir: string,
 	sourceRoot: string,
 ): string {
+	if (newMeta.files.length === 1) {
+		return fuzzyLinkOneFile(newMeta, destinationDir, sourceRoot);
+	}
 	for (const newFile of newMeta.files) {
 		const srcFilePath = join(dirname(sourceRoot), newFile.path);
 		const destFilePath = join(destinationDir, newFile.path);
@@ -72,12 +75,11 @@ function linkExactTree(
  * @return the root of linked file.
  */
 function fuzzyLinkOneFile(
-	searchee: Searchee,
 	newMeta: Metafile,
 	destinationDir: string,
 	sourceRoot: string,
 ): string {
-	const srcFilePath = join(dirname(sourceRoot), searchee.files[0].path);
+	const srcFilePath = sourceRoot;
 	const destFilePath = join(destinationDir, newMeta.files[0].path);
 	mkdirSync(dirname(destFilePath), { recursive: true });
 	linkFile(srcFilePath, destFilePath);
@@ -159,10 +161,12 @@ async function linkAllFilesInMetafile(
 	}
 
 	if (decision === Decision.MATCH) {
-		return resultOf(linkExactTree(newMeta, fullLinkDir, sourceRoot));
+		return resultOf(
+			linkExactTree(newMeta, fullLinkDir, sourceRoot)
+		);
 	} else if (decision === Decision.MATCH_SIZE_ONLY) {
 		return resultOf(
-			fuzzyLinkOneFile(searchee, newMeta, fullLinkDir, sourceRoot),
+			fuzzyLinkOneFile(newMeta, fullLinkDir, sourceRoot),
 		);
 	} else {
 		return resultOf(

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -315,6 +315,7 @@ export default class Deluge implements TorrentClient {
 				if (!determineSkipRecheck(decision)) {
 					// when paused, libtorrent doesnt start rechecking
 					// leaves torrent ready to download - ~99%
+					await new Promise((resolve) => setTimeout(resolve, 1000));
 					await this.call<string>("core.force_recheck", [
 						newTorrent.infoHash,
 					]);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -142,7 +142,7 @@ export default class QBittorrent implements TorrentClient {
 	): Promise<string> {
 		logger.verbose({
 			label: Label.QBITTORRENT,
-			message: `Making request (${retries}) to ${path} with body ${body!.toString()}`,
+			message: `Making request (${retries}) to ${path} with body ${JSON.stringify(body)}`,
 		});
 
 		let response: Response = new Response();

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -408,7 +408,7 @@ export default class QBittorrent implements TorrentClient {
 			await this.addTorrent(formData);
 			//if we have a linked file and skiprecheck is false
 			if (!skipRecheck) {
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 1000));
 				await this.recheckTorrent(newTorrent.infoHash);
 			}
 


### PR DESCRIPTION
This updates the linking for MATCH and MATCH_FILES_ONLY to support the new sourceRoot which handles subfolder layout. This was done in the style of MATCH_PARTIAL.

Also updated the timeout before rechecking to 1s in qbit and deluge.