### PR TITLE
update(id-search): support tvmaze id lookup

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -26,6 +26,7 @@ interface ExternalIds {
 	imdbId?: string;
 	tmdbId?: string;
 	tvdbId?: string;
+	tvMazeId?: string;
 }
 
 interface ParsedMovie {
@@ -168,7 +169,9 @@ async function getMediaFromArr(
 export function formatFoundIds(foundIds: ExternalIds): string {
 	return Object.entries(foundIds)
 		.filter(([idName]) =>
-			["imdbid", "tmdbid", "tvdbid"].includes(idName.toLowerCase()),
+			["imdbid", "tmdbid", "tvdbid", "tvmazeid"].includes(
+				idName.toLowerCase(),
+			),
 		)
 		.map(([idName, idValue]) => {
 			const name = idName.toUpperCase().replace("ID", "");
@@ -280,10 +283,11 @@ export async function getRelevantArrIds(
 		? caps.movieIdSearch
 		: caps.tvIdSearch;
 	const ids = parsedMedia.movie ?? parsedMedia.series;
-
-	return {
+	const x = {
 		tvdbid: idSearchCaps.tvdbId ? ids.tvdbId : undefined,
 		tmdbid: idSearchCaps.tmdbId ? ids.tmdbId : undefined,
 		imdbid: idSearchCaps.imdbId ? ids.imdbId : undefined,
+		tvmazeid: idSearchCaps.tvMazeId ? ids.tvMazeId : undefined,
 	};
+	return x;
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -54,6 +54,7 @@ export interface IdSearchParams {
 	tvdbid?: string;
 	tmdbid?: string;
 	imdbid?: string;
+	tvmazeid?: string;
 }
 
 export interface TorznabParams extends IdSearchParams {
@@ -69,6 +70,7 @@ export interface IdSearchCaps {
 	tvdbId?: boolean;
 	tmdbId?: boolean;
 	imdbId?: boolean;
+	tvMazeId?: boolean;
 }
 
 export interface Caps {
@@ -149,6 +151,7 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 			tvdbId: supportedIds.includes("tvdbid"),
 			tmdbId: supportedIds.includes("tmdbid"),
 			imdbId: supportedIds.includes("imdbid"),
+			tvMazeId: supportedIds.includes("tvmazeid"),
 		};
 	}
 


### PR DESCRIPTION
adds support for tvmaze in id searching and caps

does not need a migration since the caps are stored in json/string in the database

implementation is the same as previous ids