### PR TITLE
fix(zod/checkvalidpath): move path formatting logic after fs validation fails

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -84,8 +84,10 @@ function transformDurationString(durationStr: string, ctx: RefinementCtx) {
  */
 function checkValidPathFormat(path: string, ctx: RefinementCtx) {
 	if (
-		(sep === "\\" && !path.includes(`\\`) && !path.includes("/")) ||
-		path === "."
+		sep === "\\" &&
+		!path.includes(`\\`) &&
+		!path.includes("/") &&
+		path !== "."
 	) {
 		addZodIssue(path, ZodErrorMessages.windowsPath, ctx);
 	}

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -1,5 +1,4 @@
 import ms from "ms";
-import { sep } from "path";
 import { ErrorMapCtx, RefinementCtx, z, ZodIssueOptionalMessage } from "zod";
 import { Action, LinkType, MatchMode } from "./constants.js";
 import { logger } from "./logger.js";
@@ -15,7 +14,6 @@ const ZodErrorMessages = {
 	fuzzySizeThreshold: "fuzzySizeThreshold must be between 0 and 1.",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
-	windowsPath: `\t\t\tYour path is not formatted properly for Windows. \n\t\t\t\tPlease use "\\\\" or "/" for directory separators.`,
 	qBitAutoTMM:
 		"Using Automatic Torrent Management in qBittorrent without flatLinking enabled can result in unintended behavior.",
 	needsLinkDir:
@@ -79,22 +77,6 @@ function transformDurationString(durationStr: string, ctx: RefinementCtx) {
 }
 
 /**
- * helper function for directory validation
- * @return path if valid formatting
- */
-function checkValidPathFormat(path: string, ctx: RefinementCtx) {
-	if (
-		sep === "\\" &&
-		!path.includes(`\\`) &&
-		!path.includes("/") &&
-		path !== "."
-	) {
-		addZodIssue(path, ZodErrorMessages.windowsPath, ctx);
-	}
-	return path;
-}
-
-/**
  * an object of the zod schema
  * each are named after what they are intended to validate
  */
@@ -105,29 +87,18 @@ export const VALIDATION_SCHEMA = z
 			message: ZodErrorMessages.delay,
 		}),
 		torznab: z.array(z.string().url()),
-		dataDirs: z
-			.array(
-				z
-					.string()
-					.transform((value, ctx) =>
-						value && value.length > 0
-							? checkValidPathFormat(value, ctx)
-							: null,
-					),
-			)
-
-			.nullish(),
+		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
 		linkCategory: z.string().nullish(),
-		linkDir: z.string().transform(checkValidPathFormat).nullish(),
+		linkDir: z.string().nullish(),
 		linkType: z.nativeEnum(LinkType),
 		flatLinking: z
 			.boolean()
 			.nullish()
 			.transform((value) => (typeof value === "boolean" ? value : false)),
 		maxDataDepth: z.number().gte(1),
-		torrentDir: z.string().transform(checkValidPathFormat).nullable(),
-		outputDir: z.string().transform(checkValidPathFormat),
+		torrentDir: z.string().nullable(),
+		outputDir: z.string(),
 		includeEpisodes: z.boolean(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -33,7 +33,7 @@ async function verifyPath(
 			if (sep === "\\" && !path.includes("\\") && !path.includes("/")) {
 				logger.error(
 					"\tIt may not be formatted properly for Windows.\n" +
-						'Make sure to use "\\\\" or "/" for directory separators.',
+						'\t\t\t\tMake sure to use "\\\\" or "/" for directory separators.',
 				);
 			}
 		} else {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -12,6 +12,7 @@ import { stat, access, constants } from "fs/promises";
  * validates existence, permission, and that a path is a directory
  * @param path string of path to validate
  * @param optionName name of the configuration key
+ * @param permissions number (see constants in calling function) of permission
  * @returns true if path exists and has required permission
  */
 async function verifyPath(

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,3 +1,4 @@
+import { sep } from "path";
 import { CrossSeedError } from "./errors.js";
 import { Label, logger } from "./logger.js";
 import { Action } from "./constants.js";
@@ -28,6 +29,12 @@ async function verifyPath(
 			logger.error(
 				`\tYour ${optionName} "${path}" is not a valid directory on the filesystem.`,
 			);
+			if (sep === "\\" && !path.includes("\\") && !path.includes("/")) {
+				logger.error(
+					"\tIt may not be formatted properly for Windows.\n" +
+						'Please use "\\\\"or "/" for directory separators.',
+				);
+			}
 		} else {
 			logger.error(
 				`\tYour ${optionName} "${path}" has invalid permissions.`,

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -32,7 +32,7 @@ async function verifyPath(
 			if (sep === "\\" && !path.includes("\\") && !path.includes("/")) {
 				logger.error(
 					"\tIt may not be formatted properly for Windows.\n" +
-						'Please use "\\\\"or "/" for directory separators.',
+						'Make sure to use "\\\\" or "/" for directory separators.',
 				);
 			}
 		} else {


### PR DESCRIPTION
had inverted logic of `path === '.'` instead of `!==`

inverted the logic to allow for `.` as a path.