### PR TITLE
enhancement(reverselookup): using regex to parse rss/announce names instead of Fuse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"better-sqlite3": "^9.4.0",
 				"chalk": "^5.0.0",
 				"commander": "^8.3.0",
+				"fastest-levenshtein": "^1.0.16",
 				"fuse.js": "^6.6.2",
 				"knex": "^2.4.2",
 				"lodash-es": "^4.17.21",
@@ -1334,6 +1335,14 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"chalk": "^5.0.0",
 		"strip-ansi": "^7.1.0",
 		"commander": "^8.3.0",
+		"fastest-levenshtein": "^1.0.16",
 		"fuse.js": "^6.6.2",
 		"knex": "^2.4.2",
 		"lodash-es": "^4.17.21",

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -20,6 +20,7 @@ import {
 	RELEASE_GROUP_REGEX,
 	REPACK_PROPER_REGEX,
 	RESOLUTION_REGEX,
+	sourceRegexRemove,
 } from "./constants.js";
 
 interface ExternalIds {
@@ -238,10 +239,12 @@ export async function scanAllArrsForMedia(
 	const title =
 		mediaType === MediaType.OTHER
 			? cleanseSeparators(
-					stripExtension(searchee.name)
-						.replace(RELEASE_GROUP_REGEX, "")
-						.replace(RESOLUTION_REGEX, "")
-						.replace(REPACK_PROPER_REGEX, ""),
+					sourceRegexRemove(
+						stripExtension(searchee.name)
+							.replace(RELEASE_GROUP_REGEX, "")
+							.replace(RESOLUTION_REGEX, "")
+							.replace(REPACK_PROPER_REGEX, ""),
+					),
 				)
 			: searchee.name;
 	let error = new Error(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,11 +40,11 @@ const SOURCE_REGEXES = {
 	NF: /\b(nf|netflix(u?hd)?)\b/i,
 	HULU: /\b(hulu)\b/i,
 	ATVP: /\b(atvp|aptv)\b/i,
-	HBO: /\b(hbo)(?![ ._-]max)\b|\b(hmax|hbom|hbo[ ._-]max)\b|\b((?<!hbo[ ._-])max)\b/i,
-	PCOK: /\b(pcok|peacock)\b/i,
+	HBO: /\b(hbo)(?![ ._-]max)\b|\b(hmax|hbom|hbo[ ._-]max)\b/i,
+	PCOK: /\b(pcok)\b/i,
 	PMTP: /\b(pmtp|Paramount Plus)\b/i,
 };
-export function sourceRegexParse(title: string): string | null {
+export function parseSource(title: string): string | null {
 	for (const [source, regex] of Object.entries(SOURCE_REGEXES)) {
 		if (regex.test(title)) return source;
 	}
@@ -53,8 +53,8 @@ export function sourceRegexParse(title: string): string | null {
 export function sourceRegexRemove(title: string): string {
 	const originalLength = title.length;
 	for (const regex of Object.values(SOURCE_REGEXES)) {
-		title = title.replace(regex, "");
-		if (title.length !== originalLength) return title;
+		const newTitle = title.replace(regex, "");
+		if (newTitle.length !== originalLength) return newTitle;
 	}
 	return title;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,18 +22,42 @@ export const RELEASE_GROUP_REGEX =
 	/(?<=-)(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)(?<group>[\w .]+?)(?:\[.+\])?(?:\))?(?:\s\[.+\])?$/i;
 export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[pix](?:\d{3,4}[pi]?)?)\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
-
+export const YEAR_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/i;
 export const REPACK_PROPER_REGEX =
 	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))\b/i;
-
 export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;
-
 export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{0,5}-)?(?<title>.*)/;
-
 export const ARR_DIR_REGEX =
 	/^(?<title>(?!.*(?:(\d{3,4}[ipx])|([xh.]+26[4-6])|(mpeg)|(xvid)|(?:(he)|a)vc))[\p{L}\s:\w'’!();.,&–+-]+(?:\(\d{4}\))?)(?<id>\s[{[](?:tm|tv|im)db(?:id)?-\w+?[}\]])?$/iu;
 export const SONARR_SUBFOLDERS_REGEX =
 	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
+export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
+
+// Needs to be hanlded through helper functions since there is varitions
+const SOURCE_REGEXES = {
+	AMZN: /\b(amzn|amazon(hd)?)\b[ ._-]web[ ._-]?(dl|rip)?\b/i,
+	DSNP: /\b(dsnp|dsny|disney)\b/i,
+	NF: /\b(nf|netflix(u?hd)?)\b/i,
+	HULU: /\b(hulu)\b/i,
+	ATVP: /\b(atvp|aptv)\b/i,
+	HBO: /\b(hbo)(?![ ._-]max)\b|\b(hmax|hbom|hbo[ ._-]max)\b|\b((?<!hbo[ ._-])max)\b/i,
+	PCOK: /\b(pcok|peacock)\b/i,
+	PMTP: /\b(pmtp|Paramount Plus)\b/i,
+};
+export function sourceRegexParse(title: string): string | null {
+	for (const [source, regex] of Object.entries(SOURCE_REGEXES)) {
+		if (regex.test(title)) return source;
+	}
+	return null;
+}
+export function sourceRegexRemove(title: string): string {
+	const originalLength = title.length;
+	for (const regex of Object.values(SOURCE_REGEXES)) {
+		title = title.replace(regex, "");
+		if (title.length !== originalLength) return title;
+	}
+	return title;
+}
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
 export const AUDIO_EXTENSIONS = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,7 @@ export const SONARR_SUBFOLDERS_REGEX =
 	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
 export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
 
-// Needs to be hanlded through helper functions since there is varitions
+// Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {
 	AMZN: /\b(amzn|amazon(hd)?)\b[ ._-]web[ ._-]?(dl|rip)?\b/i,
 	DSNP: /\b(dsnp|dsny|disney)\b/i,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -22,7 +22,12 @@ import {
 	updateSearchTimestamps,
 } from "./indexers.js";
 import { Label, logger } from "./logger.js";
-import { filterByContent, filterDupes, filterTimestamps } from "./preFilter.js";
+import {
+	filterByContent,
+	filterDupes,
+	filterDupesFromSimilar,
+	filterTimestamps,
+} from "./preFilter.js";
 import { sendResultsNotification } from "./pushNotifier.js";
 import { isOk } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
@@ -37,7 +42,7 @@ import {
 import {
 	getInfoHashesToExclude,
 	getTorrentByCriteria,
-	getTorrentByFuzzyName,
+	getTorrentByName,
 	indexNewTorrents,
 	loadTorrentDirLight,
 	TorrentLocator,
@@ -243,48 +248,68 @@ export async function checkNewCandidateMatch(
 	candidate: Candidate,
 	searcheeLabel: SearcheeLabel,
 ): Promise<InjectionResult | SaveResult | null> {
-	const candidateLog = `${candidate.tracker}: ${candidate.name}`;
-	const meta = await getTorrentByFuzzyName(candidate.name);
-	if (meta === null) {
+	const candidateLog = `${candidate.name} from ${candidate.tracker}`;
+	const { keys, metas } = await getTorrentByName(candidate.name);
+	const method = keys.length ? `[${keys}]` : "Fuse fallback";
+	if (!metas.length) {
 		logger.verbose({
 			label: searcheeLabel,
-			message: `Did not find an existing entry for ${candidateLog}`,
+			message: `Did not find an existing entry using ${method} for ${candidateLog}`,
 		});
 		return null;
 	}
-
-	const hashesToExclude = await getInfoHashesToExclude();
-	const searchee: SearcheeWithLabel = {
-		...createSearcheeFromMetafile(meta),
-		label: searcheeLabel,
-	};
-	if (!filterByContent(searchee)) return null;
-
-	// make sure searchee is in database
-	await db("searchee")
-		.insert({ name: searchee.name })
-		.onConflict("name")
-		.ignore();
-
-	const assessment: ResultAssessment = await assessCandidate(
-		candidate,
-		searchee,
-		hashesToExclude,
-	);
-
-	if (!isAnyMatchedDecision(assessment.decision)) {
+	const searchees: SearcheeWithLabel[] = filterDupesFromSimilar(
+		metas.map(createSearcheeFromMetafile).filter(filterByContent),
+	).map((searchee) => ({ ...searchee, label: searcheeLabel }));
+	if (!searchees.length) {
+		logger.verbose({
+			label: searcheeLabel,
+			message: `No valid entries found using ${method} for ${candidateLog}`,
+		});
 		return null;
 	}
+	logger.verbose({
+		label: searcheeLabel,
+		message: `Unique entries [${searchees.map((m) => m.name)}] using ${method} for ${candidateLog}`,
+	});
 
-	const result = await performAction(
-		assessment.metafile!,
-		assessment.decision,
-		searchee,
-		candidate.tracker,
-	);
-	sendResultsNotification(searchee, [
-		[assessment, candidate.tracker, result],
-	]);
+	const hashesToExclude = await getInfoHashesToExclude();
+
+	let result: InjectionResult | SaveResult | null = null;
+	searchees.sort((a, b) => b.files.length - a.files.length);
+	for (const searchee of searchees) {
+		await db("searchee")
+			.insert({ name: searchee.name })
+			.onConflict("name")
+			.ignore();
+
+		const assessment: ResultAssessment = await assessCandidate(
+			candidate,
+			searchee,
+			hashesToExclude,
+		);
+
+		if (!isAnyMatchedDecision(assessment.decision)) {
+			continue;
+		}
+
+		result = await performAction(
+			assessment.metafile!,
+			assessment.decision,
+			searchee,
+			candidate.tracker,
+		);
+		sendResultsNotification(searchee, [
+			[assessment, candidate.tracker, result],
+		]);
+		if (
+			result === SaveResult.SAVED ||
+			result === InjectionResult.SUCCESS ||
+			result === InjectionResult.ALREADY_EXISTS
+		) {
+			break;
+		}
+	}
 	return result;
 }
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -106,11 +106,12 @@ export function findBlockedStringInReleaseMaybe(
 }
 
 /**
- * Filters duplicates from searchees that should be for different candidates.
+ * Filters duplicates from searchees that should be for different candidates,
+ * e.g. all searchees created by cross-seed.
  * @param searchees - An array of searchees to filter duplicates from.
- * @returns An array of searchees with duplicates removed.
+ * @returns An array of searchees with duplicates removed, preferring infoHash.
  */
-export function filterDupes(searchees: Searchee[]): Searchee[] {
+export function filterDupesByName<T extends Searchee>(searchees: T[]): T[] {
 	const duplicateMap = searchees.reduce((acc, cur) => {
 		const entry = acc.get(cur.name);
 		if (entry === undefined) {
@@ -133,12 +134,15 @@ export function filterDupes(searchees: Searchee[]): Searchee[] {
 }
 
 /**
- * Filters duplicates from searchees that are for the same candidates.
- * @param searchees - An array of searchees to filter duplicates from.
- * @returns An array of searchees with duplicates removed.
+ * Filters duplicates from searchees that are for the same candidates,
+ * e.g. searchees for the same media but different resolutions.
+ * @param searchees - An array of searchees for a specific media.
+ * @returns An array of searchees that are unique from a matching perspective.
  */
-export function filterDupesFromSimilar(searchees: Searchee[]): Searchee[] {
-	const filteredSearchees: Searchee[] = [];
+export function filterDupesFromSimilar<T extends Searchee>(
+	searchees: T[],
+): T[] {
+	const filteredSearchees: T[] = [];
 	for (const searchee of searchees) {
 		const isDupe = filteredSearchees.some((s) => {
 			if (searchee.length !== s.length) return false;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -105,6 +105,11 @@ export function findBlockedStringInReleaseMaybe(
 	});
 }
 
+/**
+ * Filters duplicates from searchees that should be for different candidates.
+ * @param searchees - An array of searchees to filter duplicates from.
+ * @returns An array of searchees with duplicates removed.
+ */
 export function filterDupes(searchees: Searchee[]): Searchee[] {
 	const duplicateMap = searchees.reduce((acc, cur) => {
 		const entry = acc.get(cur.name);
@@ -125,6 +130,32 @@ export function filterDupes(searchees: Searchee[]): Searchee[] {
 		});
 	}
 	return filtered;
+}
+
+/**
+ * Filters duplicates from searchees that are for the same candidates.
+ * @param searchees - An array of searchees to filter duplicates from.
+ * @returns An array of searchees with duplicates removed.
+ */
+export function filterDupesFromSimilar(searchees: Searchee[]): Searchee[] {
+	const filteredSearchees: Searchee[] = [];
+	for (const searchee of searchees) {
+		const isDupe = filteredSearchees.some((s) => {
+			if (searchee.length !== s.length) return false;
+			if (searchee.files.length !== s.files.length) return false;
+			const potentialFiles = s.files.map((f) => f.length);
+			return searchee.files.every((file) => {
+				const index = potentialFiles.indexOf(file.length);
+				if (index === -1) return false;
+				potentialFiles.splice(index, 1);
+				return true;
+			});
+		});
+		if (!isDupe) {
+			filteredSearchees.push(searchee);
+		}
+	}
+	return filteredSearchees;
 }
 
 type TimestampDataSql = {

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -199,7 +199,7 @@ export function getMovieKey(stem: string): {
 } | null {
 	const match = stem.match(MOVIE_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match.groups!.title, false)
+	const keyTitle = reformatTitleForSearching(match.groups!.title)
 		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 		.toLowerCase();
 	if (!keyTitle.length) return null;
@@ -215,7 +215,7 @@ export function getSeasonKey(stem: string): {
 } | null {
 	const match = stem.match(SEASON_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match.groups!.title, false)
+	const keyTitle = reformatTitleForSearching(match.groups!.title)
 		.replace(YEAR_REGEX, "")
 		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 		.toLowerCase();
@@ -225,7 +225,7 @@ export function getSeasonKey(stem: string): {
 	return { ensembleTitle, keyTitle, season };
 }
 
-export function getEpisodeAndKey(stem: string): {
+export function getEpisodeKey(stem: string): {
 	ensembleTitle: string;
 	keyTitle: string;
 	season: string;
@@ -233,7 +233,7 @@ export function getEpisodeAndKey(stem: string): {
 } | null {
 	const match = stem.match(EP_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match!.groups!.title, false)
+	const keyTitle = reformatTitleForSearching(match!.groups!.title)
 		.replace(YEAR_REGEX, "")
 		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 		.toLowerCase();
@@ -249,7 +249,7 @@ export function getEpisodeAndKey(stem: string): {
 	return { ensembleTitle, keyTitle, season, episode };
 }
 
-export function getReleaseAndKeys(stem: string): {
+export function getAnimeKeys(stem: string): {
 	ensembleTitles: string[];
 	keyTitles: string[];
 	release: number;
@@ -263,7 +263,7 @@ export function getReleaseAndKeys(stem: string): {
 	for (const title of [firstTitle, altTitle]) {
 		if (!title) continue;
 		if (isBadTitle(title)) continue;
-		const keyTitle = reformatTitleForSearching(title, false)
+		const keyTitle = reformatTitleForSearching(title)
 			.replace(YEAR_REGEX, "")
 			.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 			.toLowerCase();

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -7,7 +7,7 @@ import {
 	RELEASE_GROUP_REGEX,
 	SEASON_REGEX,
 	RES_STRICT_REGEX,
-	sourceRegexParse,
+	parseSource,
 	SONARR_SUBFOLDERS_REGEX,
 	MOVIE_REGEX,
 	NON_UNICODE_ALPHANUM_REGEX,
@@ -176,7 +176,7 @@ export async function createSearcheeFromPath(
 export function getKeyMetaInfo(stem: string, isAnime: boolean): string {
 	const resM = stem.match(RES_STRICT_REGEX)?.groups?.res;
 	const res = resM ? `.${resM}` : "";
-	const sourceM = sourceRegexParse(stem);
+	const sourceM = parseSource(stem);
 	const source = sourceM ? `.${sourceM}` : "";
 	const groupM = stem.match(RELEASE_GROUP_REGEX)?.groups?.group;
 	if (groupM) {

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -259,7 +259,7 @@ function getKeysFromName(name: string): {
 	return { keyTitles: [], useFallback: true };
 }
 
-export async function getTorrentByName(
+export async function getSimilarTorrentsByName(
 	name: string,
 ): Promise<{ keys: string[]; metas: Metafile[] }> {
 	const { keyTitles, element, useFallback } = getKeysFromName(name);
@@ -268,9 +268,6 @@ export async function getTorrentByName(
 		return { keys: [], metas };
 	}
 	const maxDistance = Math.floor(keyTitles[0].length / 4);
-	const keys = element
-		? keyTitles.map((keyTitle) => `${keyTitle}.${element}`)
-		: keyTitles;
 
 	const allEntries: { name: string; file_path: string }[] = await db(
 		"torrent",
@@ -284,8 +281,10 @@ export async function getTorrentByName(
 			);
 		});
 	});
-	if (filteredEntries.length === 0) return { keys, metas };
 
+	const keys = element
+		? keyTitles.map((keyTitle) => `${keyTitle}.${element}`)
+		: keyTitles;
 	metas.push(
 		...(await Promise.all(
 			filteredEntries.map(async (dbName) => {

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -12,14 +12,14 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Candidate } from "./pipeline.js";
 import {
-	getEpisodeAndKey,
+	getEpisodeKey,
 	createSearcheeFromTorrentFile,
 	Searchee,
 	getSeasonKey,
 	getMovieKey,
-	getReleaseAndKeys,
+	getAnimeKeys,
 } from "./searchee.js";
-import { reformatTitleForSearching, stripExtension } from "./utils.js";
+import { reformatNameForSearching, stripExtension } from "./utils.js";
 
 export interface TorrentLocator {
 	infoHash?: string;
@@ -233,10 +233,10 @@ function getKeysFromName(name: string): {
 	useFallback: boolean;
 } {
 	const stem = stripExtension(name);
-	const episodeAndKey = getEpisodeAndKey(stem);
-	if (episodeAndKey) {
-		const keyTitles = [episodeAndKey.keyTitle];
-		const element = `${episodeAndKey.season}.${episodeAndKey.episode}`;
+	const episodeKey = getEpisodeKey(stem);
+	if (episodeKey) {
+		const keyTitles = [episodeKey.keyTitle];
+		const element = `${episodeKey.season}.${episodeKey.episode}`;
 		return { keyTitles, element, useFallback: false };
 	}
 	const seasonKey = getSeasonKey(stem);
@@ -250,10 +250,10 @@ function getKeysFromName(name: string): {
 		const keyTitles = [movieKey.keyTitle];
 		return { keyTitles, useFallback: false };
 	}
-	const releaseAndKeys = getReleaseAndKeys(stem);
-	if (releaseAndKeys) {
-		const keyTitles = releaseAndKeys.keyTitles;
-		const element = releaseAndKeys.release;
+	const animeKeys = getAnimeKeys(stem);
+	if (animeKeys) {
+		const keyTitles = animeKeys.keyTitles;
+		const element = animeKeys.release;
 		return { keyTitles, element, useFallback: true };
 	}
 	return { keyTitles: [], useFallback: true };
@@ -299,7 +299,7 @@ export async function getTorrentByFuzzyName(name: string): Promise<Metafile[]> {
 	const allNames: { name: string; file_path: string }[] = await db(
 		"torrent",
 	).select("name", "file_path");
-	const fullMatch = reformatTitleForSearching(name)
+	const fullMatch = reformatNameForSearching(name)
 		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 		.toLowerCase();
 
@@ -307,7 +307,7 @@ export async function getTorrentByFuzzyName(name: string): Promise<Metafile[]> {
 	let filteredNames: typeof allNames = [];
 	if (fullMatch) {
 		filteredNames = allNames.filter((dbName) => {
-			const dbMatch = reformatTitleForSearching(dbName.name)
+			const dbMatch = reformatNameForSearching(dbName.name)
 				.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 				.toLowerCase();
 			if (!dbMatch) return false;

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -3,15 +3,23 @@ import Fuse from "fuse.js";
 import fs from "fs";
 import { extname, join, resolve } from "path";
 import { inspect } from "util";
-import { USER_AGENT } from "./constants.js";
+import { NON_UNICODE_ALPHANUM_REGEX, USER_AGENT } from "./constants.js";
 import { db } from "./db.js";
+import { distance } from "fastest-levenshtein";
 import { logger, logOnce } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { createSearcheeFromTorrentFile, Searchee } from "./searchee.js";
-import { reformatTitleForSearching, stripExtension } from "./utils.js";
 import { Candidate } from "./pipeline.js";
+import {
+	getEpisodeAndKey,
+	createSearcheeFromTorrentFile,
+	Searchee,
+	getSeasonKey,
+	getMovieKey,
+	getReleaseAndKeys,
+} from "./searchee.js";
+import { reformatTitleForSearching, stripExtension } from "./utils.js";
 
 export interface TorrentLocator {
 	infoHash?: string;
@@ -219,14 +227,81 @@ export async function loadTorrentDirLight(
 	return searchees;
 }
 
-export async function getTorrentByFuzzyName(
+function getKeysFromName(name: string): {
+	keyTitles: string[];
+	element?: string | number;
+	useFallback: boolean;
+} {
+	const stem = stripExtension(name);
+	const episodeAndKey = getEpisodeAndKey(stem);
+	if (episodeAndKey) {
+		const keyTitles = [episodeAndKey.keyTitle];
+		const element = `${episodeAndKey.season}.${episodeAndKey.episode}`;
+		return { keyTitles, element, useFallback: false };
+	}
+	const seasonKey = getSeasonKey(stem);
+	if (seasonKey) {
+		const keyTitles = [seasonKey.keyTitle];
+		const element = seasonKey.season;
+		return { keyTitles, element, useFallback: false };
+	}
+	const movieKey = getMovieKey(stem);
+	if (movieKey) {
+		const keyTitles = [movieKey.keyTitle];
+		return { keyTitles, useFallback: false };
+	}
+	const releaseAndKeys = getReleaseAndKeys(stem);
+	if (releaseAndKeys) {
+		const keyTitles = releaseAndKeys.keyTitles;
+		const element = releaseAndKeys.release;
+		return { keyTitles, element, useFallback: true };
+	}
+	return { keyTitles: [], useFallback: true };
+}
+
+export async function getTorrentByName(
 	name: string,
-): Promise<null | Metafile> {
+): Promise<{ keys: string[]; metas: Metafile[] }> {
+	const { keyTitles, element, useFallback } = getKeysFromName(name);
+	const metas = useFallback ? await getTorrentByFuzzyName(name) : [];
+	if (!keyTitles.length) {
+		return { keys: [], metas };
+	}
+	const maxDistance = Math.floor(keyTitles[0].length / 4);
+	const keys = element
+		? keyTitles.map((keyTitle) => `${keyTitle}.${element}`)
+		: keyTitles;
+
+	const allEntries: { name: string; file_path: string }[] = await db(
+		"torrent",
+	).select("name", "file_path");
+	const filteredEntries = allEntries.filter((dbName) => {
+		const entry = getKeysFromName(dbName.name);
+		if (entry.element !== element) return false;
+		return entry.keyTitles.some((dbKeyTitle) => {
+			return keyTitles.some(
+				(keyTitle) => distance(keyTitle, dbKeyTitle) <= maxDistance,
+			);
+		});
+	});
+	if (filteredEntries.length === 0) return { keys, metas };
+
+	metas.push(
+		...(await Promise.all(
+			filteredEntries.map(async (dbName) => {
+				return parseTorrentFromFilename(dbName.file_path);
+			}),
+		)),
+	);
+	return { keys, metas };
+}
+
+export async function getTorrentByFuzzyName(name: string): Promise<Metafile[]> {
 	const allNames: { name: string; file_path: string }[] = await db(
 		"torrent",
 	).select("name", "file_path");
 	const fullMatch = reformatTitleForSearching(name)
-		.replace(/[^a-z0-9]/gi, "")
+		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 		.toLowerCase();
 
 	// Attempt to filter torrents in DB to match incoming torrent before fuzzy check
@@ -234,7 +309,7 @@ export async function getTorrentByFuzzyName(
 	if (fullMatch) {
 		filteredNames = allNames.filter((dbName) => {
 			const dbMatch = reformatTitleForSearching(dbName.name)
-				.replace(/[^a-z0-9]/gi, "")
+				.replace(NON_UNICODE_ALPHANUM_REGEX, "")
 				.toLowerCase();
 			if (!dbMatch) return false;
 			return fullMatch === dbMatch;
@@ -250,12 +325,8 @@ export async function getTorrentByFuzzyName(
 		distance: 6,
 		threshold: 0.25,
 	}).search(name);
-
-	// Valid matches exist
-	if (potentialMatches.length === 0) return null;
-
-	const firstMatch = potentialMatches[0];
-	return parseTorrentFromFilename(firstMatch.item.file_path);
+	if (potentialMatches.length === 0) return [];
+	return [await parseTorrentFromFilename(potentialMatches[0].item.file_path)];
 }
 
 export async function getTorrentByCriteria(

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -36,7 +36,7 @@ import {
 	isTruthy,
 	MediaType,
 	nMsAgo,
-	reformatTitleForSearching,
+	reformatNameForSearching,
 	sanitizeUrl,
 	stripExtension,
 } from "./utils.js";
@@ -227,7 +227,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "movie",
-				q: useIds ? undefined : reformatTitleForSearching(stem),
+				q: useIds ? undefined : reformatNameForSearching(stem),
 				...relevantIds,
 			},
 		] as const;
@@ -250,7 +250,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "search",
-				q: reformatTitleForSearching(stem),
+				q: reformatNameForSearching(stem),
 			},
 		] as const;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,6 +123,10 @@ export function cleanseSeparators(str: string): string {
 		.trim();
 }
 
+export function isBadTitle(title: string): boolean {
+	return ["season", "ep"].includes(title.toLowerCase());
+}
+
 export function getAnimeQueries(name: string): string[] {
 	// Only use if getMediaType returns anime as it's conditional on a few factors
 	const animeQueries: string[] = [];
@@ -131,22 +135,22 @@ export function getAnimeQueries(name: string): string[] {
 		animeQueries.push(cleanseSeparators(`${title} ${release}`));
 	}
 	if (altTitle) {
-		// Edge cases from regex
-		if (altTitle.toLowerCase() === "season") return animeQueries;
-		if (altTitle.toLowerCase() === "ep") return animeQueries;
-
+		if (isBadTitle(altTitle)) return animeQueries;
 		animeQueries.push(cleanseSeparators(`${altTitle} ${release}`));
 	}
 	return animeQueries;
 }
 
-export function reformatTitleForSearching(name: string): string {
-	// use lazy regex evaluation
-	const fullMatch =
-		name.match(EP_REGEX)?.[0] ??
-		name.match(SEASON_REGEX)?.[0] ??
-		name.match(MOVIE_REGEX)?.[0] ??
-		name;
+export function reformatTitleForSearching(
+	name: string,
+	useRegex = true,
+): string {
+	const fullMatch = useRegex
+		? name.match(EP_REGEX)?.groups?.title ??
+			name.match(SEASON_REGEX)?.groups?.title ??
+			name.match(MOVIE_REGEX)?.groups?.title ??
+			name
+		: name;
 	return cleanseSeparators(fullMatch).match(SCENE_TITLE_REGEX)!.groups!.title;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,17 +141,17 @@ export function getAnimeQueries(name: string): string[] {
 	return animeQueries;
 }
 
-export function reformatTitleForSearching(
-	name: string,
-	useRegex = true,
-): string {
-	const fullMatch = useRegex
-		? name.match(EP_REGEX)?.groups?.title ??
+export function reformatTitleForSearching(title: string): string {
+	return cleanseSeparators(title).match(SCENE_TITLE_REGEX)!.groups!.title;
+}
+
+export function reformatNameForSearching(name: string): string {
+	return reformatTitleForSearching(
+		name.match(EP_REGEX)?.groups?.title ??
 			name.match(SEASON_REGEX)?.groups?.title ??
 			name.match(MOVIE_REGEX)?.groups?.title ??
-			name
-		: name;
-	return cleanseSeparators(fullMatch).match(SCENE_TITLE_REGEX)!.groups!.title;
+			name,
+	);
 }
 
 export const tap = (fn) => (value) => {


### PR DESCRIPTION
This replaces the Fuse method of reverse lookup to leveraging the existing regex. Only the title, season, episode is used. All other parts should be handled in the decide stage. The title is cleansed as much as possible then converted to lowercase and with symbols and spaces removed. This is already much better than the Fuse, but we then add a fuzzy using the levenshtein distance. The max distance is `Math.floor(cleanTitle.length / 4)` so short titles needs to be exact and longer titles get more leeway. I haven't come across a situation where we need this fuzzy, but I'm sure they exist.

This method vastly outperforms Fuse in all aspects.
1. It's much faster. It's always ~50ms to get all matching items from the database for me. Where Fuse took 150ms if nothing was found up to multiple seconds if items were.
2. It has far less false positives that Fuse. Fuse would erroneously move to decide on at least 1/20 announces for me, I haven't seen a single false positive for the new method. They do exist, for example I'm not using the year in the key for movies since it can be wrong, but of course it's still far better than before.
3. Better true positives. Due to all the parsing, it handles weird naming formats much better and doesn't get tripped up by spaces or dots like Fuse.
4. A not insignificant benefit is that this is much more "deterministic". You can easily make improvements and logically reason about the algorithm. Where as the previous method was essentially a black box with a few parameters to tweak.

Due to how much more robust this is, we now create searchees from all matches rather than just the first. These are ordered by most files to reduce the chance of partials. I'm also using the improved dupe check originally from the `cache-searche-queries` branch.