### PR TITLE
fix(prefilter): remove single file constraint for isSingleEpisode check

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,7 @@ export const NEWLINE_INDENT = "\n\t\t\t\t";
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
+export const IS_MULTI_EP_REGEX = /E\d+(?:[-.]?S\d+E\d|[-.]?E\d|[-.]\d)/i;
 export const SEASON_REGEX =
 	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -36,8 +36,6 @@ export function filterByContent(searchee: Searchee): boolean {
 		return false;
 	}
 
-	const isSingleEpisodeTorrent =
-		searchee.files.length === 1 && EP_REGEX.test(searchee.name);
 	const isSeasonPackEpisode =
 		searchee.path &&
 		searchee.files.length === 1 &&
@@ -46,8 +44,8 @@ export function filterByContent(searchee: Searchee): boolean {
 	if (
 		!includeEpisodes &&
 		!includeSingleEpisodes &&
-		isSingleEpisodeTorrent &&
-		!isSeasonPackEpisode
+		!isSeasonPackEpisode &&
+		EP_REGEX.test(searchee.name)
 	) {
 		logReason("it is a single episode");
 		return false;


### PR DESCRIPTION
Single episode torrents with extra files would fail the single file check. It only uses the `EP_REGEX` to perform this test.

~The new multi episode test covers the cases that sonarr allows for renaming.
https://regex101.com/r/OEZqQx/2~