### PR TITLE
bug(indexers): skip indexers with null caps and refresh with indexer job

### DIFF
--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -48,12 +48,20 @@ export async function getAllIndexers(): Promise<Indexer[]> {
 
 export async function getEnabledIndexers(): Promise<Indexer[]> {
 	return db("indexer")
-		.where({ active: true, search_cap: true, status: null })
-		.orWhere({ active: true, search_cap: true, status: IndexerStatus.OK })
-		.orWhere((b) =>
-			b
-				.where({ active: true, search_cap: true })
-				.where("retry_after", "<", Date.now()),
+		.whereNot({
+			search_cap: null,
+			tv_search_cap: null,
+			movie_search_cap: null,
+			tv_id_caps: null,
+			movie_id_caps: null,
+			cat_caps: null,
+		})
+		.where({ active: true, search_cap: true })
+		.where((i) =>
+			i
+				.where({ status: null })
+				.orWhere({ status: IndexerStatus.OK })
+				.orWhere("retry_after", "<", Date.now()),
 		)
 		.select({
 			id: "id",

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -4,6 +4,7 @@ import { main, scanRssFeeds } from "./pipeline.js";
 import { exitOnCrossSeedErrors } from "./errors.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
+import { updateCaps } from "./torznab.js";
 
 class Job {
 	name: string;
@@ -41,6 +42,7 @@ function getJobs(): Job[] {
 	if (torznab.length > 0) {
 		if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
 		if (searchCadence) jobs.push(new Job("search", searchCadence, main));
+		jobs.push(new Job("updateIndexerCaps", ms("1 day"), updateCaps));
 	}
 	return jobs;
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -498,9 +498,8 @@ function collateOutcomes<Correlator, SuccessReturnType>(
 	);
 }
 
-async function updateCaps(
-	indexers: { id: number; url: string; apikey: string }[],
-): Promise<void> {
+export async function updateCaps(): Promise<void> {
+	const indexers = await getAllIndexers();
 	const outcomes = await Promise.allSettled<Caps>(
 		indexers.map((indexer) => fetchCaps(indexer)),
 	);
@@ -540,8 +539,7 @@ export async function validateTorznabUrls() {
 		}
 	}
 	await syncWithDb();
-	const allIndexers = await getAllIndexers();
-	await updateCaps(allIndexers);
+	await updateCaps(); // Refresh every indexer's caps
 
 	const indexersWithoutSearch = await db("indexer")
 		.where({ search_cap: false, active: true })


### PR DESCRIPTION
1. `getEnabledIndexers()` no longer returns indexers with null caps. Which is possible if an indexer was down every time `cross-seed` was restarted since migrating to v6.
2. Caps are refreshed before `search` and `webhook`, not just on startup. This prevents the change above from being a silent failure if users don't restart `cross-seed` for a long time. Also benefits in the normal case as indexer caps will always be in sync without needing a restart.