### PR TITLE
fix(cli/searchlimit): remove radix parameter from searchlimit

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -255,7 +255,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		.option(
 			"--search-limit <number>",
 			"The number of searches before stops",
-			parseInt,
+			(n) => parseInt(n),
 			fallback(fileConfig.searchLimit, 0),
 		)
 		.option(


### PR DESCRIPTION
when a previous value (config file) is set for `searchLimit` and cli argument is passed, the config value is sent as the radix in parseInt, causing Zod to return a NaN and terminate

this PR solves that by using the same method `maxDataDepth` uses - `(n) => parseInt(n)` to isolate the value

as a note, parseFloat is not susceptible to this bug, so it was not done there (fuzzy/delay)