### PR TITLE
feat(search/cache): use cache to remove duplicate queries

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -216,7 +216,7 @@ module.exports = {
 	 * searchees. Setting this to higher values will result in more searchees
 	 * and more API hits to your indexers.
 	 */
-	maxDataDepth: 1,
+	maxDataDepth: 2,
 
 	/**
 	 * Directory containing .torrent files.
@@ -351,7 +351,7 @@ module.exports = {
 	 * "30 seconds"
 	 * null
 	 */
-	snatchTimeout: undefined,
+	snatchTimeout: "30 seconds",
 
 	/**
 	 * Fail search requests that haven't responded after this long.
@@ -360,7 +360,7 @@ module.exports = {
 	 * "30 seconds"
 	 * null
 	 */
-	searchTimeout: undefined,
+	searchTimeout: "2 minutes",
 
 	/**
 	 * The number of searches to make in one run/batch.

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -116,7 +116,16 @@ export function filterDupesByName<T extends Searchee>(searchees: T[]): T[] {
 		const entry = acc.get(cur.name);
 		if (entry === undefined) {
 			acc.set(cur.name, cur);
-		} else if (cur.infoHash && !entry.infoHash) {
+			return acc;
+		}
+		if (cur.files.length > entry.files.length) {
+			acc.set(cur.name, cur);
+			return acc;
+		}
+		if (cur.files.length < entry.files.length) {
+			return acc;
+		}
+		if (cur.infoHash && !entry.infoHash) {
 			acc.set(cur.name, cur);
 		}
 		return acc;

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -82,6 +82,31 @@ export interface Caps {
 	tvIdSearch: IdSearchCaps;
 }
 
+const ALL_CAPS: Caps = {
+	search: true,
+	categories: {
+		tv: true,
+		movie: true,
+		anime: true,
+		audio: true,
+		book: true,
+	},
+	tvSearch: true,
+	movieSearch: true,
+	movieIdSearch: {
+		tvdbId: true,
+		tmdbId: true,
+		imdbId: true,
+		tvMazeId: true,
+	},
+	tvIdSearch: {
+		tvdbId: true,
+		tmdbId: true,
+		imdbId: true,
+		tvMazeId: true,
+	},
+};
+
 type TorznabSearchTechnique =
 	| []
 	| [{ $: { available: "yes" | "no"; supportedParams: string } }];
@@ -191,16 +216,15 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 async function createTorznabSearchQueries(
 	searchee: Searchee,
 	mediaType: MediaType,
-	caps?: Caps,
+	caps: Caps,
 	parsedMedia?: ParsedMedia,
 ): Promise<TorznabParams[]> {
 	const stem = stripExtension(searchee.name);
-	let relevantIds: IdSearchParams = {};
-	if (caps && parsedMedia) {
-		relevantIds = await getRelevantArrIds(caps, parsedMedia);
-	}
+	const relevantIds: IdSearchParams = parsedMedia
+		? await getRelevantArrIds(caps, parsedMedia)
+		: {};
 	const useIds = Object.values(relevantIds).some(isTruthy);
-	if (mediaType === MediaType.EPISODE && (!caps || caps.tvSearch)) {
+	if (mediaType === MediaType.EPISODE && caps.tvSearch) {
 		const match = stem.match(EP_REGEX);
 		const groups = match!.groups!;
 		return [
@@ -214,7 +238,7 @@ async function createTorznabSearchQueries(
 				...relevantIds,
 			},
 		] as const;
-	} else if (mediaType === MediaType.SEASON && (!caps || caps.tvSearch)) {
+	} else if (mediaType === MediaType.SEASON && caps.tvSearch) {
 		const match = stem.match(SEASON_REGEX);
 		const groups = match!.groups!;
 		return [
@@ -225,7 +249,7 @@ async function createTorznabSearchQueries(
 				...relevantIds,
 			},
 		] as const;
-	} else if (mediaType === MediaType.MOVIE && (!caps || caps.movieSearch)) {
+	} else if (mediaType === MediaType.MOVIE && caps.movieSearch) {
 		return [
 			{
 				t: "movie",
@@ -234,14 +258,14 @@ async function createTorznabSearchQueries(
 			},
 		] as const;
 	}
-	if (useIds && (!caps || caps.tvSearch) && parsedMedia?.series) {
+	if (useIds && caps.tvSearch && parsedMedia?.series) {
 		const eps = parsedMedia.episodes;
 		const season = eps.length > 0 ? eps[0].seasonNumber : undefined;
 		const ep = eps.length === 1 ? eps[0].episodeNumber : undefined;
 		return [
 			{ t: "tvsearch", q: undefined, season, ep, ...relevantIds },
 		] as const;
-	} else if (useIds && (!caps || caps.movieSearch) && parsedMedia?.movie) {
+	} else if (useIds && caps.movieSearch && parsedMedia?.movie) {
 		return [{ t: "movie", q: undefined, ...relevantIds }] as const;
 	} else if (mediaType === MediaType.ANIME) {
 		return getAnimeQueries(stem).map((animeQuery) => ({
@@ -260,7 +284,9 @@ async function createTorznabSearchQueries(
 
 export async function getSearchString(searchee: Searchee): Promise<string> {
 	const mediaType = getMediaType(searchee);
-	const params = (await createTorznabSearchQueries(searchee, mediaType))[0];
+	const params = (
+		await createTorznabSearchQueries(searchee, mediaType, ALL_CAPS)
+	)[0];
 	const season = params.season !== undefined ? `.S${params.season}` : "";
 	const ep = params.ep !== undefined ? `.E${params.ep}` : "";
 	return `${params.q}${season}${ep}`.toLowerCase();


### PR DESCRIPTION
`cross-seed search` will now never perform duplicate queries. After searchee creation, the torznab search is calculated for each and those with the same are grouped back to back. When searching, the `IndexerCandidates` from the last search is cached and if it applies to the current search will be used (the map will ALWAYS have a size of 1, indexers not searched by previous are searched and added to cache). This allows duplicate queries to only hit each indexer once (per `cross-seed search`) and to be assessed near each other. This is mainly useful if you have multiple variations of a torrent like: different groups, resolution, source, etc which are not duplicates but will have duplicate queries. From my testing, my queries were cut in half.

These grouped searchees are ordered by most files first, then if .torrent based. We prefer most files first as that reduces the chance of a `MATCH_PARTIAL` happening when another searchee could have been a full match. I also changed how dupes are defined. Rather than just name, I check within the grouped searchees and find ones with the same size and number of files, preferring torrent based.

A nice benefit of the implementation is that if the previous searchee needed to search an indexer than the next wasn't going to, the results are still used by the next. Meaning that whenever we search for something, all searchees that care about the query will update their decisions, effectively ignoring `excludeRecentSearch` and `excludeOlder` if we are making the search anyways. This won't be the case initially but will eventually be true once a `excludeRecentSearch` cycle completes.

---
Updated some defaults in the config. Set `snatchTimeout` to 30s and `searchTimeout` to 2m. I think this is much better than leaving it at infinite. I also changed back `maxDataDepth` to 2. With the new caching, there is no risk of duplicate queries. And while partial reduces the need to go above a value of 1, in the cases of multi season releases 2 will be useful.