### PR TITLE
fix(regex/scene): require scene group in prefix be lowercase

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const REPACK_PROPER_REGEX =
 
 export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;
 
-export const SCENE_TITLE_REGEX = /^(?:\w{0,5}-)?(?<title>.*)/i;
+export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{0,5}-)?(?<title>.*)/;
 
 export const ARR_DIR_REGEX =
 	/^(?!.*(?:(\d{3,4}[ipx])|([xh]26[4-6])|(?:(he)|a)vc))[\p{L}\s:\w'’!().,&–+-]+(?:\(\d{4}\))?\s?(?:\{(?:tm|tv|im)db(?:id)?-\w+\})?$/iu;


### PR DESCRIPTION
scene groups are almost exclusively lowercase when implemented, so this strictly checks that the characters matching in the 0-5 occurrences are all lowercase or numeric in value

- [x] test against releases including hyphens in the first 5 characters
  - https://regex101.com/r/QvFUyF/4