### PR TITLE
enhancement(search): search unknown MediaType only if supported by indexer categories

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -232,7 +232,7 @@ function getRelevantArrInstances(mediaType: MediaType): string[] {
 		case MediaType.MOVIE:
 			return radarr;
 		case MediaType.ANIME:
-		case MediaType.OTHER:
+		case MediaType.VIDEO:
 			return [...sonarr, ...radarr];
 		default:
 			return [];
@@ -248,22 +248,22 @@ export async function scanAllArrsForMedia(
 		return resultOfErr(false);
 	}
 	const title =
-		mediaType === MediaType.OTHER
-			? cleanseSeparators(
+		mediaType !== MediaType.VIDEO
+			? searchee.name
+			: cleanseSeparators(
 					sourceRegexRemove(
 						stripExtension(searchee.name)
 							.replace(RELEASE_GROUP_REGEX, "")
 							.replace(RESOLUTION_REGEX, "")
 							.replace(REPACK_PROPER_REGEX, ""),
 					),
-				)
-			: searchee.name;
+				);
 	let error = new Error(
 		`No ids found for ${title} | MediaType: ${mediaType.toUpperCase()}`,
 	);
 	for (const uArrL of uArrLs) {
 		const name =
-			mediaType === MediaType.OTHER &&
+			mediaType === MediaType.VIDEO &&
 			getRuntimeConfig().sonarr?.includes(uArrL)
 				? `${title} S00E00` // Sonarr needs season or episode
 				: title;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -258,6 +258,7 @@ export default class QBittorrent implements TorrentClient {
 			const savePath = this.getCorrectSavePath(meta, torrentInfo);
 			return resultOf(savePath);
 		} catch (e) {
+			logger.debug(e);
 			if (e.message.includes("retrieve")) {
 				return resultOfErr("NOT_FOUND");
 			}
@@ -439,6 +440,7 @@ export default class QBittorrent implements TorrentClient {
 				label: Label.QBITTORRENT,
 				message: `Injection failed: ${e.message}`,
 			});
+			logger.debug(e);
 			return InjectionResult.FAILURE;
 		}
 	}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -57,8 +57,9 @@ function redactMessage(message: string | unknown, options?: RuntimeConfig) {
 
 	ret = ret.replace(/key=[a-zA-Z0-9]+/g, `key=${redactionMsg}`);
 	ret = ret.replace(/pass=[a-zA-Z0-9]+/g, `pass=${redactionMsg}`);
-	ret = ret.replace(/(?:auto\.\d+\.)([a-zA-Z0-9]+)/g, (match, key) =>
-		match.replace(key, redactionMsg),
+	ret = ret.replace(
+		/(?:(?:auto|download)[./]\d+[./])([a-zA-Z0-9]+)/g,
+		(match, key) => match.replace(key, redactionMsg),
 	);
 	ret = ret.replace(/apiKey: '.+'/g, `apiKey: ${redactionMsg}`);
 


### PR DESCRIPTION
This aims to prevent searching for media that can't exist on the indexer for unknown media types as well.
* If the searchee contains a video, always search unknown media type
* Otherwise only search if the indexer has additional categories (ones not explicitly recognized by cross-seed)

Also now matching `MediaType: MOVIE` for .rar releases. Before it was just a logging thing and maybe some uncessary api calls to sonarr. But is now necessary with this new behavior.