### PR TITLE
fix(logging/stack): add stacktraces to log files

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -96,11 +96,13 @@ export function initializeLogger(options: RuntimeConfig): void {
 			}),
 			winston.format.errors({ stack: true }),
 			winston.format.splat(),
-			winston.format.printf(({ level, message, label, timestamp }) => {
-				return `${timestamp} ${level}: ${
-					label ? `[${label}] ` : ""
-				}${stripAnsiChars(redactMessage(message, options))}`;
-			}),
+			winston.format.printf(
+				({ level, message, label, timestamp, stack }) => {
+					return `${timestamp} ${level}: ${
+						label ? `[${label}] ` : ""
+					}${stripAnsiChars(redactMessage(stack ? stack : message, options))}`;
+				},
+			),
 		),
 		transports: [
 			new DailyRotateFile({


### PR DESCRIPTION
This mirrors the configuration I added as an override to the `Console` transport. I must have just forgotten to add it to the default formatter