### PR TITLE
bug(action/link): fix incorrect link paths when linking single file

### DIFF
--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -86,12 +86,16 @@ export async function createSearcheeFromTorrentFile(
 export async function createSearcheeFromPath(
 	filepath: string,
 ): Promise<Result<Searchee, Error>> {
-	const totalLength = getFilesFromDataRoot(filepath).reduce<number>(
+	const files = getFilesFromDataRoot(filepath);
+	if (files.length === 0) {
+		return resultOfErr(new Error("No files found"));
+	}
+	const totalLength = files.reduce<number>(
 		(runningTotal, file) => runningTotal + file.length,
 		0,
 	);
 	return resultOf({
-		files: getFilesFromDataRoot(filepath),
+		files: files,
 		path: filepath,
 		name: basename(filepath),
 		length: totalLength,


### PR DESCRIPTION
1. When linking MATCH, check if searchee.files.length = 1 instead of newMeta.files.length = 1 as newMeta can contain less files than searchee even for a perfect match.
2. Check if sourceRoot isFile() with fuzzyLinkOneFile() as searchee.path could be a directory but only contains a single file (usually not searched due to de-duplication preferring torrents).
3. Updated searchee creation from path to ignore searchees with no files (empty folders).