### PR TITLE
fix(logging/config): redact apiKey from logging in configdump

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,6 +59,8 @@ function redactMessage(message: string | unknown, options?: RuntimeConfig) {
 	ret = ret.replace(/(?:auto\.\d+\.)([a-zA-Z0-9]+)/g, (match, key) =>
 		match.replace(key, redactionMsg),
 	);
+	ret = ret.replace(/apiKey: '.+'/g, `apiKey: ${redactionMsg}`);
+
 	ret = ret.replace(
 		/\/notification\/crossSeed\/[a-zA-Z-0-9_-]+/g,
 		`/notification/crossSeed/${redactionMsg}`,


### PR DESCRIPTION
apiKey from config is logged in plaintext in the configdump.

this PR removes any apiKey value from being logged.

```js
  apiKey: [REDACTED],
```