### PR TITLE
fix(client/tm): transmission logging for non-json response

### DIFF
--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -92,7 +92,7 @@ export default class Transmission implements TorrentClient {
 				);
 			}
 		} catch (e) {
-			if (e instanceof TypeError) {
+			if (e instanceof SyntaxError) {
 				logger.error({
 					label: Label.TRANSMISSION,
 					message: `Transmission returned non-JSON response`,


### PR DESCRIPTION
corrects the throw resulting from a non-json response being a `SyntaxError` rather than `TypeError` which results in logging incomplete errors

closes #702 