### PR TITLE
enhancement(decide/res): ignore resolution type

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -19,7 +19,7 @@ import { findBlockedStringInReleaseMaybe } from "./preFilter.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 import { parseTorrentFromFilename, snatch, SnatchError } from "./torrent.js";
-import { humanReadableSize, stripExtension } from "./utils.js";
+import { extractInt, humanReadableSize, stripExtension } from "./utils.js";
 
 export interface ResultAssessment {
 	decision: Decision;
@@ -215,7 +215,7 @@ function resolutionDoesMatch(
 	if (!searcheeRes || !candidateRes) {
 		return matchMode !== MatchMode.SAFE;
 	}
-	return searcheeRes.startsWith(candidateRes);
+	return extractInt(searcheeRes) === extractInt(candidateRes);
 }
 function releaseVersionDoesMatch(
 	searcheeName: string,

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -27,6 +27,7 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
 import {
 	cleanseSeparators,
+	extractInt,
 	formatAsList,
 	getAnimeQueries,
 	getApikey,
@@ -189,8 +190,6 @@ async function createTorznabSearchQueries(
 	parsedMedia?: ParsedMedia,
 ): Promise<TorznabParams[]> {
 	const stem = stripExtension(searchee.name);
-	const extractNumber = (str: string): number =>
-		parseInt(str.match(/\d+/)![0]);
 	let relevantIds: IdSearchParams = {};
 	if (parsedMedia) {
 		relevantIds = await getRelevantArrIds(caps, parsedMedia);
@@ -203,11 +202,9 @@ async function createTorznabSearchQueries(
 			{
 				t: "tvsearch",
 				q: useIds ? undefined : cleanseSeparators(groups.title),
-				season: groups.season
-					? extractNumber(groups.season)
-					: groups.year,
+				season: groups.season ? extractInt(groups.season) : groups.year,
 				ep: groups.episode
-					? extractNumber(groups.episode)
+					? extractInt(groups.episode)
 					: `${groups.month}/${groups.day}`,
 				...relevantIds,
 			},
@@ -219,7 +216,7 @@ async function createTorznabSearchQueries(
 			{
 				t: "tvsearch",
 				q: useIds ? undefined : cleanseSeparators(groups.title),
-				season: extractNumber(groups.season),
+				season: extractInt(groups.season),
 				...relevantIds,
 			},
 		] as const;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -214,3 +214,7 @@ export function extractCredentialsFromUrl(
 export function capitalizeFirstLetter(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
+
+export function extractInt(str: string): number {
+	return parseInt(str.match(/\d+/)![0]);
+}


### PR DESCRIPTION
[From discord](https://discord.com/channels/880949701845872672/1249298183452885046/12492981834528850460)

`Name: Love Island S11E06 Unseen Bits `**1080i**` HDTV DD2.0 H.264-DARKFLiX`
`File: Love.Island.S11E06.Unseen.Bits.`**1080p**`.HDTV.H264-DARKFLiX.mkv`
`verbose: [decide] Love.Island.S11E06.Unseen.Bits.1080p.HDTV.H264-DARKFLiX - no match for BeyondHD torrent Love Island S11E06 Unseen Bits 1080i HDTV DD2.0 H.264-DARKFLiX - its resolution does not match: 1080p -> 1080i`
The video is actually 1080i but the scene release was named 1080p, and only BHD decided to be diligent and correctly call it 1080i in the release name, while keeping the file.