### PR TITLE
fix(preFilter): search season pack episode from webhook if includeSingleEpisodes

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -224,6 +224,7 @@ export async function searchForLocalTorrentByCriteria(
 		...searchee,
 		label: Label.WEBHOOK,
 	}));
+	const includeEpisodes = searchees.length === 1;
 	const hashesToExclude = await getInfoHashesToExclude();
 	let totalFound = 0;
 	let filtered = 0;
@@ -231,7 +232,7 @@ export async function searchForLocalTorrentByCriteria(
 	for (const [i, searchee] of searchees.entries()) {
 		const progress = chalk.blue(`(${i + 1}/${searchees.length}) `);
 		try {
-			if (!filterByContent(searchee)) {
+			if (!filterByContent(searchee, includeEpisodes)) {
 				filtered++;
 				continue;
 			}
@@ -279,7 +280,7 @@ export async function checkNewCandidateMatch(
 		metas
 			.map(createSearcheeFromMetafile)
 			.map((searchee) => ({ ...searchee, label: searcheeLabel }))
-			.filter(filterByContent),
+			.filter((searchee) => filterByContent(searchee)),
 	);
 	if (!searchees.length) {
 		logger.verbose({
@@ -370,7 +371,7 @@ async function findSearchableTorrents(searcheeLabel: SearcheeLabel): Promise<{
 
 	// Group the exact same search queries together for easy cache use later
 	const grouping = new Map<string, SearcheeWithLabel[]>();
-	for (const searchee of allSearchees.filter(filterByContent)) {
+	for (const searchee of allSearchees.filter((s) => filterByContent(s))) {
 		const key = await getSearchString(searchee);
 		if (!grouping.has(key)) {
 			grouping.set(key, []);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -29,7 +29,10 @@ function logReason(reason: string, searchee: Searchee): void {
 	});
 }
 
-export function filterByContent(searchee: SearcheeWithLabel): boolean {
+export function filterByContent(
+	searchee: SearcheeWithLabel,
+	includeEpisodes?: boolean,
+): boolean {
 	const {
 		fuzzySizeThreshold,
 		includeNonVideos,
@@ -44,6 +47,7 @@ export function filterByContent(searchee: SearcheeWithLabel): boolean {
 	}
 
 	if (
+		(!includeEpisodes || !includeSingleEpisodes) &&
 		searchee.path &&
 		searchee.files.length === 1 &&
 		(SEASON_REGEX.test(basename(dirname(searchee.path))) ||

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -69,7 +69,6 @@ export function sendResultsNotification(
 	searchee: SearcheeWithLabel,
 	results: [ResultAssessment, TrackerName, ActionResult][],
 ) {
-	const name = searchee.name;
 	const source = searchee.label;
 	const notableSuccesses = results.filter(
 		([, , actionResult]) =>
@@ -80,6 +79,7 @@ export function sendResultsNotification(
 		([, , actionResult]) => actionResult === InjectionResult.FAILURE,
 	);
 	if (notableSuccesses.length) {
+		const name = notableSuccesses[0][0].metafile!.name;
 		const numTrackers = notableSuccesses.length;
 		const infoHashes = notableSuccesses.map(
 			([assessment]) => assessment.metafile!.infoHash,
@@ -104,6 +104,7 @@ export function sendResultsNotification(
 	}
 
 	if (failures.length) {
+		const name = notableSuccesses[0][0].metafile!.name;
 		const numTrackers = failures.length;
 		const infoHashes = failures.map(
 			([assessment]) => assessment.metafile!.infoHash,


### PR DESCRIPTION
Previously would not search if a path based criteria for webhook was supplied and it was in a season folder. Will no longer check if season pack episodes from webhook searches.

Also using metafile.name for notifications since searchee.name can be artificial.