### PR TITLE
fix(clients): set download path when adding torrent

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -390,6 +390,7 @@ export default class QBittorrent implements TorrentClient {
 			const formData = new FormData();
 			formData.append("torrents", buffer, filename);
 			if (path) {
+				formData.append("downloadPath", savePath);
 				formData.append("savepath", savePath);
 			}
 			formData.append(

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -134,12 +134,15 @@ module.exports = {
 	 * IF YOU ARE USING HARDLINKS, THIS MUST BE UNDER THE SAME VOLUME AS YOUR
 	 * DATADIRS. THIS PATH MUST ALSO BE ACCESSIBLE VIA YOUR TORRENT CLIENT
 	 * USING THE SAME PATH.
+	 *
+	 * We recommend reading the following FAQ entry:
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#what-linktype-should-i-use
 	 */
 	linkDir: undefined,
 
 	/**
 	 * cross-seed will use links of this type to inject data-based matches into
-	 * your client.
+	 * your client. We recommend reading the following FAQ entry:
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#what-linktype-should-i-use
 	 * Options: "symlink", "hardlink".
 	 */
@@ -166,6 +169,9 @@ module.exports = {
 	 * "partial" is like risky but allows matches if they are missing small
 	 * files like .nfo/.srt.
 	 * Options: "safe", "risky", "partial".
+	 *
+	 * We recommend reading the following FAQ entry:
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#what-linktype-should-i-use
 	 */
 	matchMode: "safe",
 


### PR DESCRIPTION
This prevents hardlinks from breaking when a torrent is moved from/to the `save_path` after rechecking a match partial and completing the torrent. Only matters if the user's `downloadPath` is on a different drive. Tested and working in qBittorrent. Need to address for other clients as well.