### PR TITLE
fix(logging/arr): check if corresponding arr is disabled before logging

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -221,6 +221,9 @@ export async function scanAllArrsForExternalIds(
 	mediaType: MediaType,
 ): Promise<Result<ExternalIds, boolean>> {
 	const uArrLs = getRelevantArrInstances(mediaType);
+	if (uArrLs.length === 0) {
+		return resultOfErr(false);
+	}
 	try {
 		for (const uArrL of uArrLs) {
 			const externalIds = await getExternalIdsFromArr(searchee, uArrL);


### PR DESCRIPTION
when there are no provided arr corresponding to the media type, it will still erroneously log that it is missing.

this adds a simple check early in the arr flow to make sure there is a corresponding URL before proceeding

rather than switch to a result for something so simple, and because of #696 being open right now, i kept this as a simple length check.

note: I'm not sure this is crucial for merging, but depending on the timeframe that #696 takes, i figured that getting something to demonstrate the problem might be best before i forget