### PR TITLE
fix(action/unlink): use stricter test for unlinking if injection already exists

### DIFF
--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -1,7 +1,7 @@
 import { Metafile } from "../parseTorrent.js";
 import { DecisionAnyMatch, InjectionResult } from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { Searchee } from "../searchee.js";
+import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
 import Transmission from "./Transmission.js";
@@ -12,7 +12,8 @@ let activeClient: TorrentClient;
 
 export interface TorrentClient {
 	getDownloadDir: (
-		searchee: Searchee,
+		meta: SearcheeWithInfoHash | Metafile,
+		options: { onlyCompleted: boolean },
 	) => Promise<
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	>;


### PR DESCRIPTION
This updated check is only necessary for the `inject-saved-torrents` feature. Due to how it's handling injection, it was possible to unlink files that it just tried to link which defeats one of it's features.

This current change more explicitly defines when we would want to unlink in case of `ALREADY_EXISTS`. Only the changes in action.ts, specifically `rmSync` and the check added before unlinking are new. The updated `getDownloadDir` function was pulled from the `ensemble-matching` branch which just allows getting the savePath for incomplete torrents.