### PR TITLE
feat(decide/cache): retry cached decisions

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -289,14 +289,7 @@ program
 	.command("clear-cache")
 	.description("Clear the cache of downloaded-and-rejected torrents")
 	.action(async () => {
-		await db("decision").del();
-		await db("indexer").update({
-			status: null,
-			retry_after: null,
-			search_cap: null,
-			tv_search_cap: null,
-			movie_search_cap: null,
-		});
+		await db("decision").whereNull("info_hash").del();
 		await db.destroy();
 	});
 program

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const ANIME_REGEX =
 	/^(?:\[(?<group>.*?)\][_\s-]?)?(?:\[?(?<title>.+?)[_\s-]?(?:\(?(?:\d{1,2}(?:st|nd|rd|th))?\s?Season)?[_\s-]?\]?)(?:[([~/|-]\s?(?!\d{1,4})(?<altTitle>.+?)[)\]~-]?\s?)?[_\s-]?(?:[[(]?(?<year>(?:19|20)\d{2})[)\]]?)?[[_\s-](?:S\d{1,2})?[_\s-]{0,3}(?:#|EP?|(?:SP))?[_\s-]{0,3}(?!\d+[a-uw-z])(?<release>\d{1,4})(?!\.1)/i;
 export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w .]+?)(?:\[.+\])?(?:\))?(?:\s\[.+\])?$/i;
+export const ANIME_GROUP_REGEX = /^\s*\[(?<group>.+?)\]/i;
 export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[pix](?:\d{3,4}[pi]?)?)\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
 export const YEAR_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/i;
@@ -136,6 +137,7 @@ export enum Decision {
 	BLOCKED_RELEASE = "BLOCKED_RELEASE",
 	PROPER_REPACK_MISMATCH = "PROPER_REPACK_MISMATCH",
 	RESOLUTION_MISMATCH = "RESOLUTION_MISMATCH",
+	SOURCE_MISMATCH = "SOURCE_MISMATCH",
 }
 export type DecisionAnyMatch =
 	| Decision.MATCH
@@ -148,6 +150,15 @@ export function isAnyMatchedDecision(
 		decision === Decision.MATCH ||
 		decision === Decision.MATCH_SIZE_ONLY ||
 		decision === Decision.MATCH_PARTIAL
+	);
+}
+export function isStaticDecision(decision: Decision): boolean {
+	return (
+		decision === Decision.RELEASE_GROUP_MISMATCH ||
+		decision === Decision.RESOLUTION_MISMATCH ||
+		decision === Decision.SOURCE_MISMATCH ||
+		decision === Decision.PROPER_REPACK_MISMATCH ||
+		decision === Decision.MAGNET_LINK
 	);
 }
 

--- a/src/migrations/06-uniqueDecisions.ts
+++ b/src/migrations/06-uniqueDecisions.ts
@@ -1,0 +1,34 @@
+import Knex from "knex";
+
+async function up(knex: Knex.Knex): Promise<void> {
+	// Remove null info_hash as we may run out of memory if too many entries
+	await knex("decision").whereNull("info_hash").del();
+
+	// Remove duplicate decisions preserving the most recent one
+	await knex.raw(`
+        DELETE FROM decision
+        WHERE id NOT IN (
+            SELECT id
+            FROM (
+                SELECT id, ROW_NUMBER() OVER (PARTITION BY searchee_id, guid ORDER BY last_seen DESC) AS row_num
+                FROM decision
+            ) AS subquery
+            WHERE row_num = 1
+        )
+    `);
+
+	// Add unique constraint to prevent duplicates and add fuzzy_size_factor
+	await knex.schema.alterTable("decision", (table) => {
+		table.float("fuzzy_size_factor").defaultTo(0.02);
+		table.unique(["searchee_id", "guid"]);
+	});
+}
+
+async function down(knex: Knex.Knex): Promise<void> {
+	return knex.schema.alterTable("decision", (table) => {
+		table.dropColumn("fuzzy_size_factor");
+		table.dropUnique(["searchee_id", "guid"]);
+	});
+}
+
+export default { name: "06-uniqueDecisions", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -4,6 +4,7 @@ import timestamps from "./02-timestamps.js";
 import rateLimits from "./03-rateLimits.js";
 import auth from "./04-auth.js";
 import caps from "./05-caps.js";
+import uniqueDecisions from "./06-uniqueDecisions.js";
 
 export const migrations = {
 	getMigrations: () =>
@@ -14,6 +15,7 @@ export const migrations = {
 			rateLimits,
 			auth,
 			caps,
+			uniqueDecisions,
 		]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -104,8 +104,8 @@ async function findOnOtherSites(
 		.ignore();
 
 	const response = await searchTorznab(searchee, cachedSearch, progress);
-	const searchedIndexers =
-		response.length - cachedSearch.indexerCandidates.length;
+	const cachedIndexers = cachedSearch.indexerCandidates.length;
+	const searchedIndexers = response.length - cachedIndexers;
 	cachedSearch.indexerCandidates = response;
 
 	const results: Candidate[] = response.flatMap((e) =>
@@ -115,6 +115,12 @@ async function findOnOtherSites(
 		})),
 	);
 
+	if (response.length) {
+		logger.verbose({
+			label: Label.DECIDE,
+			message: `Assessing ${results.length} candidates for ${searchee.name} from ${searchedIndexers}|${cachedIndexers} indexers by search|cache`,
+		});
+	}
 	const assessments = await assessCandidates(
 		results,
 		searchee,

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -2,6 +2,7 @@ import { readdirSync, statSync } from "fs";
 import { basename, dirname, extname, join, relative } from "path";
 import {
 	ANIME_REGEX,
+	ANIME_GROUP_REGEX,
 	ARR_DIR_REGEX,
 	EP_REGEX,
 	RELEASE_GROUP_REGEX,
@@ -173,7 +174,7 @@ export async function createSearcheeFromPath(
 	});
 }
 
-export function getKeyMetaInfo(stem: string, isAnime: boolean): string {
+export function getKeyMetaInfo(stem: string): string {
 	const resM = stem.match(RES_STRICT_REGEX)?.groups?.res;
 	const res = resM ? `.${resM}` : "";
 	const sourceM = parseSource(stem);
@@ -182,10 +183,7 @@ export function getKeyMetaInfo(stem: string, isAnime: boolean): string {
 	if (groupM) {
 		return `${res}${source}-${groupM}`.toLowerCase();
 	}
-	if (!isAnime) {
-		return `${res}${source}`.toLowerCase();
-	}
-	const groupAnimeM = stem.match(ANIME_REGEX)?.groups?.group;
+	const groupAnimeM = stem.match(ANIME_GROUP_REGEX)?.groups?.group;
 	if (groupAnimeM) {
 		return `${res}${source}-${groupAnimeM}`.toLowerCase();
 	}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -815,10 +815,6 @@ async function getAndLogIndexers(
 		label: searchee.label,
 		message: `${progress}Searching for ${searcheeLog} | MediaType: ${mediaTypeLog} | IDs: ${idsStr}`,
 	});
-	logger.verbose({
-		label: Label.TORZNAB,
-		message: `Using ${indexersToSearch.length}|${cachedSearch.indexerCandidates.length} indexers by search|cache for ${searcheeLog}${reasonStr}`,
-	});
 
 	return { indexersToSearch, parsedMedia };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { File, Searchee } from "./searchee.js";
 import { Metafile } from "./parseTorrent.js";
 import chalk, { ChalkInstance } from "chalk";
+import { getRuntimeConfig } from "./runtimeConfig.js";
 
 export enum MediaType {
 	EPISODE = "episode",
@@ -152,7 +153,7 @@ export function reformatNameForSearching(name: string): string {
 	return reformatTitleForSearching(
 		name.match(EP_REGEX)?.groups?.title ??
 			name.match(SEASON_REGEX)?.groups?.title ??
-			name.match(MOVIE_REGEX)?.groups?.title ??
+			name.match(MOVIE_REGEX)?.[0] ??
 			name,
 	);
 }
@@ -226,4 +227,14 @@ export function capitalizeFirstLetter(string) {
 
 export function extractInt(str: string): number {
 	return parseInt(str.match(/\d+/)![0]);
+}
+
+export function getFuzzySizeFactor(): number {
+	const { fuzzySizeThreshold } = getRuntimeConfig();
+	return fuzzySizeThreshold;
+}
+
+export function getMinSizeRatio(): number {
+	const { fuzzySizeThreshold } = getRuntimeConfig();
+	return 1 - fuzzySizeThreshold;
 }


### PR DESCRIPTION
Updated how decision cache is handled so that users will never need delete the database or `cross-seed clear-cache` for v6 and beyond. For most decisions, it will reassess as the cache could get invalidated in many ways by config changes or future updates. To better assist this, caching has been updated to take advantage of the `inject-saved-torrents` feature of matching without snatching if the torrent exists in `torrent_cache`. In addition, all .torrent files that are snatched, not just successful matches, will now be saved in `torrent_cache`. Cache .torrent files are retrieved by the candidate guid only, so similar searchees don't need to resnatch. The priority of decisions has also changed to better handle fast paths when cached. With these changes, torrents are only ever snatched ONCE for the lifetime of `cross-seed`.

With all the changes to decision, it would benefit from having true unique entries so I opted to solve #522 with a migration. I added a column for `fuzzy_size_factor` (`fuzzy_size_threshold` or `seasonFromEpisodes`) as well. I also deleted all decisions that had a null `info_hash` partly because it was necessary to not overload node's memory but it also serves to give users a fresh start with all the improvements with zero effect on `torrent_cache`.

The only decisions that won't be reassessed are `RELEASE_GROUP_MISMATCH`, `PROPER_REPACK_MISMATCH`, `RESOLUTION_MISMATCH`, `SOURCE_MISMATCH`, `MAGNET_LINK`. I would like for us to try to finalize these regex's now as if we update it in the future, we would need to clear them for users.

I removed checking `matchMode` in the decisions that won't be retried as these decisions are permanent but matchMode might change. I added checking the anime group to handle some edge cases where the group is matched incorrectly. No longer checking REPACK/PROPER as we always want to pass in risky/partial but we can't use matchMode for this either.

I also changed `filterTimestamps` so users won't need to change `excludeRecentSearch` or `excludeOlder` when adding new indexers. Otherwise `excludeOlder` keeps the behavior of checking for the first time seen across any indexer.

---
With these changes, we can confidently state there is never a reason to delete the database or cache for v6 and forever. `cross-seed clear-cache` has been updated to only delete decisions where `info_hash` is null. We no longer need to hurt the cache as these decisions will be reassessed anyways. I removed clearing indexer caps here as it's updated for all indexers at every startup.

If the user has updated their config, they would only need to possibly update `excludeRecentSearch` and `excludeOlder`. If we modify the algorithms for decisions that won't be retried, `cross-seed clear-cache` will need to be ran. We can ask user to run it but I think we can do it for them with our own migration logic. If we add the current release of `cross-seed` to the settings table, we can check that at startup. We can then perform simple housekeeping tasks between versions that aren't a database migration.