### PR TITLE
enhancement(decide/snatch): retry rss/announce snatch after delay

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -76,7 +76,7 @@ interface FoundOnOtherSites {
 
 async function assessCandidates(
 	candidates: Candidate[],
-	searchee: Searchee,
+	searchee: SearcheeWithLabel,
 	hashesToExclude: string[],
 ): Promise<AssessmentWithTracker[]> {
 	const assessments: AssessmentWithTracker[] = [];
@@ -177,7 +177,7 @@ async function findMatchesBatch(
 		try {
 			const sleepTime = delay * 1000 - (Date.now() - prevSearchTime);
 			if (sleepTime > 0) {
-				await new Promise((r) => setTimeout(r, sleepTime));
+				await wait(sleepTime);
 			}
 			const searchTime = Date.now();
 


### PR DESCRIPTION
Some trackers frequently announce before it's possible to snatch. Now if a snatch fails from rss/announce, we wait 30s before resnatching. The added delay is not a concern as 99.9% rss/announce won't pass the reverse lookup and even fewer will attempt snatching.

This is done instead of returning a 202 for announce so a snatch can only happen twice rather than users current retry attempts.