### PR TITLE
feat(match): ensemble matching for episodes

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -174,6 +174,44 @@ function linkFuzzyTree(
 	return { contentPath, alreadyExisted, linkedNewFiles };
 }
 
+function linkVirtualSearchee(
+	searchee: Searchee,
+	newMeta: Metafile,
+	destinationDir: string,
+	options: { ignoreMissing: boolean },
+): LinkResult {
+	let alreadyExisted = false;
+	let linkedNewFiles = false;
+	const availableFiles = searchee.files.slice();
+	for (const newFile of newMeta.files) {
+		let matchedSearcheeFiles = availableFiles.filter(
+			(searcheeFile) => searcheeFile.length === newFile.length,
+		);
+		if (matchedSearcheeFiles.length > 1) {
+			matchedSearcheeFiles = matchedSearcheeFiles.filter(
+				(searcheeFile) => searcheeFile.name === newFile.name,
+			);
+		}
+		if (matchedSearcheeFiles.length) {
+			const srcFilePath = matchedSearcheeFiles[0].path; // Absolute path
+			const destFilePath = join(destinationDir, newFile.path);
+			const index = availableFiles.indexOf(matchedSearcheeFiles[0]);
+			availableFiles.splice(index, 1);
+			if (existsSync(destFilePath)) {
+				alreadyExisted = true;
+				continue;
+			}
+			if (options.ignoreMissing && !existsSync(srcFilePath)) continue;
+			mkdirSync(dirname(destFilePath), { recursive: true });
+			if (linkFile(srcFilePath, destFilePath)) {
+				linkedNewFiles = true;
+			}
+		}
+	}
+	const contentPath = join(destinationDir, newMeta.name);
+	return { contentPath, alreadyExisted, linkedNewFiles };
+}
+
 function unlinkMetafile(meta: Metafile, destinationDir: string) {
 	const file = meta.files[0];
 	let rootFolder = file.path;
@@ -213,28 +251,8 @@ export async function linkAllFilesInMetafile(
 		flatLinking ? linkDir! : join(linkDir!, tracker),
 	);
 
-	let sourceRoot: string;
-	if (searchee.path) {
-		if (!existsSync(searchee.path)) {
-			logger.error({
-				label: searchee.label,
-				message: `Linking failed, ${searchee.path} not found. Make sure Docker volume mounts are set up properly.`,
-			});
-			return resultOfErr("MISSING_DATA");
-		}
-		const result = await createSearcheeFromPath(searchee.path);
-		if (result.isErr()) {
-			return resultOfErr("TORRENT_NOT_FOUND");
-		}
-		const refreshedSearchee = result.unwrap();
-		if (
-			options.onlyCompleted &&
-			searchee.length !== refreshedSearchee.length
-		) {
-			return resultOfErr("TORRENT_NOT_COMPLETE");
-		}
-		sourceRoot = searchee.path;
-	} else {
+	let sourceRoot: string | undefined;
+	if (searchee.infoHash) {
 		const downloadDirResult = await getClient()!.getDownloadDir(
 			searchee as SearcheeWithInfoHash,
 			{ onlyCompleted: options.onlyCompleted },
@@ -259,9 +277,50 @@ export async function linkAllFilesInMetafile(
 			});
 			return resultOfErr("MISSING_DATA");
 		}
+	} else if (searchee.path) {
+		if (!existsSync(searchee.path)) {
+			logger.error({
+				label: searchee.label,
+				message: `Linking failed, ${searchee.path} not found. Make sure Docker volume mounts are set up properly.`,
+			});
+			return resultOfErr("MISSING_DATA");
+		}
+		const result = await createSearcheeFromPath(searchee.path);
+		if (result.isErr()) {
+			return resultOfErr("TORRENT_NOT_FOUND");
+		}
+		const refreshedSearchee = result.unwrap();
+		if (
+			options.onlyCompleted &&
+			searchee.length !== refreshedSearchee.length
+		) {
+			return resultOfErr("TORRENT_NOT_COMPLETE");
+		}
+		sourceRoot = searchee.path;
+	} else {
+		for (const file of searchee.files) {
+			if (!existsSync(file.path)) {
+				logger.error(
+					`Linking failed, ${file.path} not found. Make sure Docker volume mounts are set up properly.`,
+				);
+				return resultOfErr("MISSING_DATA");
+			}
+			if (
+				options.onlyCompleted &&
+				file.length !== statSync(file.path).size
+			) {
+				return resultOfErr("TORRENT_NOT_COMPLETE");
+			}
+		}
 	}
 
-	if (decision === Decision.MATCH) {
+	if (!sourceRoot) {
+		return resultOf(
+			linkVirtualSearchee(searchee, newMeta, fullLinkDir, {
+				ignoreMissing: !options.onlyCompleted,
+			}),
+		);
+	} else if (decision === Decision.MATCH) {
 		return resultOf(
 			linkExactTree(newMeta, fullLinkDir, sourceRoot, {
 				ignoreMissing: !options.onlyCompleted,

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -419,7 +419,7 @@ module.exports = {
 	 *
 	 * Each string must be prefixed with the type of block you want to use,
 	 * followed by a colon. Labels are considered tags.
-	 * "name:", "folder:", "category:", "tag:", "tracker:", "hash:", "sizeBelow:", "sizeAbove:"
+	 * "name:", "folder:", "category:", "tag:", "tracker:", "infoHash:", "sizeBelow:", "sizeAbove:"
 	 * Note that sizes are an integer for the number of bytes.
 	 * There are additional prefixes that take in a regex for more complex matching.
 	 * Read more: https://www.cross-seed.org/docs/basics/options#blocklist
@@ -436,7 +436,7 @@ module.exports = {
 		"category:icycool",
 		"tag:everybody",
 		"tracker:tracker.example.com:8080",
-		"hash:3317e6485454354751555555366a8308c1e92093",
+		"infoHash:3317e6485454354751555555366a8308c1e92093",
 		"sizeBelow:12345",
 		"sizeAbove:98765",
 	],

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -289,6 +289,15 @@ module.exports = {
 	includeNonVideos: false,
 
 	/**
+	 * Match season packs from the individual episodes you already have.
+	 *
+	 * undefined or null - disabled
+	 * 1 - must have all episodes
+	 * 0.8 - must have at least 80% of the episodes
+	 */
+	seasonFromEpisodes: 1,
+
+	/**
 	 * You should NOT modify this unless you have good reason.
 	 * The following option is the preliminary value to compare sizes of
 	 * releases for further comparison.

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -42,7 +42,7 @@ const ZodErrorMessages = {
 	fuzzySizeThresholdMax:
 		"fuzzySizeThreshold cannot be greater than 0.1 when using searchCadence or rssCadence.",
 	seasonFromEpisodesMin:
-		"seasonFromEpisodes cannot be less than 0.5 when using searchCadence",
+		"seasonFromEpisodes cannot be less than 0.5 when using searchCadence or rssCadence",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -53,10 +53,9 @@ const ZodErrorMessages = {
 		"outputDir should only contain .torrent files, cross-seed will populate and manage (https://www.cross-seed.org/docs/basics/options#outputdir)",
 	needsTorrentDir:
 		"You need to set torrentDir for rss and announce matching to work.",
-	needsInject:
-		"You need to use the 'inject' action for partial matching or seasonFromEpisodes.",
+	needsInject: "You need to use the 'inject' action for seasonFromEpisodes.",
 	needsLinkDir:
-		"You need to set a linkDir (and have your data accessible) for risky/partial matching and seasonFromEpisodes to work.",
+		"When using action 'inject', you need to set a linkDir (and have your data accessible) for risky/partial matching and seasonFromEpisodes.",
 	linkDirInOtherDirs:
 		"You cannot have your linkDir inside of your torrentDir/dataDirs/outputDir. Please adjust your paths to correct this.",
 	dataDirsInOtherDirs:
@@ -434,8 +433,7 @@ export const VALIDATION_SCHEMA = z
 		(config) =>
 			process.env.DEV ||
 			config.action === Action.INJECT ||
-			(config.matchMode !== MatchMode.PARTIAL &&
-				!config.seasonFromEpisodes),
+			!config.seasonFromEpisodes,
 		ZodErrorMessages.needsInject,
 	)
 	.refine(
@@ -445,7 +443,9 @@ export const VALIDATION_SCHEMA = z
 	.refine(
 		(config) =>
 			config.linkDir ||
-			(config.matchMode === MatchMode.SAFE && !config.seasonFromEpisodes),
+			(!config.seasonFromEpisodes &&
+				(config.action === Action.SAVE ||
+					config.matchMode === MatchMode.SAFE)),
 		ZodErrorMessages.needsLinkDir,
 	)
 	.refine((config) => {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,7 @@ export interface FileConfig {
 	outputDir?: string;
 	rtorrentRpcUrl?: string;
 	includeNonVideos?: boolean;
+	seasonFromEpisodes?: number;
 	fuzzySizeThreshold?: number;
 	excludeOlder?: string;
 	excludeRecentSearch?: string;

--- a/src/db.ts
+++ b/src/db.ts
@@ -16,3 +16,9 @@ export const db = Knex.knex({
 	migrations: { migrationSource: migrations },
 	useNullAsDefault: true,
 });
+
+export const memDB = Knex.knex({
+	client: "better-sqlite3",
+	connection: ":memory:",
+	useNullAsDefault: true,
+});

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -27,7 +27,7 @@ import { findAllSearchees } from "./pipeline.js";
 import { sendResultsNotification } from "./pushNotifier.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { SearcheeWithLabel } from "./searchee.js";
+import { createEnsembleSearchees, SearcheeWithLabel } from "./searchee.js";
 import {
 	findAllTorrentFilesInDir,
 	parseMetadataFromFilename,
@@ -631,7 +631,11 @@ export async function injectSavedTorrents(): Promise<void> {
 		message: `Found ${chalk.bold.white(torrentFilePaths.length)} torrent file(s) to inject in ${targetDirLog}`,
 	});
 	const summary = createSummary(torrentFilePaths.length);
-	const searchees = await findAllSearchees(Label.INJECT);
+	const realSearchees = await findAllSearchees(Label.INJECT);
+	const ensembleSearchees = await createEnsembleSearchees(realSearchees, {
+		useFilters: false,
+	});
+	const searchees = [...realSearchees, ...ensembleSearchees];
 	for (const [i, torrentFilePath] of torrentFilePaths.entries()) {
 		const progress = chalk.blue(`(${i + 1}/${torrentFilePaths.length})`);
 		await injectSavedTorrent(progress, torrentFilePath, summary, searchees);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -41,6 +41,7 @@ import {
 	createSearcheeFromMetafile,
 	createSearcheeFromPath,
 	createSearcheeFromTorrentFile,
+	getNewestFileAge,
 	getSeasonKey,
 	Searchee,
 	SearcheeLabel,
@@ -413,6 +414,7 @@ async function pushEnsembleForCandidate(
 		title: ensembleTitle,
 		files: files,
 		length: totalLength,
+		mtimeMs: await getNewestFileAge(files.map((f) => f.path)),
 		label: searcheeLabel,
 	});
 	logger.verbose({

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -399,16 +399,18 @@ async function pushEnsembleForCandidate(
 	}
 	// Get searchee.length by total size of each episode (average if multiple files for episode)
 	const uniqueElements = new Set(ensemble.map((e) => e.element));
-	const totalLength = [...uniqueElements].reduce((acc, cur) => {
-		const elements = ensemble.filter(
-			(e) =>
-				e.element === cur &&
-				files.some((f) => f.path === e.absolute_path),
-		);
-		const avg =
-			elements.reduce((a, c) => a + c.length, 0) / elements.length;
-		return acc + avg;
-	}, 0);
+	const totalLength = Math.round(
+		[...uniqueElements].reduce((acc, cur) => {
+			const elements = ensemble.filter(
+				(e) =>
+					e.element === cur &&
+					files.some((f) => f.path === e.absolute_path),
+			);
+			const avg =
+				elements.reduce((a, c) => a + c.length, 0) / elements.length;
+			return acc + avg;
+		}, 0),
+	);
 	searchees.push({
 		name: ensembleTitle,
 		title: ensembleTitle,

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -15,7 +15,12 @@ import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { getNewestFileAge, Searchee, SearcheeWithLabel } from "./searchee.js";
+import {
+	getSearcheeNewestFileAge,
+	Searchee,
+	SearcheeWithLabel,
+	SearcheeWithoutInfoHash,
+} from "./searchee.js";
 import { indexerDoesSupportMediaType } from "./torznab.js";
 import {
 	comparing,
@@ -305,7 +310,10 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		seasonFromEpisodes &&
 		!searchee.infoHash &&
 		!searchee.path &&
-		earliest_last_search < (await getNewestFileAge(searchee))
+		earliest_last_search <
+			(await getSearcheeNewestFileAge(
+				searchee as SearcheeWithoutInfoHash,
+			))
 	) {
 		return true;
 	}

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -15,7 +15,7 @@ import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee, SearcheeWithLabel } from "./searchee.js";
+import { getNewestFileAge, Searchee, SearcheeWithLabel } from "./searchee.js";
 import { indexerDoesSupportMediaType } from "./torznab.js";
 import {
 	comparing,
@@ -262,7 +262,8 @@ type TimestampDataSql = {
 };
 
 export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
-	const { excludeOlder, excludeRecentSearch } = getRuntimeConfig();
+	const { excludeOlder, excludeRecentSearch, seasonFromEpisodes } =
+		getRuntimeConfig();
 	const enabledIndexers = await getEnabledIndexers();
 	const mediaType = getMediaType(searchee);
 	const timestampDataSql: TimestampDataSql = (await db("searchee")
@@ -300,6 +301,14 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 
 	const { earliest_first_search, latest_first_search, earliest_last_search } =
 		timestampDataSql;
+	if (
+		seasonFromEpisodes &&
+		!searchee.infoHash &&
+		!searchee.path &&
+		earliest_last_search < (await getNewestFileAge(searchee))
+	) {
+		return true;
+	}
 
 	const skipBefore = excludeOlder
 		? nMsAgo(excludeOlder)

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -18,6 +18,7 @@ export interface RuntimeConfig {
 	includeSingleEpisodes: boolean;
 	verbose: boolean;
 	includeNonVideos: boolean;
+	seasonFromEpisodes?: number;
 	fuzzySizeThreshold: number;
 	excludeOlder?: number;
 	excludeRecentSearch?: number;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -407,7 +407,10 @@ export function getReleaseGroup(stem: string): string | null {
 		: parsedGroupMatchString;
 }
 
-const logReason = (reason: string, options: { useFilters: boolean }): void => {
+const logEnsemble = (
+	reason: string,
+	options: { useFilters: boolean },
+): void => {
 	if (!options.useFilters) return;
 	logger.verbose({
 		label: Label.PREFILTER,
@@ -570,7 +573,7 @@ function createVirtualSeasonSearchee(
 		const highestEpisode = Math.max(...(episodes as number[]));
 		const availPct = episodes.length / highestEpisode;
 		if (options.useFilters && availPct < seasonFromEpisodes) {
-			logReason(
+			logEnsemble(
 				`Skipping virtual searchee for ${ensembleTitle} episodes as there's only ${episodes.length}/${highestEpisode} (${availPct.toFixed(2)} < ${seasonFromEpisodes.toFixed(2)})`,
 				options,
 			);
@@ -599,20 +602,20 @@ function createVirtualSeasonSearchee(
 	}
 	seasonSearchee.mtimeMs = newestFileAge;
 	if (seasonSearchee.files.length < minEpisodes) {
-		logReason(
+		logEnsemble(
 			`Skipping virtual searchee for ${ensembleTitle} episodes as only ${seasonSearchee.files.length} episode files were found (min: ${minEpisodes})`,
 			options,
 		);
 		return null;
 	}
 	if (options.useFilters && Date.now() - newestFileAge < ms("8 days")) {
-		logReason(
+		logEnsemble(
 			`Skipping virtual searchee for ${ensembleTitle} episodes as some are below the minimum age of 8 days: ${humanReadableDate(newestFileAge)}`,
 			options,
 		);
 		return null;
 	}
-	logReason(
+	logEnsemble(
 		`Created virtual searchee for ${ensembleTitle}: ${episodeSearchees.size} episodes - ${seasonSearchee.files.length} files - ${humanReadableSize(seasonSearchee.length)}`,
 		options,
 	);
@@ -625,7 +628,7 @@ export async function createEnsembleSearchees(
 ): Promise<SearcheeWithLabel[]> {
 	const { seasonFromEpisodes } = getRuntimeConfig();
 	if (!seasonFromEpisodes) return [];
-	logReason(`Creating virtual searchees for seasons...`, options);
+	logEnsemble(`Creating virtual searchees for seasons...`, options);
 
 	const { keyMap, ensembleTitleMap } = organizeEnsembleKeys(
 		allSearchees,
@@ -647,7 +650,7 @@ export async function createEnsembleSearchees(
 		);
 		if (seasonSearchee) seasonSearchees.push(seasonSearchee);
 	}
-	logReason(
+	logEnsemble(
 		`Created ${seasonSearchees.length} virtual season searchees...`,
 		options,
 	);

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -130,14 +130,15 @@ export async function getNewestFileAge(
 export async function getSearcheeNewestFileAge(
 	searchee: SearcheeWithoutInfoHash,
 ): Promise<number> {
-	if (!searchee.path) {
+	const { path } = searchee;
+	if (!path) {
 		return getNewestFileAge(searchee.files.map((file) => file.path));
 	}
-	const pathStat = statSync(searchee.path);
+	const pathStat = statSync(path);
 	if (pathStat.isFile()) return pathStat.mtimeMs;
 	return getNewestFileAge(
 		searchee.files.map((file) =>
-			getAbsoluteFilePath(searchee.path!, file.path, false),
+			getAbsoluteFilePath(path, file.path, false),
 		),
 	);
 }

--- a/src/signalHandlers.ts
+++ b/src/signalHandlers.ts
@@ -1,7 +1,8 @@
-import { db } from "./db.js";
+import { db, memDB } from "./db.js";
 
 async function exitGracefully() {
 	await db.destroy();
+	await memDB.destroy();
 	process.exit();
 }
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -35,7 +35,12 @@ import {
 import { Label, logger } from "./logger.js";
 import { Candidate } from "./pipeline.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { getNewestFileAge, Searchee, SearcheeWithLabel } from "./searchee.js";
+import {
+	getSearcheeNewestFileAge,
+	Searchee,
+	SearcheeWithLabel,
+	SearcheeWithoutInfoHash,
+} from "./searchee.js";
 import {
 	cleanTitle,
 	combineAsyncIterables,
@@ -848,7 +853,10 @@ async function getAndLogIndexers(
 		if (
 			isEnsemble &&
 			entry.lastSearched &&
-			entry.lastSearched < (await getNewestFileAge(searchee))
+			entry.lastSearched <
+				(await getSearcheeNewestFileAge(
+					searchee as SearcheeWithoutInfoHash,
+				))
 		) {
 			return true;
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,14 +362,18 @@ export function extractInt(str: string): number {
 	return parseInt(str.match(/\d+/)![0]);
 }
 
-export function getFuzzySizeFactor(): number {
-	const { fuzzySizeThreshold } = getRuntimeConfig();
-	return fuzzySizeThreshold;
+export function getFuzzySizeFactor(searchee: Searchee): number {
+	const { fuzzySizeThreshold, seasonFromEpisodes } = getRuntimeConfig();
+	return seasonFromEpisodes && !searchee.infoHash && !searchee.path
+		? 1 - seasonFromEpisodes
+		: fuzzySizeThreshold;
 }
 
-export function getMinSizeRatio(): number {
-	const { fuzzySizeThreshold } = getRuntimeConfig();
-	return 1 - fuzzySizeThreshold;
+export function getMinSizeRatio(searchee: Searchee): number {
+	const { fuzzySizeThreshold, seasonFromEpisodes } = getRuntimeConfig();
+	return seasonFromEpisodes && !searchee.infoHash && !searchee.path
+		? seasonFromEpisodes
+		: 1 - fuzzySizeThreshold;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,9 @@ import { File, Searchee } from "./searchee.js";
 type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
 
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
+	[P in K]: undefined;
+};
 
 export function isTruthy<T>(value: T): value is Truthy<T> {
 	return Boolean(value);


### PR DESCRIPTION
This feature allows grabbing rss/announce and searching of seasons from individual episodes. Along with the changes in v6, this feature completes all possible matches from cross-seed aside from tweaks.

This works by introducing a new type of searchee, a virtual searchee. This is needed since the episodes are sourced from multiple torrents and folders. As such, it hash no `infoHash` or `path`. All areas of the application where these were used for logic has been updated to reflect this new possiblity. In general, this should be treated as a data based searchee if searchee.path is not need. So most checks went from `if (searchee.path)` to `if (!searchee.infoHash)` so that virtual searchees are included.

Virtual searchees also have absolute file paths instead of relative to make linking easier. This required some small changes when linking as well as changes in perfect matches. For a perfect match, when the item is a virtual searchee it only requires a name match on each file rather than path.

To support rss/announce, the information needed to be cached. I opted to use an in memory database as I did not want to add to the existing which would need migrations. For 2k entries, it takes about ~3s on startup and about 1MB of memory.

This feature works best with search. Due to the nature of the problem, it's easier to find matches by searching rather than from rss/announce, especially for anime.

Also, I added a check to see if the size changed for data based searches and report `TORRENT_NOT_COMPLETE` if it hash. A similar check was done for ensemble but on each file.

---

The implementation is to parse titles and put them in a standard format `cleanTitle.season.resolution.source-RlsGrp` called key. As such two new regexs were added for resolution and source. These are necessary to restrict searching for mixed resolutions and sources. Once there is more than 2 distinct episodes that all have the same key, it's eligible to be searched. The searchee name will be the key while the files will be the absolute path to the largest file in each episode torrent.

Some additional checks are put into place. The highest episode number is used as the total number in the season. We then check for the presence of all episodes down to E01 and if more than the `seasonFromEpisodes` is missing, it won't be created. It also checks to ensure that the file with the newest modified time is at least 8 days old since most episodes are released weekly. Of course this will search if there is a mid season break and get no results but the alternative would be to use a sonarr (likely will later). To account for this, if the age of the newest episode is after its last search time, we will search it again immediately (assuming it's more than 8 days old).