### PR TITLE
fix(pipeline): check existence of path before creation

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -321,10 +321,13 @@ export async function main(): Promise<void> {
 	const { outputDir, linkDir } = getRuntimeConfig();
 	const { samples, hashesToExclude } = await findSearchableTorrents();
 
-	fs.mkdirSync(outputDir, { recursive: true });
-	if (linkDir) {
+	if (!fs.existsSync(outputDir)) {
+		fs.mkdirSync(outputDir, { recursive: true });
+	}
+	if (linkDir && !fs.existsSync(linkDir)) {
 		fs.mkdirSync(linkDir, { recursive: true });
 	}
+
 	const totalFound = await findMatchesBatch(samples, hashesToExclude);
 
 	logger.info({


### PR DESCRIPTION
in the case of windows users using a drive letter only for their paths (`X:\\`) then mkdir will fail for operation not permitted, as you cannot create a drive letter.

this will check if the path exists before creation, if so it wont attempt to create it preventing a stack from being thrown.

```node:fs:1373
  const result = binding.mkdir(
                         ^

Error: EPERM: operation not permitted, mkdir 'Z:\'
    at Object.mkdirSync (node:fs:1373:26)
    at main (file:///C:/Users/Audio.Main/AppData/Roaming/npm/node_modules/cross-seed/dist/pipeline.js:183:8)
    at async Command.<anonymous> (file:///C:/Users/Audio.Main/AppData/Roaming/npm/node_modules/cross-seed/dist/cmd.js:235:9)
    at async Command.parseAsync (C:\Users\Audio.Main\AppData\Roaming\npm\node_modules\cross-seed\node_modules\commander\lib\command.js:923:5)
    at async file:///C:/Users/Audio.Main/AppData/Roaming/npm/node_modules/cross-seed/dist/cmd.js:244:1 {
  errno: -4048,
  code: 'EPERM',
  syscall: 'mkdir',
  path: 'Z:\\'
}
```