### PR TITLE
Add support for basic auth

### DIFF
--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -15,6 +15,7 @@ export interface Indexer {
 	id: number;
 	url: string;
 	apikey: string;
+	basicauth: string;
 	/**
 	 * Whether the indexer is currently specified in config
 	 */
@@ -34,6 +35,7 @@ export async function getAllIndexers(): Promise<Indexer[]> {
 		id: "id",
 		url: "url",
 		apikey: "apikey",
+		basicauth: "basicauth",
 		active: "active",
 		status: "status",
 		retryAfter: "retry_after",
@@ -67,6 +69,7 @@ export async function getEnabledIndexers(): Promise<Indexer[]> {
 			id: "id",
 			url: "url",
 			apikey: "apikey",
+			basicauth: "basicauth",
 			active: "active",
 			status: "status",
 			retryAfter: "retry_after",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,18 @@ export function sanitizeUrl(url: string | URL): string {
 	}
 	return url.origin + url.pathname;
 }
-
+export function getBasicAuth(url: string | URL): string {
+	if (typeof url === "string") {
+		url = new URL(url);
+	}
+	const username = url.username
+	const password = url.password
+	if (!username || !password) {
+		return '';
+	}
+	const btoa = `${Buffer.from(username + ':' + password).toString('base64')}`
+	return btoa
+}
 export function getApikey(url: string) {
 	return new URL(url).searchParams.get("apikey");
 }


### PR DESCRIPTION
Access auth protected instances of your torznab apps. Helpful if you already have prowlarr setup on a seedbox / server and want to quickly use cross-seed on a separate machine.

Tested with a remote instance of prowlarr to cross-seed on my local machine.

user:pass is extracted from the URL in the config then converted to btoa format and stored in the database under 'basicauth' column.

I couldn't figure out how to add the new column through code but running this in cross-seed.db worked
"ALTER TABLE indexer ADD COLUMN basicauth TEXT;"