### PR TITLE
fix(arr/id): address typo and additional logging details

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -224,14 +224,20 @@ export async function performAction(
 				destinationDir = dirname(searchee.path);
 			}
 		} else {
+			const result = linkedFilesRootResult.unwrapErrOrThrow();
+			logger.error(`Failed to link files for ${newMeta.name}: ${result}`);
+			const injectionResult =
+				result === "TORRENT_NOT_COMPLETE"
+					? InjectionResult.TORRENT_NOT_COMPLETE
+					: InjectionResult.FAILURE;
 			logInjectionResult(
-				InjectionResult.FAILURE,
+				injectionResult,
 				tracker,
 				newMeta.name,
 				decision,
 			);
 			await saveTorrentFile(tracker, getMediaType(searchee), newMeta);
-			return InjectionResult.FAILURE;
+			return injectionResult;
 		}
 	} else if (searchee.path) {
 		// should be a MATCH, as risky requires a linkDir to be set

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -249,7 +249,7 @@ export async function getRelevantArrIds(
 
 	return {
 		tvdbid: idSearchCaps.tvdbId ? ids.tvdbId : undefined,
-		tmdbid: idSearchCaps.tvdbId ? ids.tmdbId : undefined,
+		tmdbid: idSearchCaps.tmdbId ? ids.tmdbId : undefined,
 		imdbid: idSearchCaps.imdbId ? ids.imdbId : undefined,
 	};
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -275,6 +275,7 @@ export async function searchTorznab(
 	const enabledIndexers = await getEnabledIndexers();
 
 	const name = searchee.name;
+	const mediaType = getMediaType(searchee);
 
 	// search history for name across all indexers
 	const timestampDataSql = await db("searchee")
@@ -296,7 +297,7 @@ export async function searchTorznab(
 		);
 		return (
 			indexerDoesSupportMediaType(
-				getMediaType(searchee),
+				mediaType,
 				JSON.parse(indexer.categories),
 			) &&
 			(!entry ||
@@ -310,7 +311,7 @@ export async function searchTorznab(
 	const timeOrCatCallout = " (filtered by category/timestamps)";
 	logger.info({
 		label: Label.TORZNAB,
-		message: `Searching ${indexersToUse.length} indexers for ${name}${
+		message: `(${mediaType.toUpperCase()}) Searching ${indexersToUse.length} indexers for ${name}${
 			indexersToUse.length < enabledIndexers.length
 				? timeOrCatCallout
 				: ""


### PR DESCRIPTION
addresses a typo in the relevantId function as well as additional logging surrounding mediatype and linking failures