### PR TITLE
feat(search/sonarr): add path parsing and support for sonarr season folders

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -167,11 +167,6 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			fallback(fileConfig.includeNonVideos, false),
 		)
 		.option(
-			"-e, --include-episodes",
-			"Include all episode torrents in the search (including from season packs)",
-			fallback(fileConfig.includeEpisodes, false),
-		)
-		.option(
 			"--include-single-episodes",
 			"Include single episode torrents in the search",
 			fallback(fileConfig.includeSingleEpisodes, false),
@@ -180,7 +175,6 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"--no-include-non-videos",
 			"Don't include torrents which contain non-videos",
 		)
-		.option("--no-include-episodes", "Don't include episode torrents")
 		.option(
 			"--fuzzy-size-threshold <decimal>",
 			"The size difference allowed to be considered a match.",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -47,12 +47,12 @@ module.exports = {
 
 	/**
 	 * URL(s) to your Radarr instance(s), included in the same way as torznab
-	 * URLs but for your Sonarr: note that api is not at the end. see below.
+	 * URLs but for your Radarr: note that api is not at the end. see below.
 	 *
 	 * You should order these in most likely to match -> least likely order.
 	 * They are searched sequentially as they are listed.
 	 *
-	 * This apikey parameter comes from Sonarr
+	 * This apikey parameter comes from Radarr
 	 *
 	 * Example: radarr: ["http://radarr:7878/?apikey=12345"],
 	 *
@@ -133,8 +133,9 @@ module.exports = {
 	 * to your downloaded torrent data to find matches, rather than relying
 	 * entirely on the .torrent files themselves for matching.
 	 *
-	 * If directories are entered, they must all be on the one line and they
+	 * If directories are entered, they must all be in a single option and they
 	 * need to be surrounded by brackets.
+	 *
 	 * Windows users will need to use double backslash in all paths in this
 	 * config.
 	 *
@@ -148,12 +149,11 @@ module.exports = {
 
 	/**
 	 * Defines what qBittorrent or Deluge category to set on linked torrents
-	 * Default is "cross-seed-link".
 	 *
 	 * qBittorrent: If you have linking enabled, all torrents will be injected
 	 * to this category.
 	 *
-	 * Default is "cross-seed-data".
+	 * Default is "cross-seed-link".
 	 */
 	linkCategory: "cross-seed-link",
 
@@ -252,35 +252,39 @@ module.exports = {
 	includeSingleEpisodes: false,
 
 	/**
-	 * Include torrents which contain non-video files.
+	 * Include torrents which are comprised of non-video files.
 	 * This option does not override includeEpisodes or includeSingleEpisodes.
 	 *
-	 * If this option is set to false, any folders or torrents containing ANY
-	 * non-video files will automatically be excluded from cross-seed searches.
+	 * If this option is set to false, any folders or torrents whose
+	 * totalNonVideoFilesSize / totalSize > fuzzySizeThreshold
+	 * will be excluded.
 	 *
-	 * For example, if you have .srt or .nfo files inside your folders/torrents
-	 * you would set this as true.
+	 * For example, if you have .srt or .nfo files inside a torrent, using
+	 * false will still allow the torrent to be considered for cross-seeding
+	 * while disallowing torrents that are music, games, books, etc.
 	 * For full disc based folders (not .ISO) you may wish to set this as true.
-	 * You may also want to set this as false to exclude things like music,
-	 * games, or books.
 	 *
-	 * To search for everything except episodes, use:
+	 * To search for all video media except individual episodes, use:
 	 *
 	 *		includeEpisodes: false
 	 *		includeSingleEpisodes: false
-	 *		includeNonVideos: true
+	 *		includeNonVideos: false
 	 *
-	 * To search for everything including episodes, use:
+	 * To search for  all video media including episodes, use:
 	 *
 	 *		includeEpisodes: true
-	 *		includeNonVideos: true
+	 *		includeNonVideos: false
 	 *
-	 * To search for everything except season pack episodes (data-based) use:
+	 * To search for  all video media except season pack episodes (data-based) use:
 	 *
 	 *		includeEpisodes: false
 	 *		includeSingleEpisodes: true
-	 *		includeNonVideos: true
+	 *		includeNonVideos: false
 	 *
+	 * To search for absolutely ALL types of content, including non-video, configure
+	 * your episode settings based on the above examples and use:
+	 *
+	 * 		includeNonVideos: true
 	 */
 	includeNonVideos: false,
 

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -238,22 +238,16 @@ module.exports = {
 	outputDir: ".",
 
 	/**
-	 * Whether to search for all episode torrents, including those from season
-	 * packs.
-	 * This option overrides includeSingleEpisodes when set to true.
-	 */
-	includeEpisodes: false,
-
-	/**
-	 * Whether to include single episode torrents in the search (not those from
-	 * season packs). Like `includeEpisodes` but slightly more restrictive.
-	 * true/false always match single episodes from rss and announce.
+	 * Whether to include single episode torrents in a search (not those from
+	 * season packs).
+	 *
+	 * This setting does not affect matching episodes from rss and
+	 * announce.
 	 */
 	includeSingleEpisodes: false,
 
 	/**
 	 * Include torrents which are comprised of non-video files.
-	 * This option does not override includeEpisodes or includeSingleEpisodes.
 	 *
 	 * If this option is set to false, any folders or torrents whose
 	 * totalNonVideoFilesSize / totalSize > fuzzySizeThreshold
@@ -266,18 +260,11 @@ module.exports = {
 	 *
 	 * To search for all video media except individual episodes, use:
 	 *
-	 *		includeEpisodes: false
 	 *		includeSingleEpisodes: false
 	 *		includeNonVideos: false
 	 *
-	 * To search for  all video media including episodes, use:
+	 * To search for all video media including individual episodes, use:
 	 *
-	 *		includeEpisodes: true
-	 *		includeNonVideos: false
-	 *
-	 * To search for  all video media except season pack episodes (data-based) use:
-	 *
-	 *		includeEpisodes: false
 	 *		includeSingleEpisodes: true
 	 *		includeNonVideos: false
 	 *

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -246,8 +246,8 @@ module.exports = {
 
 	/**
 	 * Whether to include single episode torrents in the search (not those from
-	 * season packs).
-	 * Like `includeEpisodes` but slightly more restrictive.
+	 * season packs). Like `includeEpisodes` but slightly more restrictive.
+	 * true/false always match single episodes from rss and announce.
 	 */
 	includeSingleEpisodes: false,
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -122,7 +122,6 @@ export const VALIDATION_SCHEMA = z
 		maxDataDepth: z.number().gte(1),
 		torrentDir: z.string().nullable(),
 		outputDir: z.string(),
-		includeEpisodes: z.boolean(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
 		fuzzySizeThreshold: z.number().positive().lte(1, {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -13,7 +13,6 @@ export interface FileConfig {
 	action?: Action;
 	pconfigVersion?: number;
 	delay?: number;
-	includeEpisodes?: boolean;
 	includeSingleEpisodes?: boolean;
 	outputDir?: string;
 	rtorrentRpcUrl?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?!(?:19|20)\d{2})(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?(?!(?:19|20)\d{2})E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const IS_MULTI_EP_REGEX = /E\d+(?:[-.]?S\d+E\d|[-.]?E\d|[-.]\d)/i;
 export const SEASON_REGEX =
-	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s](?!E\d+))/i;
+	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s]?(?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:18|19|20)\d{2})[)\]]?(?![pix])/i;
 export const ANIME_REGEX =
@@ -31,7 +31,9 @@ export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;
 export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{0,5}-)?(?<title>.*)/;
 
 export const ARR_DIR_REGEX =
-	/^(?!.*(?:(\d{3,4}[ipx])|([xh]26[4-6])|(?:(he)|a)vc))[\p{L}\s:\w'’!().,&–+-]+(?:\(\d{4}\))?\s?(?:\{(?:tm|tv|im)db(?:id)?-\w+\})?$/iu;
+	/^(?<title>(?!.*(?:(\d{3,4}[ipx])|([xh.]+26[4-6])|(mpeg)|(xvid)|(?:(he)|a)vc))[\p{L}\s:\w'’!();.,&–+-]+(?:\(\d{4}\))?)(?<id>\s[{[](?:tm|tv|im)db(?:id)?-\w+?[}\]])?$/iu;
+export const SONARR_SUBFOLDERS_REGEX =
+	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 export const AUDIO_EXTENSIONS = [
@@ -71,9 +73,6 @@ export const ALL_EXTENSIONS = [
 	...AUDIO_EXTENSIONS,
 	...BOOK_EXTENSIONS,
 ];
-
-export const IGNORED_FOLDERS_REGEX =
-	/^(S(eason )?\d{1,4}|((CD|DVD|DISC)\d{1,2}))$/i;
 
 export const TORRENT_CACHE_FOLDER = "torrent_cache";
 export const UNKNOWN_TRACKER = "UnknownTracker";

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -1,21 +1,16 @@
 import { readdirSync, statSync } from "fs";
 import { basename, extname, join } from "path";
-import {
-	IGNORED_FOLDERS_SUBSTRINGS,
-	IGNORED_FOLDERS_REGEX,
-	VIDEO_EXTENSIONS,
-} from "./constants.js";
+import { IGNORED_FOLDERS_SUBSTRINGS, VIDEO_EXTENSIONS } from "./constants.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 
 function shouldIgnorePathHeuristically(root: string, isDir: boolean) {
-	const folderBaseName = basename(root);
+	const searchBasename = basename(root);
 	if (isDir) {
-		return (
-			IGNORED_FOLDERS_SUBSTRINGS.includes(folderBaseName.toLowerCase()) ||
-			IGNORED_FOLDERS_REGEX.test(folderBaseName)
+		return IGNORED_FOLDERS_SUBSTRINGS.includes(
+			searchBasename.toLowerCase(),
 		);
 	} else {
-		return !VIDEO_EXTENSIONS.includes(extname(folderBaseName));
+		return !VIDEO_EXTENSIONS.includes(extname(searchBasename));
 	}
 }
 export function findPotentialNestedRoots(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -202,11 +202,13 @@ export async function searchForLocalTorrentByCriteria(
 	searchees.map((s) => (s.label = Label.WEBHOOK));
 	const hashesToExclude = await getInfoHashesToExclude();
 	let totalFound = 0;
+	let filtered = 0;
 	for (const [i, searchee] of searchees.entries()) {
 		const progress = chalk.blue(`(${i + 1}/${searchees.length}) `);
 		try {
 			if (!filterByContent(searchee)) {
-				return null;
+				filtered++;
+				continue;
 			}
 			const sleep = wait(delay * 1000);
 
@@ -229,6 +231,7 @@ export async function searchForLocalTorrentByCriteria(
 			logger.debug(e);
 		}
 	}
+	if (filtered === searchees.length) return null;
 	return totalFound;
 }
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -12,7 +12,7 @@ import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee } from "./searchee.js";
+import { Searchee, SearcheeWithLabel } from "./searchee.js";
 import { indexerDoesSupportMediaType } from "./torznab.js";
 import {
 	getLogString,
@@ -38,7 +38,7 @@ function isSeasonPackEpisode(searchee: Searchee): boolean {
 	);
 }
 
-export function filterByContent(searchee: Searchee): boolean {
+export function filterByContent(searchee: SearcheeWithLabel): boolean {
 	const {
 		fuzzySizeThreshold,
 		includeEpisodes,
@@ -59,6 +59,7 @@ export function filterByContent(searchee: Searchee): boolean {
 		!includeEpisodes &&
 		!includeSingleEpisodes &&
 		!isSeasonPackEp &&
+		![Label.ANNOUNCE, Label.RSS].includes(searchee.label) &&
 		EP_REGEX.test(searchee.name)
 	) {
 		logReason("it is a single episode", searchee);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -72,7 +72,7 @@ export function filterByContent(searchee: SearcheeWithLabel): boolean {
 
 	if (!includeNonVideos && nonVideoSizeRatio > fuzzySizeThreshold) {
 		logReason(
-			`nonVideoSizeRatio > fuzzySizeThreshold: ${nonVideoSizeRatio} > ${fuzzySizeThreshold}`,
+			`nonVideoSizeRatio ${nonVideoSizeRatio} > ${fuzzySizeThreshold} fuzzySizeThreshold`,
 			searchee,
 		);
 		return false;
@@ -87,7 +87,7 @@ export function filterByContent(searchee: SearcheeWithLabel): boolean {
 			SONARR_SUBFOLDERS_REGEX.test(basename(searchee.path))
 		)
 	) {
-		logReason("it is could be an arr movie/series directory", searchee);
+		logReason("it looks like an arr movie/series directory", searchee);
 		return false;
 	}
 	return true;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -29,19 +29,9 @@ function logReason(reason: string, searchee: Searchee): void {
 	});
 }
 
-function isSeasonPackEpisode(searchee: Searchee): boolean {
-	return (
-		!!searchee.path &&
-		searchee.files.length === 1 &&
-		(SEASON_REGEX.test(basename(dirname(searchee.path))) ||
-			SONARR_SUBFOLDERS_REGEX.test(basename(dirname(searchee.path))))
-	);
-}
-
 export function filterByContent(searchee: SearcheeWithLabel): boolean {
 	const {
 		fuzzySizeThreshold,
-		includeEpisodes,
 		includeNonVideos,
 		includeSingleEpisodes,
 		blockList,
@@ -53,21 +43,22 @@ export function filterByContent(searchee: SearcheeWithLabel): boolean {
 		return false;
 	}
 
-	const isSeasonPackEp = isSeasonPackEpisode(searchee);
+	if (
+		searchee.path &&
+		searchee.files.length === 1 &&
+		(SEASON_REGEX.test(basename(dirname(searchee.path))) ||
+			SONARR_SUBFOLDERS_REGEX.test(basename(dirname(searchee.path))))
+	) {
+		logReason("it is a season pack episode", searchee);
+		return false;
+	}
 
 	if (
-		!includeEpisodes &&
 		!includeSingleEpisodes &&
-		!isSeasonPackEp &&
 		![Label.ANNOUNCE, Label.RSS].includes(searchee.label) &&
 		EP_REGEX.test(searchee.name)
 	) {
 		logReason("it is a single episode", searchee);
-		return false;
-	}
-
-	if (!includeEpisodes && isSeasonPackEp) {
-		logReason("it is a season pack episode", searchee);
 		return false;
 	}
 

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -8,7 +8,7 @@ import {
 import { ResultAssessment } from "./decide.js";
 import { logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee } from "./searchee.js";
+import { SearcheeWithLabel } from "./searchee.js";
 import { formatAsList } from "./utils.js";
 
 export let pushNotifier: PushNotifier;
@@ -66,7 +66,7 @@ export class PushNotifier {
 }
 
 export function sendResultsNotification(
-	searchee: Searchee,
+	searchee: SearcheeWithLabel,
 	results: [ResultAssessment, TrackerName, ActionResult][],
 ) {
 	const name = searchee.name;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -12,7 +12,6 @@ export interface RuntimeConfig {
 	linkCategory: string;
 	torrentDir?: string;
 	outputDir: string;
-	includeEpisodes: boolean;
 	includeSingleEpisodes: boolean;
 	verbose: boolean;
 	includeNonVideos: boolean;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -1,10 +1,17 @@
 import { readdirSync, statSync } from "fs";
-import { basename, join, relative } from "path";
+import { basename, dirname, extname, join, relative } from "path";
 import { Label, logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { parseTorrentFromFilename } from "./torrent.js";
 import { WithRequired } from "./utils.js";
+import {
+	ANIME_REGEX,
+	ARR_DIR_REGEX,
+	EP_REGEX,
+	SONARR_SUBFOLDERS_REGEX,
+	VIDEO_EXTENSIONS,
+} from "./constants.js";
 
 export interface File {
 	length: number;
@@ -100,20 +107,55 @@ export async function createSearcheeFromTorrentFile(
 }
 
 export async function createSearcheeFromPath(
-	filepath: string,
+	root: string,
 ): Promise<Result<Searchee, Error>> {
-	const files = getFilesFromDataRoot(filepath);
+	const files = getFilesFromDataRoot(root);
 	if (files.length === 0) {
-		return resultOfErr(new Error("No files found"));
+		const msg = `No files found in ${root}`;
+		logger.verbose({
+			label: Label.PREFILTER,
+			message: msg,
+		});
+		return resultOfErr(new Error(msg));
 	}
 	const totalLength = files.reduce<number>(
 		(runningTotal, file) => runningTotal + file.length,
 		0,
 	);
+
+	const baseName = basename(root);
+	const seasonMatch =
+		baseName.length < 12 ? baseName.match(SONARR_SUBFOLDERS_REGEX) : null;
+	if (!seasonMatch) {
+		return resultOf({
+			files: files,
+			path: root,
+			name: baseName,
+			length: totalLength,
+		});
+	}
+	// Title is just SXX or Season XX, need to find title above or below
+	const videoFile = files.find((file) =>
+		VIDEO_EXTENSIONS.includes(extname(file.name)),
+	);
+
+	const title =
+		videoFile?.name.match(EP_REGEX)?.groups?.title ??
+		basename(dirname(root)).match(ARR_DIR_REGEX)?.groups?.title ??
+		videoFile?.name.match(ANIME_REGEX)?.groups?.title;
+	if (!title) {
+		const msg = `Could not find title for ${root} in parent directory or child files`;
+		logger.verbose({
+			label: Label.PREFILTER,
+			message: msg,
+		});
+		return resultOfErr(new Error(msg));
+	}
+
 	return resultOf({
 		files: files,
-		path: filepath,
-		name: basename(filepath),
+		path: root,
+		name: `${title} S${seasonMatch?.groups?.seasonNum}`,
 		length: totalLength,
 	});
 }

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -37,6 +37,7 @@ export interface Searchee {
 }
 
 export type SearcheeWithInfoHash = WithRequired<Searchee, "infoHash">;
+export type SearcheeWithLabel = WithRequired<Searchee, "label">;
 
 export function hasInfoHash(
 	searchee: Searchee,

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -135,7 +135,7 @@ export async function createSearcheeFromPath(
 			length: totalLength,
 		});
 	}
-	// Title is just SXX or Season XX, need to find title above or below
+	// Name is just SXX or Season XX, need to find title above or below
 	const videoFile = files.find((file) =>
 		VIDEO_EXTENSIONS.includes(extname(file.name)),
 	);
@@ -156,7 +156,7 @@ export async function createSearcheeFromPath(
 	return resultOf({
 		files: files,
 		path: root,
-		name: `${title} S${seasonMatch?.groups?.seasonNum}`,
+		name: `${title} S${seasonMatch.groups!.seasonNum}`,
 		length: totalLength,
 	});
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,9 +172,11 @@ export function getLogString(data: Metafile | Searchee, color: ChalkInstance) {
 	}
 	return data.infoHash
 		? `${color(data.name)} ${chalk.dim(`[${data.infoHash.slice(0, 8)}...]`)}`
-		: data.path
-			? color(data.path)
-			: color(data.name);
+		: !data.path
+			? color(data.name)
+			: data.name === basename(data.path)
+				? color(data.path)
+				: `${color(data.name)} ${chalk.dim(`[${data.path}]`)}`;
 }
 
 export function formatAsList(strings: string[]) {


### PR DESCRIPTION
## overview
when a path is sent via webhook or search command and matches what was previously IGNORED_FOLDERS (SONARR_SUBFOLDERS_REGEX now) regex, we will parse the path for the parent folder (series) and the dirname (season) to cart the searches. this will allow risky/partial matching to parse the path and conduct meaningful searches for sonarr libraries

### specifics
- this allows for sonarr libraries with season folders to be parsed and effectively searched with valid queries, as well as enabling season packs sourced from usenet to be searched upon completion with an import script where otherwise "Season 01" would be ignored entirely or searched erroneously as "Season 01" yielding non-matching results in 99% of cases.
- also enables includeEpisodes to effectively filter out against season folders in sonarr libraries - includeEpisodes will always ignore individual episodes within sonarr library season folders if set to false, and the opposite for true.
- also possible to leverage maxDataDepth to omit the single episodes as well in the same manner
- the behavior of `includeNonVideos` updated to allow for metadata and subs in the season folder. now if the percentage of non-video files in a folder/torrent is less than the fuzzysizethreshold as a percentage of total length it will not be excluded
- includeSingleEpisodes is always enabled for rss/announce, these are always valid to use
- removed includeEpisodes as the extra searches over includeSingleEpisodes are likely for trumped/dead episodes

# note:
**awaiting sonarr implementation of "grouped" notification events (when entire import is completed as opposed to each import)**

https://github.com/Sonarr/Sonarr/issues/4273