### PR TITLE
bug(decide): fix incorrect matching due to case and punctuation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,10 @@ export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[ipx])\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
 
 export const REPACK_PROPER_REGEX =
-	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))|(?<arrtype>(?:Proper|v\d))\b/;
+	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))\b/i;
+
+export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;
+
 export const SCENE_TITLE_REGEX = /^(?:\w{0,5}-)?(?<title>.*)/i;
 
 export const ARR_DIR_REGEX =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const MOVIE_REGEX =
 export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_.\s-]?)?(?:\[?(?<title>.+?)[_.\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_.\s-]?\]?)(?:[([~/|-]\s?(?!\d{1,4})(?<altTitle>.+?)[)\]~-]?\s?)?[_.\s-]?(?:[[(]?(?<year>(?:19|20)\d{2})[)\]]?)?[[_.\s-](?:S\d{1,2})?[_.\s-]{0,3}(?:#|EP?|(?:SP))?[_.\s-]{0,3}(?<release>\d{1,4})/i;
 export const RELEASE_GROUP_REGEX =
-	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w ]+?)(?:\[.+\])?(?:\))?(?=(?:\.\w{1,5})?$)/i;
+	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w .]+?)(?:\[.+\])?(?:\))?$/i;
 export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[ipx])\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync, utimesSync, writeFileSync } from "fs";
 import path from "path";
 import { appDir } from "./configuration.js";
 import {
+	ARR_PROPER_REGEX,
 	Decision,
 	isDecisionAnyMatch,
 	MatchMode,
@@ -219,18 +220,22 @@ function releaseVersionDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode,
 ) {
-	const searcheeVersionType = searcheeName.match(REPACK_PROPER_REGEX);
-	const candidateVersionType = candidateName.match(REPACK_PROPER_REGEX);
+	const searcheeVersionType =
+		stripExtension(searcheeName).match(REPACK_PROPER_REGEX);
+	const candidateVersionType =
+		stripExtension(candidateName).match(REPACK_PROPER_REGEX);
 	const searcheeTypeStr = searcheeVersionType?.groups?.type
 		?.trim()
 		?.toLowerCase();
 	const candidateTypeStr = candidateVersionType?.groups?.type
 		?.trim()
 		?.toLowerCase();
+	const arrProperType =
+		stripExtension(searcheeName).match(ARR_PROPER_REGEX)?.groups?.arrtype;
 
 	if (
 		searcheeTypeStr !== candidateTypeStr ||
-		searcheeVersionType?.groups?.arrtype
+		(arrProperType && candidateVersionType)
 	) {
 		return matchMode !== MatchMode.SAFE;
 	}

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -19,7 +19,7 @@ import { findBlockedStringInReleaseMaybe } from "./preFilter.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 import { parseTorrentFromFilename, snatch, SnatchError } from "./torrent.js";
-import { humanReadableSize } from "./utils.js";
+import { humanReadableSize, stripExtension } from "./utils.js";
 
 export interface ResultAssessment {
 	decision: Decision;
@@ -83,9 +83,11 @@ const createReasonLogger =
 				reason = "it has a different file tree";
 				break;
 			case Decision.RELEASE_GROUP_MISMATCH:
-				reason = `it has a different release group: ${searchee.name
+				reason = `it has a different release group: ${stripExtension(
+					searchee.name,
+				)
 					.match(RELEASE_GROUP_REGEX)
-					?.groups?.group?.trim()} -> ${candidate.name
+					?.groups?.group?.trim()} -> ${stripExtension(candidate.name)
 					.match(RELEASE_GROUP_REGEX)
 					?.groups?.group?.trim()}`;
 				break;
@@ -246,11 +248,11 @@ function releaseGroupDoesMatch(
 	candidateName: string,
 	matchMode: MatchMode,
 ) {
-	const searcheeReleaseGroup = searcheeName
+	const searcheeReleaseGroup = stripExtension(searcheeName)
 		.match(RELEASE_GROUP_REGEX)
 		?.groups?.group?.trim()
 		?.toLowerCase();
-	const candidateReleaseGroup = candidateName
+	const candidateReleaseGroup = stripExtension(candidateName)
 		.match(RELEASE_GROUP_REGEX)
 		?.groups?.group?.trim()
 		?.toLowerCase();


### PR DESCRIPTION
fixes incorrect matching in cases of, for example,"Repack" being used in releases when "REPACK" is the original in either candidate or searches

splits the arrtype and proper/repack into two regex

closes #700 

- remove reliance on checking for file extensions in group regex to determine group - used stripextension prior to applying regex instead
- separate proper from arr format and case-insensitive formatting, adds a condition that candidates be a repack/proper when searches is identified as a repack/proper when its possible the searchee is from an arr library
- fix periods not being accounted for in group regex when present in group name



- [ ] needs testing through regex101 for potential outliers
- https://regex101.com/r/FqOjtj/6 (group regex with test cases)