### PR TITLE
Refactor Result type

### DIFF
--- a/src/Result.ts
+++ b/src/Result.ts
@@ -32,10 +32,6 @@ class OkResult<T> {
 	orElse(): T {
 		return this.contents;
 	}
-
-	toArray(): [T] {
-		return [this.contents];
-	}
 }
 
 class ErrResult<U> {
@@ -72,10 +68,6 @@ class ErrResult<U> {
 	orElse<T>(t: T): T {
 		return t;
 	}
-
-	toArray(): [] {
-		return [];
-	}
 }
 
 export type Result<T, U> = OkResult<T> | ErrResult<U>;
@@ -86,4 +78,8 @@ export function resultOf<T, U>(value: T): Result<T, U> {
 
 export function resultOfErr<T, U>(value: U): Result<T, U> {
 	return new ErrResult(value);
+}
+
+export function isOk<T, U>(result: Result<T, U>): result is OkResult<T> {
+	return result.isOk();
 }

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -1,78 +1,84 @@
-export interface Result<T, U> {
-	isOk(): boolean;
-	isErr(): boolean;
-	mapOk<R>(mapper: (t: T) => R): Result<R, U>;
-	mapErr<R>(mapper: (u: U) => R): Result<T, R>;
-	unwrapOrThrow(errToThrow?: Error): T;
-	unwrapErrOrThrow(): U;
-}
-
-class OkResult<T, U> implements Result<T, U> {
+class OkResult<T> {
 	private readonly contents: T;
 
 	constructor(contents: T) {
 		this.contents = contents;
 	}
 
-	isOk() {
+	isOk(): this is OkResult<T> {
 		return true;
 	}
 
-	isErr() {
+	isErr(): false {
 		return false;
 	}
 
-	mapOk<R>(mapper: (t: T) => R): Result<R, U> {
+	mapOk<R>(mapper: (t: T) => R): OkResult<R> {
 		return new OkResult(mapper(this.contents));
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	mapErr<R>(mapper: (u: U) => R): Result<T, R> {
-		return this as unknown as Result<T, R>;
+	mapErr(): OkResult<T> {
+		return this;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	unwrapOrThrow(errToThrow?: Error): T {
+	unwrap(): T {
 		return this.contents;
 	}
 
-	unwrapErrOrThrow(): U {
-		throw new Error("Tried to unwrap an OkResult's error");
+	unwrapOrThrow(): T {
+		return this.contents;
+	}
+
+	orElse(): T {
+		return this.contents;
+	}
+
+	toArray(): [T] {
+		return [this.contents];
 	}
 }
 
-class ErrResult<T, U> implements Result<T, U> {
+class ErrResult<U> {
 	private readonly contents: U;
 
 	constructor(contents: U) {
 		this.contents = contents;
 	}
 
-	isOk(): boolean {
+	isOk(): this is OkResult<never> {
 		return false;
 	}
 
-	isErr(): boolean {
+	isErr(): this is ErrResult<U> {
 		return true;
 	}
 
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	mapOk<R>(mapper: (t: T) => R): Result<R, U> {
-		return this as unknown as Result<R, U>;
+	mapOk(): ErrResult<U> {
+		return this;
 	}
 
-	mapErr<R>(mapper: (u: U) => R): Result<T, R> {
+	mapErr<R>(mapper: (u: U) => R): ErrResult<R> {
 		return new ErrResult(mapper(this.contents));
 	}
 
-	unwrapOrThrow(errToThrow?: Error): T {
-		throw errToThrow ?? new Error("Tried to unwrap an ErrResult's error");
-	}
-
-	unwrapErrOrThrow(): U {
+	unwrapErr(): U {
 		return this.contents;
 	}
+
+	unwrapOrThrow(errToThrow: Error): never {
+		throw errToThrow;
+	}
+
+	orElse<T>(t: T): T {
+		return t;
+	}
+
+	toArray(): [] {
+		return [];
+	}
 }
+
+export type Result<T, U> = OkResult<T> | ErrResult<U>;
 
 export function resultOf<T, U>(value: T): Result<T, U> {
 	return new OkResult(value);

--- a/src/action.ts
+++ b/src/action.ts
@@ -154,7 +154,7 @@ async function linkAllFilesInMetafile(
 			);
 		}
 		sourceRoot = join(
-			downloadDirResult.unwrapOrThrow(),
+			downloadDirResult.unwrap(),
 			searchee.files.length === 1
 				? searchee.files[0].path
 				: searchee.name,
@@ -214,10 +214,10 @@ export async function performAction(
 			decision,
 		);
 		if (linkedFilesRootResult.isOk()) {
-			destinationDir = dirname(linkedFilesRootResult.unwrapOrThrow());
+			destinationDir = dirname(linkedFilesRootResult.unwrap());
 		} else if (
 			decision === Decision.MATCH &&
-			linkedFilesRootResult.unwrapErrOrThrow() === "MISSING_DATA"
+			linkedFilesRootResult.unwrapErr() === "MISSING_DATA"
 		) {
 			logger.warn("Falling back to non-linking.");
 			if (searchee.path) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -224,7 +224,7 @@ export async function performAction(
 				destinationDir = dirname(searchee.path);
 			}
 		} else {
-			const result = linkedFilesRootResult.unwrapErrOrThrow();
+			const result = linkedFilesRootResult.unwrapErr();
 			logger.error(`Failed to link files for ${newMeta.name}: ${result}`);
 			const injectionResult =
 				result === "TORRENT_NOT_COMPLETE"

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -58,7 +58,7 @@ async function checkArrIsActive(uArrL: string, arrInstance: string) {
 	}>(uArrL, "/api");
 
 	if (arrPingCheck.isOk()) {
-		const arrPingResponse = arrPingCheck.unwrapOrThrow();
+		const arrPingResponse = arrPingCheck.unwrap();
 		if (!arrPingResponse?.current) {
 			throw new CrossSeedError(
 				`Failed to establish a connection to ${arrInstance} URL: ${uArrL}`,
@@ -145,7 +145,7 @@ async function getExternalIdsFromArr(
 	);
 
 	if (response.isOk()) {
-		const responseBody = response.unwrapOrThrow() as ParseResponse;
+		const responseBody = response.unwrap() as ParseResponse;
 		if ("movie" in responseBody) {
 			const { tvdbId, tmdbId, imdbId } = responseBody.movie;
 			return { tvdbId, imdbId, tmdbId };
@@ -258,10 +258,6 @@ export async function getAvailableArrIds(
 	searchee: Searchee,
 ): Promise<ExternalIds> {
 	const mediaType = getMediaType(searchee);
-	try {
-		const result = await scanAllArrsForExternalIds(searchee, mediaType);
-		return result.unwrapOrThrow();
-	} catch (e) {
-		return {};
-	}
+	const result = await scanAllArrsForExternalIds(searchee, mediaType);
+	return result.orElse({});
 }

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -65,7 +65,7 @@ async function checkArrIsActive(uArrL: string, arrInstance: string) {
 			);
 		}
 	} else {
-		const error = arrPingCheck.unwrapErrOrThrow();
+		const error = arrPingCheck.unwrapErr();
 		throw new CrossSeedError(
 			`Could not contact ${arrInstance} at ${uArrL}`,
 			{

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -290,7 +290,7 @@ export default class RTorrent implements TorrentClient {
 
 		const result = await this.getDownloadLocation(meta, searchee, path);
 		if (result.isErr()) {
-			switch (result.unwrapErrOrThrow()) {
+			switch (result.unwrapErr()) {
 				case "NOT_FOUND":
 					return InjectionResult.FAILURE;
 				case "TORRENT_NOT_COMPLETE":
@@ -299,7 +299,7 @@ export default class RTorrent implements TorrentClient {
 					return InjectionResult.FAILURE;
 			}
 		}
-		const { directoryBase, basePath } = result.unwrapOrThrow();
+		const { directoryBase, basePath } = result.unwrap();
 
 		const torrentFilePath = resolve(
 			outputDir,

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -184,7 +184,7 @@ export default class Transmission implements TorrentClient {
 			if (result.isErr()) {
 				return InjectionResult.FAILURE;
 			} else {
-				downloadDir = result.unwrapOrThrow();
+				downloadDir = result.unwrap();
 			}
 		}
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -251,12 +251,12 @@ async function assessCandidateHelper(
 	const result = await snatch(link, tracker);
 
 	if (result.isErr()) {
-		return result.unwrapErrOrThrow() === SnatchError.RATE_LIMITED
+		return result.unwrapErr() === SnatchError.RATE_LIMITED
 			? { decision: Decision.RATE_LIMITED }
 			: { decision: Decision.DOWNLOAD_FAILED };
 	}
 
-	const candidateMeta = result.unwrapOrThrow();
+	const candidateMeta = result.unwrap();
 
 	if (hashesToExclude.includes(candidateMeta.infoHash)) {
 		return { decision: Decision.INFO_HASH_ALREADY_EXISTS };

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -23,6 +23,7 @@ import {
 import { Label, logger } from "./logger.js";
 import { filterByContent, filterDupes, filterTimestamps } from "./preFilter.js";
 import { sendResultsNotification } from "./pushNotifier.js";
+import { isOk } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import {
 	createSearcheeFromMetafile,
@@ -275,7 +276,7 @@ async function findSearchableTorrents() {
 		const searcheeResults = await Promise.all(
 			torrents.map(createSearcheeFromTorrentFile), //also create searchee from path
 		);
-		allSearchees = searcheeResults.flatMap((r) => r.toArray());
+		allSearchees = searcheeResults.filter(isOk).map((r) => r.unwrap());
 	} else {
 		if (typeof torrentDir === "string") {
 			allSearchees.push(...(await loadTorrentDirLight(torrentDir)));
@@ -284,7 +285,9 @@ async function findSearchableTorrents() {
 			const searcheeResults = await Promise.all(
 				findSearcheesFromAllDataDirs().map(createSearcheeFromPath),
 			);
-			allSearchees.push(...searcheeResults.flatMap((t) => t.toArray()));
+			allSearchees.push(
+				...searcheeResults.filter(isOk).map((r) => r.unwrap()),
+			);
 		}
 	}
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -199,7 +199,9 @@ export async function searchForLocalTorrentByCriteria(
 				createSearcheeFromPath,
 			),
 		);
-		searchees = searcheeResults.map((t) => t.unwrapOrThrow());
+		searchees = searcheeResults.map((t) =>
+			t.unwrapOrThrow(new Error("Failed to unwrap error searchee")),
+		);
 	} else {
 		searchees = [await getTorrentByCriteria(criteria)];
 	}
@@ -273,9 +275,7 @@ async function findSearchableTorrents() {
 		const searcheeResults = await Promise.all(
 			torrents.map(createSearcheeFromTorrentFile), //also create searchee from path
 		);
-		allSearchees = searcheeResults
-			.filter((t) => t.isOk())
-			.map((t) => t.unwrapOrThrow());
+		allSearchees = searcheeResults.flatMap((r) => r.toArray());
 	} else {
 		if (typeof torrentDir === "string") {
 			allSearchees.push(...(await loadTorrentDirLight(torrentDir)));
@@ -284,11 +284,7 @@ async function findSearchableTorrents() {
 			const searcheeResults = await Promise.all(
 				findSearcheesFromAllDataDirs().map(createSearcheeFromPath),
 			);
-			allSearchees.push(
-				...searcheeResults
-					.filter((t) => t.isOk())
-					.map((t) => t.unwrapOrThrow()),
-			);
+			allSearchees.push(...searcheeResults.flatMap((t) => t.toArray()));
 		}
 	}
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -200,9 +200,7 @@ export async function searchForLocalTorrentByCriteria(
 				createSearcheeFromPath,
 			),
 		);
-		searchees = searcheeResults.map((t) =>
-			t.unwrapOrThrow(new Error("Failed to unwrap error searchee")),
-		);
+		searchees = searcheeResults.filter(isOk).map((t) => t.unwrap());
 	} else {
 		searchees = [await getTorrentByCriteria(criteria)];
 	}

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -190,7 +190,7 @@ export async function loadTorrentDirLight(
 		const searcheeResult =
 			await createSearcheeFromTorrentFile(torrentFilePath);
 		if (searcheeResult.isOk()) {
-			searchees.push(searcheeResult.unwrapOrThrow());
+			searchees.push(searcheeResult.unwrap());
 		}
 	}
 	return searchees;


### PR DESCRIPTION
The current Result type is okay, but it doesn't actually leverage Typescript's ability to catch bugs at build time. This PR does a few things:
- Result is now a **union type** of `OkResult | ErrResult`
- `unwrapOrThrow(err?: Error)` has been separated into two methods:
    - `unwrap()` this method ONLY exists on OkResult. In order to call it, you need to use `isOk` or `isErr` to do type narrowing so that TypeScript knows the method exists. 
    - `unwrapOrThrow(err: Error)` This is a convenience method to throw an error if the result is an ErrResult. It is like the old version of `unwrapOrThrow`, except the argument is now required. This exists on BOTH OkResult and ErrResult. 
    - I migrated all calls to `unwrapOrThrow()` with no arguments to use `unwrap()`, and kept calls of `unwrapOrThrow(new Error('error message'))` with one argument to use `unwrapOrThrow()`. 
- `unwrapErr()` this method ONLY exists on ErrResult. In order to call it, you need to use `isOk` or `isErr` to do type narrowing so that TypeScript knows the method exists. 
- `isOk` and `isErr` are now [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) which means they will do type narrowing. Once you call `result.isOk()`, typescript "grants you access" to calling the `unwrap()` method. 
- I added a first-class `isOk` function (not an instance method on either of the result classes) because TypeScript doesn't understand when you `.filter(r => r.isOk())`. It understands `filter(isOk)` though.
