### PR TITLE
fix(regex): movie matched as episode

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,7 @@ export const TORRENT_TAG = "cross-seed";
 export const TORRENT_CATEGORY_SUFFIX = `.cross-seed`;
 
 export const EP_REGEX =
-	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?<episode>(?:E|(?<=S\d+[_.\s-]{1,3}))\d+(?:[\s-]?E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
+	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const SEASON_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =


### PR DESCRIPTION
The movie `A.Whisker.Away.2020.1080p.BluRay.Opus5.1.H.265-LYS1TH3A.mkv` was matched as an episode due to the `Opus5.1` where `s5` was season and `1` was episode.

This matched due to the support for `SXX - E?YY` anime format. But it turns out that `.` is never used instead of `-` or `_` here so it can safely be removed.

Also found `Haunted.Mansion.2023.1080P.Bluray.TrueHD.Atmos7.1.Hybrid.DoVi.HEVC.X265-FZHD` where `Atmos7.1` has the same issue.