### PR TITLE
fix(search/cache): verify ids before using cached search

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -23,11 +23,22 @@ import {
 	sourceRegexRemove,
 } from "./constants.js";
 
-interface ExternalIds {
+export interface ExternalIds {
 	imdbId?: string;
 	tmdbId?: string;
 	tvdbId?: string;
 	tvMazeId?: string;
+}
+export function arrIdsEqual(
+	a: ExternalIds | undefined,
+	b: ExternalIds | undefined,
+): boolean {
+	return (
+		a?.imdbId === b?.imdbId &&
+		a?.tmdbId === b?.tmdbId &&
+		a?.tvdbId === b?.tvdbId &&
+		a?.tvMazeId === b?.tvMazeId
+	);
 }
 
 interface ParsedMovie {


### PR DESCRIPTION
No issues have been found, but we should do this just to be safe. Since there could be differences between raw searches and id searches, we should verify both.

Also now using a custom type instead of map which fits better its purpose.