### PR TITLE
enhancement(action/unlink): unlink failed injections and save incomplete torrents

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -188,11 +188,7 @@ function logArrQueryResult(
 		if (!Object.values(externalIds).some(isTruthy)) {
 			logger.verbose({
 				label: label,
-				message: `Lookup failed for ${chalk.yellow(searchTerm)} - ${chalk.red(error.message)}`,
-			});
-			logger.verbose({
-				label: label,
-				message: `Make sure the item is added to an Arr instance.`,
+				message: `Lookup failed for ${chalk.yellow(searchTerm)} - ${chalk.red(error.message)} - make sure the item is added to an Arr instance.`,
 			});
 			return;
 		}
@@ -245,7 +241,9 @@ export async function scanAllArrsForMedia(
 						.replace(REPACK_PROPER_REGEX, ""),
 				)
 			: searchee.name;
-	let error = new Error(`No ids found for ${title} [${mediaType}]`);
+	let error = new Error(
+		`No ids found for ${title} | MediaType: ${mediaType.toUpperCase()}`,
+	);
 	for (const uArrL of uArrLs) {
 		const name =
 			mediaType === MediaType.OTHER &&


### PR DESCRIPTION
The unlink logic was pulled from the `inject-saved-torrents` branch so it has been used for a while without issues. I've expanded it to cover the bug here [from discord](https://discord.com/channels/880949701845872672/1228878509414420594/1250084947985694721). Torrents with the same hash from different trackers would still be linked with `flatLinking: false`.

I also starting saving torrents when source is incomplete, which is for the inject feature but we can start doing this now.