### PR TITLE
fix(search/delay): value over max signed int produces default to 1s

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -8,6 +8,7 @@ import {
 	Action,
 	LinkType,
 	MatchMode,
+	NEWLINE_INDENT,
 	PROGRAM_NAME,
 	PROGRAM_VERSION,
 } from "./constants.js";
@@ -73,7 +74,7 @@ export async function validateAndSetRuntimeConfig(options: RuntimeConfig) {
 			logger.error(
 				`${
 					path.length > 0 ? `Option: ${optionLine}` : "Configuration:"
-				}\n\t\t\t\t${message}\n\t\t\t\t(https://www.cross-seed.org/docs/basics/options${
+				}${NEWLINE_INDENT}${message}${NEWLINE_INDENT}(https://www.cross-seed.org/docs/basics/options${
 					urlPath ? `#${urlPath.toLowerCase()}` : ""
 				})\n`,
 			);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
 export const TORRENT_TAG = "cross-seed";
 export const TORRENT_CATEGORY_SUFFIX = `.cross-seed`;
+export const NEWLINE_INDENT = "\n\t\t\t\t";
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;


### PR DESCRIPTION
when using a value over max signed int cross-seed will default back to 1s, producing searching behavior that essentially hammers your indexers rather than producing any semblance of a longer timeout

closes #704 