### PR TITLE
fix(torznab/search): better queries strings for unsupported media

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -276,7 +276,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "search",
-				q: reformatNameForSearching(stem),
+				q: cleanseSeparators(stem),
 			},
 		] as const;
 	}


### PR DESCRIPTION
this PR addresses media types we do not natively support, but should prevent from making absurd or erroneous queries that may result in excessive and inaccurate results - potentially overwhelming cross-seed during matching and creating a bottleneck.

logs from the reporting user showed their query for a music album resulted in nearly 50k results, and while this is absurd is mainly due to the query strings we send and a lack of truncation on the tracker (which is dumb too lol)

to address this, I've done the following

* clense the seperators (ONLY) for unsupported mediatypes, since parsing anything out is going to be mostly irrelevant for this. 