### PR TITLE
enhancement(decide/match): support multi-file risky based matching

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -6,6 +6,7 @@ import {
 	Action,
 	ActionResult,
 	Decision,
+	DecisionAnyMatch,
 	InjectionResult,
 	LinkType,
 	SaveResult,
@@ -126,10 +127,7 @@ async function linkAllFilesInMetafile(
 	searchee: Searchee,
 	newMeta: Metafile,
 	tracker: string,
-	decision:
-		| Decision.MATCH
-		| Decision.MATCH_SIZE_ONLY
-		| Decision.MATCH_PARTIAL,
+	decision: DecisionAnyMatch,
 ): Promise<
 	Result<
 		string,
@@ -185,10 +183,7 @@ async function linkAllFilesInMetafile(
 
 export async function performAction(
 	newMeta: Metafile,
-	decision:
-		| Decision.MATCH
-		| Decision.MATCH_SIZE_ONLY
-		| Decision.MATCH_PARTIAL,
+	decision: DecisionAnyMatch,
 	searchee: Searchee,
 	tracker: string,
 ): Promise<ActionResult> {

--- a/src/action.ts
+++ b/src/action.ts
@@ -96,7 +96,7 @@ function fuzzyLinkOneFile(
 /**
  * @return the root of linked files.
  */
-function fuzzyLinkPartial(
+function linkFuzzyTree(
 	searchee: Searchee,
 	newMeta: Metafile,
 	destinationDir: string,
@@ -170,13 +170,9 @@ async function linkAllFilesInMetafile(
 		return resultOf(
 			linkExactTree(searchee, newMeta, fullLinkDir, sourceRoot),
 		);
-	} else if (decision === Decision.MATCH_SIZE_ONLY) {
-		return resultOf(
-			fuzzyLinkOneFile(searchee, newMeta, fullLinkDir, sourceRoot),
-		);
 	} else {
 		return resultOf(
-			fuzzyLinkPartial(searchee, newMeta, fullLinkDir, sourceRoot),
+			linkFuzzyTree(searchee, newMeta, fullLinkDir, sourceRoot),
 		);
 	}
 }

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,6 +1,6 @@
 import ms from "ms";
 import {
-	Decision,
+	DecisionAnyMatch,
 	InjectionResult,
 	TORRENT_TAG,
 	TORRENT_CATEGORY_SUFFIX,
@@ -297,10 +297,7 @@ export default class Deluge implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 		path?: string,
 	): Promise<InjectionResult> {
 		try {
@@ -388,10 +385,7 @@ export default class Deluge implements TorrentClient {
 		filename: string,
 		filedump: string,
 		path: string,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 	): InjectData {
 		const toRecheck = shouldRecheck(decision);
 		return [

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -1,6 +1,6 @@
 import { dirname } from "path";
 import {
-	Decision,
+	DecisionAnyMatch,
 	InjectionResult,
 	TORRENT_TAG,
 	TORRENT_CATEGORY_SUFFIX,
@@ -340,10 +340,7 @@ export default class QBittorrent implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 		path?: string,
 	): Promise<InjectionResult> {
 		const { flatLinking, linkCategory } = getRuntimeConfig();

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -3,7 +3,11 @@ import { stat, unlink, writeFile } from "fs/promises";
 import { dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
 import xmlrpc, { Client } from "xmlrpc";
-import { Decision, InjectionResult, TORRENT_TAG } from "../constants.js";
+import {
+	DecisionAnyMatch,
+	InjectionResult,
+	TORRENT_TAG,
+} from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -276,10 +280,7 @@ export default class RTorrent implements TorrentClient {
 	async inject(
 		meta: Metafile,
 		searchee: Searchee,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 		path?: string,
 	): Promise<InjectionResult> {
 		const { outputDir } = getRuntimeConfig();

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -1,5 +1,5 @@
 import { Metafile } from "../parseTorrent.js";
-import { Decision, InjectionResult } from "../constants.js";
+import { DecisionAnyMatch, InjectionResult } from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee } from "../searchee.js";
 import QBittorrent from "./QBittorrent.js";
@@ -19,10 +19,7 @@ export interface TorrentClient {
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 		path?: string,
 	) => Promise<InjectionResult>;
 	validateConfig: () => Promise<void>;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -1,4 +1,8 @@
-import { Decision, InjectionResult, TORRENT_TAG } from "../constants.js";
+import {
+	DecisionAnyMatch,
+	InjectionResult,
+	TORRENT_TAG,
+} from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -168,10 +172,7 @@ export default class Transmission implements TorrentClient {
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
-		decision:
-			| Decision.MATCH
-			| Decision.MATCH_SIZE_ONLY
-			| Decision.MATCH_PARTIAL,
+		decision: DecisionAnyMatch,
 		path?: string,
 	): Promise<InjectionResult> {
 		let downloadDir: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const ANIME_REGEX =
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
 export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[ipx])\b/i;
+export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
 
 export const REPACK_PROPER_REGEX =
 	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))|(?<arrtype>(?:Proper|v\d))\b/;
@@ -93,9 +94,12 @@ export enum Decision {
 	MATCH = "MATCH",
 	MATCH_SIZE_ONLY = "MATCH_SIZE_ONLY",
 	MATCH_PARTIAL = "MATCH_PARTIAL",
+	FUZZY_SIZE_MISMATCH = "FUZZY_SIZE_MISMATCH",
 	SIZE_MISMATCH = "SIZE_MISMATCH",
+	PARTIAL_SIZE_MISMATCH = "PARTIAL_SIZE_MISMATCH",
 	NO_DOWNLOAD_LINK = "NO_DOWNLOAD_LINK",
 	DOWNLOAD_FAILED = "DOWNLOAD_FAILED",
+	MAGNET_LINK = "MAGNET_LINK",
 	RATE_LIMITED = "RATE_LIMITED",
 	INFO_HASH_ALREADY_EXISTS = "INFO_HASH_ALREADY_EXISTS",
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
@@ -103,6 +107,19 @@ export enum Decision {
 	BLOCKED_RELEASE = "BLOCKED_RELEASE",
 	PROPER_REPACK_MISMATCH = "PROPER_REPACK_MISMATCH",
 	RESOLUTION_MISMATCH = "RESOLUTION_MISMATCH",
+}
+export type DecisionAnyMatch =
+	| Decision.MATCH
+	| Decision.MATCH_SIZE_ONLY
+	| Decision.MATCH_PARTIAL;
+export function isDecisionAnyMatch(
+	decision: Decision,
+): decision is DecisionAnyMatch {
+	return (
+		decision === Decision.MATCH ||
+		decision === Decision.MATCH_SIZE_ONLY ||
+		decision === Decision.MATCH_PARTIAL
+	);
 }
 
 export enum MatchMode {

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -127,13 +127,20 @@ export function compareFileTreesIgnoringNames(
 	candidate: Metafile,
 	searchee: Searchee,
 ): boolean {
-	const cmp = (candidate, searchee) => {
-		return searchee.length === candidate.length;
-	};
-
-	return candidate.files.every((elOfA) =>
-		searchee.files.some((elOfB) => cmp(elOfA, elOfB)),
-	);
+	for (const candidateFile of candidate.files) {
+		let matchedSearcheeFiles = searchee.files.filter(
+			(searcheeFile) => searcheeFile.length === candidateFile.length,
+		);
+		if (matchedSearcheeFiles.length > 1) {
+			matchedSearcheeFiles = matchedSearcheeFiles.filter(
+				(searcheeFile) => searcheeFile.name === candidateFile.name,
+			);
+		}
+		if (matchedSearcheeFiles.length === 0) {
+			return false;
+		}
+	}
+	return true;
 }
 
 export function comparePartialSizeOnly(
@@ -306,11 +313,7 @@ async function assessCandidateHelper(
 	}
 
 	const sizeMatch = compareFileTreesIgnoringNames(metafile, searchee);
-	if (
-		sizeMatch &&
-		matchMode !== MatchMode.SAFE &&
-		searchee.files.length === 1
-	) {
+	if (sizeMatch && matchMode !== MatchMode.SAFE) {
 		return { decision: Decision.MATCH_SIZE_ONLY, metafile };
 	}
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -1,12 +1,13 @@
-import { existsSync, writeFileSync } from "fs";
+import { existsSync, statSync, utimesSync, writeFileSync } from "fs";
 import path from "path";
 import { appDir } from "./configuration.js";
 import {
 	Decision,
+	isDecisionAnyMatch,
 	MatchMode,
 	RELEASE_GROUP_REGEX,
 	REPACK_PROPER_REGEX,
-	RESOLUTION_REGEX,
+	RES_STRICT_REGEX,
 	TORRENT_CACHE_FOLDER,
 } from "./constants.js";
 import { db } from "./db.js";
@@ -32,13 +33,13 @@ const createReasonLogger =
 		searchee: Searchee,
 		candidate: Candidate,
 	): void => {
+		if (cached) return;
 		function logReason(reason): void {
 			logger.verbose({
 				label: Label.DECIDE,
 				message: `${name} - no match for ${tracker} torrent ${Title} - ${reason}`,
 			});
 		}
-		const sizeDiff = candidate.size - searchee.length;
 
 		let reason;
 		switch (decision) {
@@ -48,17 +49,19 @@ const createReasonLogger =
 				return;
 			case Decision.MATCH:
 				return;
+			case Decision.FUZZY_SIZE_MISMATCH:
 			case Decision.SIZE_MISMATCH:
-				reason = `its size does not match - (${
-					Math.abs(sizeDiff) > 10000000 // 10MB is the rounding error
-						? `${humanReadableSize(searchee.length)} -> ${humanReadableSize(candidate.size)}`
-						: `${sizeDiff > 0 ? "+" : ""}${sizeDiff} bytes`
-				})`;
+			case Decision.PARTIAL_SIZE_MISMATCH:
+				reason = `its size does not match by ${decision}${
+					candidate.size
+						? `: ${candidate.size >= searchee.length ? "+" : ""}${humanReadableSize(candidate.size - searchee.length)}`
+						: ""
+				}`;
 				break;
 			case Decision.RESOLUTION_MISMATCH:
-				reason = `its resolution does not match - (${searchee.name
-					.match(RESOLUTION_REGEX)?.[0]
-					?.trim()} -> ${candidate.name.match(RESOLUTION_REGEX)?.[0]?.trim()})`;
+				reason = `its resolution does not match: ${
+					searchee.name.match(RES_STRICT_REGEX)?.groups?.res
+				} -> ${candidate.name.match(RES_STRICT_REGEX)?.groups?.res}`;
 				break;
 			case Decision.NO_DOWNLOAD_LINK:
 				reason = "it doesn't have a download link";
@@ -69,6 +72,9 @@ const createReasonLogger =
 			case Decision.DOWNLOAD_FAILED:
 				reason = "the torrent file failed to download";
 				break;
+			case Decision.MAGNET_LINK:
+				reason = "the torrent is a magnet link";
+				break;
 			case Decision.INFO_HASH_ALREADY_EXISTS:
 				reason = "the info hash matches a torrent you already have";
 				break;
@@ -76,31 +82,29 @@ const createReasonLogger =
 				reason = "it has a different file tree";
 				break;
 			case Decision.RELEASE_GROUP_MISMATCH:
-				reason = `it has a different release group - (${searchee.name
-					.match(RELEASE_GROUP_REGEX)?.[0]
-					?.trim()} -> ${candidate.name
-					.match(RELEASE_GROUP_REGEX)?.[0]
-					?.trim()})`;
+				reason = `it has a different release group: ${searchee.name
+					.match(RELEASE_GROUP_REGEX)
+					?.groups?.group?.trim()} -> ${candidate.name
+					.match(RELEASE_GROUP_REGEX)
+					?.groups?.group?.trim()}`;
 				break;
 			case Decision.PROPER_REPACK_MISMATCH:
-				reason = `one is a different subsequent release - (${
+				reason = `one is a different subsequent release: ${
 					searchee.name.match(REPACK_PROPER_REGEX)?.groups?.type ??
 					"INITIAL"
-				} -> ${candidate.name.match(REPACK_PROPER_REGEX)?.groups?.type ?? "INITIAL"})`;
+				} -> ${candidate.name.match(REPACK_PROPER_REGEX)?.groups?.type ?? "INITIAL"}`;
 				break;
 			case Decision.BLOCKED_RELEASE:
-				reason = `it matches the blocklist - ("${findBlockedStringInReleaseMaybe(
+				reason = `it matches the blocklist: "${findBlockedStringInReleaseMaybe(
 					searchee,
 					getRuntimeConfig().blockList,
-				)}")`;
+				)}"`;
 				break;
 			default:
 				reason = decision;
 				break;
 		}
-		if (!cached) {
-			logReason(reason);
-		}
+		logReason(reason);
 	};
 
 export function compareFileTrees(
@@ -132,7 +136,7 @@ export function compareFileTreesIgnoringNames(
 	);
 }
 
-export function compareFileTreesPartialIgnoringNames(
+export function comparePartialSizeOnly(
 	candidate: Metafile,
 	searchee: Searchee,
 ): boolean {
@@ -173,13 +177,35 @@ export function compareFileTreesPartial(
 	return availablePieces / totalPieces >= 1 - fuzzySizeThreshold;
 }
 
-function sizeDoesMatch(resultSize: number, searchee: Searchee) {
+function fuzzySizeDoesMatch(resultSize: number, searchee: Searchee) {
 	const { fuzzySizeThreshold } = getRuntimeConfig();
 
 	const { length } = searchee;
 	const lowerBound = length - fuzzySizeThreshold * length;
 	const upperBound = length + fuzzySizeThreshold * length;
 	return resultSize >= lowerBound && resultSize <= upperBound;
+}
+function resolutionDoesMatch(
+	searcheeName: string,
+	candidateName: string,
+	matchMode: MatchMode,
+) {
+	const searcheeRes = searcheeName
+		.match(RES_STRICT_REGEX)
+		?.groups?.res?.trim()
+		?.toLowerCase();
+	const candidateRes = candidateName
+		.match(RES_STRICT_REGEX)
+		?.groups?.res?.trim()
+		?.toLowerCase();
+	if (searcheeRes === candidateRes) {
+		return true;
+	}
+	// if we are unsure, pass in risky or partial mode but fail in safe mode
+	if (!searcheeRes || !candidateRes) {
+		return matchMode !== MatchMode.SAFE;
+	}
+	return searcheeRes.startsWith(candidateRes);
 }
 function releaseVersionDoesMatch(
 	searcheeName: string,
@@ -209,12 +235,12 @@ function releaseGroupDoesMatch(
 	matchMode: MatchMode,
 ) {
 	const searcheeReleaseGroup = searcheeName
-		.match(RELEASE_GROUP_REGEX)?.[0]
-		?.trim()
+		.match(RELEASE_GROUP_REGEX)
+		?.groups?.group?.trim()
 		?.toLowerCase();
 	const candidateReleaseGroup = candidateName
-		.match(RELEASE_GROUP_REGEX)?.[0]
-		?.trim()
+		.match(RELEASE_GROUP_REGEX)
+		?.groups?.group?.trim()
 		?.toLowerCase();
 	if (searcheeReleaseGroup === candidateReleaseGroup) {
 		return true;
@@ -227,20 +253,12 @@ function releaseGroupDoesMatch(
 }
 
 async function assessCandidateHelper(
-	{ link, size, name, tracker }: Candidate,
+	candidate: Candidate,
 	searchee: Searchee,
 	hashesToExclude: string[],
 ): Promise<ResultAssessment> {
 	const { matchMode, blockList } = getRuntimeConfig();
-	if (findBlockedStringInReleaseMaybe(searchee, blockList)) {
-		return { decision: Decision.BLOCKED_RELEASE };
-	}
-
-	if (size && !sizeDoesMatch(size, searchee)) {
-		return { decision: Decision.SIZE_MISMATCH };
-	}
-
-	if (!link) return { decision: Decision.NO_DOWNLOAD_LINK };
+	const { name, size, link } = candidate;
 
 	if (!releaseGroupDoesMatch(searchee.name, name, matchMode)) {
 		return { decision: Decision.RELEASE_GROUP_MISMATCH };
@@ -248,63 +266,79 @@ async function assessCandidateHelper(
 	if (!releaseVersionDoesMatch(searchee.name, name, matchMode)) {
 		return { decision: Decision.PROPER_REPACK_MISMATCH };
 	}
-	const result = await snatch(link, tracker);
+	if (size) {
+		if (!fuzzySizeDoesMatch(size, searchee)) {
+			return { decision: Decision.FUZZY_SIZE_MISMATCH };
+		}
+	} else {
+		if (!resolutionDoesMatch(searchee.name, name, matchMode)) {
+			return { decision: Decision.RESOLUTION_MISMATCH };
+		}
+	}
+	if (!link) {
+		return { decision: Decision.NO_DOWNLOAD_LINK };
+	}
 
+	if (findBlockedStringInReleaseMaybe(searchee, blockList)) {
+		return { decision: Decision.BLOCKED_RELEASE };
+	}
+
+	const result = await snatch(candidate);
 	if (result.isErr()) {
-		return result.unwrapErr() === SnatchError.RATE_LIMITED
+		const err = result.unwrapErr();
+		return err === SnatchError.RATE_LIMITED
 			? { decision: Decision.RATE_LIMITED }
-			: { decision: Decision.DOWNLOAD_FAILED };
+			: err === SnatchError.MAGNET_LINK
+				? { decision: Decision.MAGNET_LINK }
+				: { decision: Decision.DOWNLOAD_FAILED };
+	}
+	const metafile = result.unwrap();
+	cacheTorrentFile(metafile);
+	candidate.size = metafile.length; // Trackers can be wrong
+
+	if (hashesToExclude.includes(metafile.infoHash)) {
+		return { decision: Decision.INFO_HASH_ALREADY_EXISTS, metafile };
 	}
 
-	const candidateMeta = result.unwrap();
-
-	if (hashesToExclude.includes(candidateMeta.infoHash)) {
-		return { decision: Decision.INFO_HASH_ALREADY_EXISTS };
-	}
-	const sizeMatch = compareFileTreesIgnoringNames(candidateMeta, searchee);
-	const perfectMatch = compareFileTrees(candidateMeta, searchee);
-
+	const perfectMatch = compareFileTrees(metafile, searchee);
 	if (perfectMatch) {
-		return { decision: Decision.MATCH, metafile: candidateMeta };
+		return { decision: Decision.MATCH, metafile };
 	}
+
+	const sizeMatch = compareFileTreesIgnoringNames(metafile, searchee);
 	if (
 		sizeMatch &&
 		matchMode !== MatchMode.SAFE &&
 		searchee.files.length === 1
 	) {
-		return {
-			decision: Decision.MATCH_SIZE_ONLY,
-			metafile: candidateMeta,
-		};
+		return { decision: Decision.MATCH_SIZE_ONLY, metafile };
 	}
 
 	if (matchMode === MatchMode.PARTIAL) {
-		const partialSizeMatch = compareFileTreesPartialIgnoringNames(
-			candidateMeta,
-			searchee,
-		);
+		const partialSizeMatch = comparePartialSizeOnly(metafile, searchee);
 		if (!partialSizeMatch) {
-			return { decision: Decision.SIZE_MISMATCH };
+			return { decision: Decision.PARTIAL_SIZE_MISMATCH, metafile };
 		}
-
-		const partialMatch = compareFileTreesPartial(candidateMeta, searchee);
+		const partialMatch = compareFileTreesPartial(metafile, searchee);
 		if (partialMatch) {
-			return {
-				decision: Decision.MATCH_PARTIAL,
-				metafile: candidateMeta,
-			};
+			return { decision: Decision.MATCH_PARTIAL, metafile };
 		}
 	} else if (!sizeMatch) {
-		return { decision: Decision.SIZE_MISMATCH };
+		return { decision: Decision.SIZE_MISMATCH, metafile };
 	}
 
-	return { decision: Decision.FILE_TREE_MISMATCH };
+	return { decision: Decision.FILE_TREE_MISMATCH, metafile };
 }
 
 function existsInTorrentCache(infoHash: string): boolean {
-	return existsSync(
-		path.join(appDir(), TORRENT_CACHE_FOLDER, `${infoHash}.cached.torrent`),
+	const torrentPath = path.join(
+		appDir(),
+		TORRENT_CACHE_FOLDER,
+		`${infoHash}.cached.torrent`,
 	);
+	if (!existsSync(torrentPath)) return false;
+	utimesSync(torrentPath, new Date(), statSync(torrentPath).mtime);
+	return true;
 }
 
 async function getCachedTorrentFile(infoHash: string): Promise<Metafile> {
@@ -314,14 +348,13 @@ async function getCachedTorrentFile(infoHash: string): Promise<Metafile> {
 }
 
 function cacheTorrentFile(meta: Metafile): void {
-	writeFileSync(
-		path.join(
-			appDir(),
-			TORRENT_CACHE_FOLDER,
-			`${meta.infoHash}.cached.torrent`,
-		),
-		meta.encode(),
+	const torrentPath = path.join(
+		appDir(),
+		TORRENT_CACHE_FOLDER,
+		`${meta.infoHash}.cached.torrent`,
 	);
+	if (existsInTorrentCache(meta.infoHash)) return;
+	writeFileSync(torrentPath, meta.encode());
 }
 
 async function assessAndSaveResults(
@@ -336,14 +369,6 @@ async function assessAndSaveResults(
 		infoHashesToExclude,
 	);
 
-	if (
-		assessment.decision === Decision.MATCH ||
-		assessment.decision === Decision.MATCH_SIZE_ONLY ||
-		assessment.decision === Decision.MATCH_PARTIAL
-	) {
-		cacheTorrentFile(assessment.metafile!);
-	}
-
 	await db.transaction(async (trx) => {
 		const now = Date.now();
 		const { id } = await trx("searchee")
@@ -354,12 +379,7 @@ async function assessAndSaveResults(
 			searchee_id: id,
 			guid: guid,
 			decision: assessment.decision,
-			info_hash:
-				assessment.decision === Decision.MATCH ||
-				assessment.decision === Decision.MATCH_SIZE_ONLY ||
-				assessment.decision === Decision.MATCH_PARTIAL
-					? assessment.metafile!.infoHash
-					: null,
+			info_hash: assessment.metafile?.infoHash ?? null,
 			last_seen: now,
 			first_seen: now,
 		});
@@ -399,9 +419,7 @@ async function assessCandidateCaching(
 		);
 		logReason(assessment.decision, false, searchee, candidate);
 	} else if (
-		(cacheEntry.decision === Decision.MATCH ||
-			cacheEntry.decision === Decision.MATCH_SIZE_ONLY ||
-			cacheEntry.decision === Decision.MATCH_PARTIAL) &&
+		isDecisionAnyMatch(cacheEntry.decision) &&
 		infoHashesToExclude.includes(cacheEntry.infoHash)
 	) {
 		// has been added since the last run
@@ -410,9 +428,8 @@ async function assessCandidateCaching(
 			.where({ id: cacheEntry.id })
 			.update({ decision: Decision.INFO_HASH_ALREADY_EXISTS });
 	} else if (
-		(cacheEntry.decision === Decision.MATCH ||
-			cacheEntry.decision === Decision.MATCH_SIZE_ONLY ||
-			cacheEntry.decision === Decision.MATCH_PARTIAL) &&
+		isDecisionAnyMatch(cacheEntry.decision) &&
+		cacheEntry.infoHash &&
 		existsInTorrentCache(cacheEntry.infoHash)
 	) {
 		// cached match
@@ -420,11 +437,7 @@ async function assessCandidateCaching(
 			decision: cacheEntry.decision,
 			metafile: await getCachedTorrentFile(cacheEntry.infoHash),
 		};
-	} else if (
-		cacheEntry.decision === Decision.MATCH ||
-		cacheEntry.decision === Decision.MATCH_SIZE_ONLY ||
-		cacheEntry.decision === Decision.MATCH_PARTIAL
-	) {
+	} else if (isDecisionAnyMatch(cacheEntry.decision)) {
 		assessment = await assessAndSaveResults(
 			candidate,
 			searchee,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -7,6 +7,7 @@ import {
 	ActionResult,
 	Decision,
 	InjectionResult,
+	isDecisionAnyMatch,
 	SaveResult,
 } from "./constants.js";
 import {
@@ -126,11 +127,8 @@ async function findOnOtherSites(
 		},
 	);
 
-	const matches = assessments.filter(
-		(e) =>
-			e.assessment.decision === Decision.MATCH ||
-			e.assessment.decision === Decision.MATCH_SIZE_ONLY ||
-			e.assessment.decision === Decision.MATCH_PARTIAL,
+	const matches = assessments.filter((e) =>
+		isDecisionAnyMatch(e.assessment.decision),
 	);
 	const actionResults = await performActions(searchee, matches);
 	if (actionResults.includes(InjectionResult.TORRENT_NOT_COMPLETE)) {
@@ -245,11 +243,7 @@ export async function checkNewCandidateMatch(
 		hashesToExclude,
 	);
 
-	if (
-		assessment.decision !== Decision.MATCH &&
-		assessment.decision !== Decision.MATCH_SIZE_ONLY &&
-		assessment.decision !== Decision.MATCH_PARTIAL
-	) {
+	if (!isDecisionAnyMatch(assessment.decision)) {
 		return null;
 	}
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -311,11 +311,11 @@ export async function searchTorznab(
 	const timeOrCatCallout = " (filtered by category/timestamps)";
 	logger.info({
 		label: Label.TORZNAB,
-		message: `(${mediaType.toUpperCase()}) Searching ${indexersToUse.length} indexers for ${name}${
+		message: `Searching ${indexersToUse.length} indexers for ${name}${
 			indexersToUse.length < enabledIndexers.length
 				? timeOrCatCallout
 				: ""
-		}`,
+		} [${mediaType.toUpperCase()}]`,
 	});
 	const searcheeIds =
 		indexersToUse.length > 0 ? await getAvailableArrIds(searchee) : {};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ export function humanReadableSize(bytes: number) {
 	const k = 1000;
 	const sizes = ["B", "kB", "MB", "GB", "TB"];
 	// engineering notation: (coefficient) * 1000 ^ (exponent)
-	const exponent = Math.floor(Math.log(bytes) / Math.log(k));
+	const exponent = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
 	const coefficient = bytes / Math.pow(k, exponent);
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }


### PR DESCRIPTION
This mainly is to support multi-file risky based matching moving the 100% MATCH_PARTIAL matches to MATCH_SIZE_ONLY. I refactored decide.js to the state it will be downstream.

1st commit:
1. The priority of decisions 
2. Reporting more granular decisions
3. Caching all snatched .torrent files and saving infoHash with decision if present (might as well start doing this now for `cache-search-queries`). We can optionally cleanup based on modified time since it is updated each time it's used.
4. Better error message for decisions and snatch.

2nd commit:
1. Support multi-file risky based matches