### PR TITLE
feat(action/inject): resume injections below size threshold and readd skipRecheck

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -255,10 +255,11 @@ export default class Deluge implements TorrentClient {
 	 */
 	async resumeInjection(
 		infoHash: string,
+		decision: DecisionAnyMatch,
 		options: { checkOnce: boolean },
 	): Promise<void> {
 		let sleepTime = resumeSleepTime;
-		const maxRemainingBytes = getMaxRemainingBytes();
+		const maxRemainingBytes = getMaxRemainingBytes(decision);
 		const stopTime = getResumeStopTime();
 		let stop = false;
 		while (Date.now() < stopTime) {
@@ -452,7 +453,7 @@ export default class Deluge implements TorrentClient {
 					// leaves torrent ready to download - ~99%
 					await wait(1000);
 					await this.recheckTorrent(newTorrent.infoHash);
-					this.resumeInjection(newTorrent.infoHash, {
+					this.resumeInjection(newTorrent.infoHash, decision, {
 						checkOnce: false,
 					});
 				}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -538,10 +538,11 @@ export default class QBittorrent implements TorrentClient {
 
 	async resumeInjection(
 		infoHash: string,
+		decision: DecisionAnyMatch,
 		options: { checkOnce: boolean },
 	): Promise<void> {
 		let sleepTime = resumeSleepTime;
-		const maxRemainingBytes = getMaxRemainingBytes();
+		const maxRemainingBytes = getMaxRemainingBytes(decision);
 		const stopTime = getResumeStopTime();
 		let stop = false;
 		while (Date.now() < stopTime) {
@@ -690,7 +691,9 @@ export default class QBittorrent implements TorrentClient {
 			}
 			if (toRecheck) {
 				await this.recheckTorrent(newInfo.hash);
-				this.resumeInjection(newInfo.hash, { checkOnce: false });
+				this.resumeInjection(newInfo.hash, decision, {
+					checkOnce: false,
+				});
 			}
 
 			return InjectionResult.SUCCESS;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -18,6 +18,10 @@ import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { loadTorrentDirLight } from "../torrent.js";
 import {
 	TorrentMetadataInClient,
+	getMaxRemainingBytes,
+	getResumeStopTime,
+	resumeErrSleepTime,
+	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
 	validateSavePaths,
@@ -26,6 +30,7 @@ import {
 	extractCredentialsFromUrl,
 	extractInt,
 	getLogString,
+	humanReadableSize,
 	sanitizeInfoHash,
 	wait,
 } from "../utils.js";
@@ -531,6 +536,64 @@ export default class QBittorrent implements TorrentClient {
 		);
 	}
 
+	async resumeInjection(
+		infoHash: string,
+		options: { checkOnce: boolean },
+	): Promise<void> {
+		let sleepTime = resumeSleepTime;
+		const maxRemainingBytes = getMaxRemainingBytes();
+		const stopTime = getResumeStopTime();
+		let stop = false;
+		while (Date.now() < stopTime) {
+			if (options.checkOnce) {
+				if (stop) return;
+				stop = true;
+			}
+			await wait(sleepTime);
+			const torrentInfo = await this.getTorrentInfo(infoHash);
+			if (!torrentInfo) {
+				sleepTime = resumeErrSleepTime; // Dropping connections or restart
+				continue;
+			}
+			if (["checkingDL", "checkingUP"].includes(torrentInfo.state)) {
+				continue;
+			}
+			const torrentLog = `${torrentInfo.name} [${sanitizeInfoHash(infoHash)}]`;
+			if (
+				!["pausedDL", "stoppedDL", "pausedUP", "stoppedUP"].includes(
+					torrentInfo.state,
+				)
+			) {
+				logger.warn({
+					label: Label.QBITTORRENT,
+					message: `Will not resume ${torrentLog}: state is ${torrentInfo.state}`,
+				});
+				return;
+			}
+			if (torrentInfo.amount_left > maxRemainingBytes) {
+				logger.warn({
+					label: Label.QBITTORRENT,
+					message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.amount_left, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+				});
+				return;
+			}
+			logger.info({
+				label: Label.QBITTORRENT,
+				message: `Resuming ${torrentLog}: ${humanReadableSize(torrentInfo.amount_left, { binary: true })} remaining`,
+			});
+			await this.request(
+				`/torrents/${this.versionMajor >= 5 ? "start" : "resume"}`,
+				`hashes=${infoHash}`,
+				X_WWW_FORM_URLENCODED,
+			);
+			return;
+		}
+		logger.warn({
+			label: Label.QBITTORRENT,
+			message: `Will not resume torrent ${infoHash}: timeout`,
+		});
+	}
+
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
@@ -627,6 +690,7 @@ export default class QBittorrent implements TorrentClient {
 			}
 			if (toRecheck) {
 				await this.recheckTorrent(newInfo.hash);
+				this.resumeInjection(newInfo.hash, { checkOnce: false });
 			}
 
 			return InjectionResult.SUCCESS;

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -480,10 +480,11 @@ export default class RTorrent implements TorrentClient {
 
 	async resumeInjection(
 		infoHash: string,
+		decision: DecisionAnyMatch,
 		options: { checkOnce: boolean },
 	): Promise<void> {
 		let sleepTime = resumeSleepTime;
-		const maxRemainingBytes = getMaxRemainingBytes();
+		const maxRemainingBytes = getMaxRemainingBytes(decision);
 		const stopTime = getResumeStopTime();
 		let stop = false;
 		while (Date.now() < stopTime) {
@@ -583,7 +584,9 @@ export default class RTorrent implements TorrentClient {
 					].filter((e) => e !== null),
 				);
 				if (toRecheck) {
-					this.resumeInjection(meta.infoHash, { checkOnce: false });
+					this.resumeInjection(meta.infoHash, decision, {
+						checkOnce: false,
+					});
 				}
 				break;
 			} catch (e) {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -56,6 +56,7 @@ export interface TorrentClient {
 	}) => Promise<Map<string, string>>;
 	resumeInjection: (
 		infoHash: string,
+		decision: DecisionAnyMatch,
 		options: { checkOnce: boolean },
 	) => Promise<void>;
 	inject: (
@@ -150,8 +151,8 @@ export function shouldRecheck(
 	searchee: Searchee,
 	decision: DecisionAnyMatch,
 ): boolean {
-	const { matchMode } = getRuntimeConfig();
-	if (matchMode === MatchMode.SAFE) return true;
+	const { skipRecheck } = getRuntimeConfig();
+	if (!skipRecheck) return true;
 	if (decision === Decision.MATCH_PARTIAL) return true;
 	if (!searchee.infoHash) return true;
 	if (hasExt(searchee.files, VIDEO_DISC_EXTENSIONS)) return true;
@@ -159,8 +160,9 @@ export function shouldRecheck(
 }
 
 // Resuming partials
-export function getMaxRemainingBytes() {
+export function getMaxRemainingBytes(decision: DecisionAnyMatch) {
 	const { matchMode, maxRemainingForResume } = getRuntimeConfig();
+	if (decision !== Decision.MATCH_PARTIAL) return 0;
 	if (matchMode !== MatchMode.PARTIAL) return 0;
 	return maxRemainingForResume * 1024 * 1024;
 }

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -161,10 +161,10 @@ export function shouldRecheck(
 
 // Resuming partials
 export function getMaxRemainingBytes(decision: DecisionAnyMatch) {
-	const { matchMode, maxRemainingForResume } = getRuntimeConfig();
+	const { matchMode, autoResumeMaxDownload } = getRuntimeConfig();
 	if (decision !== Decision.MATCH_PARTIAL) return 0;
 	if (matchMode !== MatchMode.PARTIAL) return 0;
-	return maxRemainingForResume * 1024 * 1024;
+	return autoResumeMaxDownload;
 }
 export const resumeSleepTime = ms("15 seconds");
 export const resumeErrSleepTime = ms("5 minutes");

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -273,10 +273,11 @@ export default class Transmission implements TorrentClient {
 
 	async resumeInjection(
 		infoHash: string,
+		decision: DecisionAnyMatch,
 		options: { checkOnce: boolean },
 	): Promise<void> {
 		let sleepTime = resumeSleepTime;
-		const maxRemainingBytes = getMaxRemainingBytes();
+		const maxRemainingBytes = getMaxRemainingBytes(decision);
 		const stopTime = getResumeStopTime();
 		let stop = false;
 		while (Date.now() < stopTime) {
@@ -363,7 +364,9 @@ export default class Transmission implements TorrentClient {
 					labels: [TORRENT_TAG],
 				},
 			);
-			this.resumeInjection(newTorrent.infoHash, { checkOnce: false });
+			this.resumeInjection(newTorrent.infoHash, decision, {
+				checkOnce: false,
+			});
 		} catch (e) {
 			return InjectionResult.FAILURE;
 		}

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -13,11 +13,20 @@ import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { loadTorrentDirLight } from "../torrent.js";
 import {
 	TorrentMetadataInClient,
+	getMaxRemainingBytes,
+	getResumeStopTime,
+	resumeErrSleepTime,
+	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
 	validateSavePaths,
 } from "./TorrentClient.js";
-import { extractCredentialsFromUrl } from "../utils.js";
+import {
+	extractCredentialsFromUrl,
+	humanReadableSize,
+	sanitizeInfoHash,
+	wait,
+} from "../utils.js";
 
 const XTransmissionSessionId = "X-Transmission-Session-Id";
 type Method =
@@ -25,7 +34,8 @@ type Method =
 	| "torrent-add"
 	| "torrent-get"
 	| "torrent-stop"
-	| "torrent-verify";
+	| "torrent-verify"
+	| "torrent-start";
 
 interface Response<T> {
 	result: "success" | string;
@@ -261,6 +271,65 @@ export default class Transmission implements TorrentClient {
 		});
 	}
 
+	async resumeInjection(
+		infoHash: string,
+		options: { checkOnce: boolean },
+	): Promise<void> {
+		let sleepTime = resumeSleepTime;
+		const maxRemainingBytes = getMaxRemainingBytes();
+		const stopTime = getResumeStopTime();
+		let stop = false;
+		while (Date.now() < stopTime) {
+			if (options.checkOnce) {
+				if (stop) return;
+				stop = true;
+			}
+			await wait(sleepTime);
+			const queryResponse = await this.request<TorrentGetResponseArgs>(
+				"torrent-get",
+				{
+					fields: ["leftUntilDone", "name", "status"],
+					ids: [infoHash],
+				},
+			);
+			if (queryResponse.torrents.length === 0) {
+				sleepTime = resumeErrSleepTime; // Dropping connections or restart
+				continue;
+			}
+			const [{ leftUntilDone, name, status }] = queryResponse.torrents;
+			if ([1, 2].includes(status)) {
+				continue;
+			}
+			const torrentLog = `${name} [${sanitizeInfoHash(infoHash)}]`;
+			if (status !== 0) {
+				logger.warn({
+					label: Label.TRANSMISSION,
+					message: `Will not resume ${torrentLog}: status is ${status}`,
+				});
+				return;
+			}
+			if (leftUntilDone > maxRemainingBytes) {
+				logger.warn({
+					label: Label.TRANSMISSION,
+					message: `Will not resume ${torrentLog}: ${humanReadableSize(leftUntilDone, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+				});
+				return;
+			}
+			logger.info({
+				label: Label.TRANSMISSION,
+				message: `Resuming ${torrentLog}: ${humanReadableSize(leftUntilDone, { binary: true })} remaining`,
+			});
+			await this.request<void>("torrent-start", {
+				ids: [infoHash],
+			});
+			return;
+		}
+		logger.warn({
+			label: Label.TRANSMISSION,
+			message: `Will not resume torrent ${infoHash}: timeout`,
+		});
+	}
+
 	async inject(
 		newTorrent: Metafile,
 		searchee: Searchee,
@@ -294,6 +363,7 @@ export default class Transmission implements TorrentClient {
 					labels: [TORRENT_TAG],
 				},
 			);
+			this.resumeInjection(newTorrent.infoHash, { checkOnce: false });
 		} catch (e) {
 			return InjectionResult.FAILURE;
 		}

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -124,6 +124,12 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.makeOptionMandatory(),
 		)
 		.option(
+			"--max-remaining-for-resume <decimal>",
+			"The maximum size in MB remaining for a torrent to be resumed",
+			parseFloat,
+			fallback(fileConfig.maxRemainingForResume, 50),
+		)
+		.option(
 			"--link-category <cat>",
 			"Torrent client category to set on linked torrents",
 			fallback(fileConfig.linkCategory, "cross-seed-link"),

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -124,6 +124,11 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.makeOptionMandatory(),
 		)
 		.option(
+			"--no-skip-recheck",
+			"Recheck every torrent before resuming. Leave this off to only recheck those that are necessary.",
+			fallback(fileConfig.skipRecheck, true),
+		)
+		.option(
 			"--max-remaining-for-resume <decimal>",
 			"The maximum size in MB remaining for a torrent to be resumed",
 			parseFloat,

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -129,10 +129,10 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			fallback(fileConfig.skipRecheck, true),
 		)
 		.option(
-			"--max-remaining-for-resume <decimal>",
-			"The maximum size in MB remaining for a torrent to be resumed",
-			parseFloat,
-			fallback(fileConfig.maxRemainingForResume, 50),
+			"--auto-resume-max-download <number>",
+			"The maximum size in bytes remaining for a torrent to be resumed",
+			parseInt,
+			fallback(fileConfig.autoResumeMaxDownload, 52428800),
 		)
 		.option(
 			"--link-category <cat>",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -220,10 +220,10 @@ module.exports = {
 	skipRecheck: true,
 
 	/**
-	 * The maximum size in MB remaining for a torrent to be resumed.
-	 * Must be in the range of 0 to 50.
+	 * The maximum size in bytes remaining for a torrent to be resumed.
+	 * Must be in the range of 0 to 52428800 (50 MiB).
 	 */
-	maxRemainingForResume: 50,
+	autoResumeMaxDownload: 52428800,
 
 	/**
 	 * Determines how deep into the specified dataDirs to go to generate new

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -199,7 +199,7 @@ module.exports = {
 	/**
 	 * Determines flexibility of naming during matching.
 	 * "safe" will allow only perfect name/size matches using the standard
-	 * matching algorithm. All matches will be checked before resuming.
+	 * matching algorithm.
 	 * "risky" uses filesize as its only comparison point.
 	 * "partial" is like risky but allows matches if they are missing small
 	 * files like .nfo/.srt.
@@ -212,8 +212,16 @@ module.exports = {
 	matchMode: "safe",
 
 	/**
+	 * Skip rechecking on injection if unnecessary. Certain matches will
+	 * always be rechecked such as: partial, data based, and disc files.
+	 * Set to false to recheck all torrents before resuming, usually unnecessary.
+	 * Torrents will be resumed regardless of this setting.
+	 */
+	skipRecheck: true,
+
+	/**
 	 * The maximum size in MB remaining for a torrent to be resumed.
-	 * Must be in the range of 0MB - 50MB.
+	 * Must be in the range of 0 to 50.
 	 */
 	maxRemainingForResume: 50,
 

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -199,7 +199,7 @@ module.exports = {
 	/**
 	 * Determines flexibility of naming during matching.
 	 * "safe" will allow only perfect name/size matches using the standard
-	 * matching algorithm.
+	 * matching algorithm. All matches will be checked before resuming.
 	 * "risky" uses filesize as its only comparison point.
 	 * "partial" is like risky but allows matches if they are missing small
 	 * files like .nfo/.srt.
@@ -210,6 +210,12 @@ module.exports = {
 	 * https://www.cross-seed.org/docs/tutorials/linking#hardlinks-vs-symlinks
 	 */
 	matchMode: "safe",
+
+	/**
+	 * The maximum size in MB remaining for a torrent to be resumed.
+	 * Must be in the range of 0MB - 50MB.
+	 */
+	maxRemainingForResume: 50,
 
 	/**
 	 * Determines how deep into the specified dataDirs to go to generate new

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -23,6 +23,7 @@ const ZodErrorMessages = {
 	fuzzySizeThreshold:
 		"fuzzySizeThreshold must be between 0 and 1 with a maximum of 0.1 when using searchCadence or rssCadence",
 	injectNeedsInjectMode: "`cross-seed inject` requires the 'inject' action.",
+	maxRemainingForResumeMax: "maxRemainingForResume must be between 0 and 50.",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -135,6 +136,10 @@ export const VALIDATION_SCHEMA = z
 		torznab: z.array(z.string().url()),
 		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
+		maxRemainingForResume: z
+			.number()
+			.gte(0, ZodErrorMessages.maxRemainingForResumeMax)
+			.lte(50, ZodErrorMessages.maxRemainingForResumeMax),
 		linkCategory: z.string().nullish(),
 		linkDir: z.string().nullish(),
 		linkType: z.nativeEnum(LinkType),

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -136,6 +136,7 @@ export const VALIDATION_SCHEMA = z
 		torznab: z.array(z.string().url()),
 		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
+		skipRecheck: z.boolean(),
 		maxRemainingForResume: z
 			.number()
 			.gte(0, ZodErrorMessages.maxRemainingForResumeMax)

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -23,7 +23,8 @@ const ZodErrorMessages = {
 	fuzzySizeThreshold:
 		"fuzzySizeThreshold must be between 0 and 1 with a maximum of 0.1 when using searchCadence or rssCadence",
 	injectNeedsInjectMode: "`cross-seed inject` requires the 'inject' action.",
-	maxRemainingForResumeMax: "maxRemainingForResume must be between 0 and 50.",
+	autoResumeMaxDownloadUnsupported:
+		"autoResumeMaxDownload must be between 0 and 52428800.",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -137,10 +138,10 @@ export const VALIDATION_SCHEMA = z
 		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
 		skipRecheck: z.boolean(),
-		maxRemainingForResume: z
+		autoResumeMaxDownload: z
 			.number()
-			.gte(0, ZodErrorMessages.maxRemainingForResumeMax)
-			.lte(50, ZodErrorMessages.maxRemainingForResumeMax),
+			.gte(0, ZodErrorMessages.autoResumeMaxDownloadUnsupported)
+			.lte(52428800, ZodErrorMessages.autoResumeMaxDownloadUnsupported),
 		linkCategory: z.string().nullish(),
 		linkDir: z.string().nullish(),
 		linkType: z.nativeEnum(LinkType),

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -24,7 +24,7 @@ const ZodErrorMessages = {
 		"fuzzySizeThreshold must be between 0 and 1 with a maximum of 0.1 when using searchCadence or rssCadence",
 	injectNeedsInjectMode: "`cross-seed inject` requires the 'inject' action.",
 	autoResumeMaxDownloadUnsupported:
-		"autoResumeMaxDownload must be between 0 and 52428800.",
+		"autoResumeMaxDownload must be an integer of bytes between between 0 and 52428800 (50 MiB).",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -140,6 +140,7 @@ export const VALIDATION_SCHEMA = z
 		skipRecheck: z.boolean(),
 		autoResumeMaxDownload: z
 			.number()
+			.int()
 			.gte(0, ZodErrorMessages.autoResumeMaxDownloadUnsupported)
 			.lte(52428800, ZodErrorMessages.autoResumeMaxDownloadUnsupported),
 		linkCategory: z.string().nullish(),

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,7 @@ export interface FileConfig {
 	excludeRecentSearch?: string;
 	dataDirs?: string[];
 	matchMode?: MatchMode;
+	skipRecheck?: boolean;
 	maxRemainingForResume?: number;
 	linkDir?: string;
 	linkType?: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,7 @@ export interface FileConfig {
 	excludeRecentSearch?: string;
 	dataDirs?: string[];
 	matchMode?: MatchMode;
+	maxRemainingForResume?: number;
 	linkDir?: string;
 	linkType?: string;
 	flatLinking?: boolean;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,7 +23,7 @@ export interface FileConfig {
 	dataDirs?: string[];
 	matchMode?: MatchMode;
 	skipRecheck?: boolean;
-	maxRemainingForResume?: number;
+	autoResumeMaxDownload?: number;
 	linkDir?: string;
 	linkType?: string;
 	flatLinking?: boolean;

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -545,7 +545,11 @@ async function injectSavedTorrent(
 	}
 }
 
-function logInjectSummary(summary: InjectSummary, flatLinking: boolean) {
+function logInjectSummary(
+	summary: InjectSummary,
+	flatLinking: boolean,
+	injectDir: string | undefined,
+) {
 	const incompleteMsg = `${chalk.bold.yellow(summary.ALREADY_EXISTS)} existed in client${
 		summary.INCOMPLETE_CANDIDATES
 			? chalk.dim(` (${summary.INCOMPLETE_CANDIDATES} were incomplete)`)
@@ -585,10 +589,12 @@ function logInjectSummary(summary: InjectSummary, flatLinking: boolean) {
 			message: `Some torrents could be linked to linkDir/${UNKNOWN_TRACKER} - follow .torrent naming format in the docs to avoid this`,
 		});
 	}
-	logger.info({
-		label: Label.INJECT,
-		message: `Waiting on post-injection tasks to complete...`,
-	});
+	if (injectDir) {
+		logger.info({
+			label: Label.INJECT,
+			message: `Waiting on post-injection tasks to complete...`,
+		});
+	}
 }
 
 function createSummary(total: number): InjectSummary {
@@ -630,7 +636,7 @@ export async function injectSavedTorrents(): Promise<void> {
 		const progress = chalk.blue(`(${i + 1}/${torrentFilePaths.length})`);
 		await injectSavedTorrent(progress, torrentFilePath, summary, searchees);
 	}
-	logInjectSummary(summary, flatLinking);
+	logInjectSummary(summary, flatLinking, injectDir);
 }
 
 export async function restoreFromTorrentCache(): Promise<void> {

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -5,6 +5,7 @@ export interface RuntimeConfig {
 	torznab: string[];
 	dataDirs?: string[];
 	matchMode: MatchMode;
+	skipRecheck: boolean;
 	maxRemainingForResume: number;
 	linkDir?: string;
 	linkType: LinkType;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -6,7 +6,7 @@ export interface RuntimeConfig {
 	dataDirs?: string[];
 	matchMode: MatchMode;
 	skipRecheck: boolean;
-	maxRemainingForResume: number;
+	autoResumeMaxDownload: number;
 	linkDir?: string;
 	linkType: LinkType;
 	flatLinking: boolean;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -5,6 +5,7 @@ export interface RuntimeConfig {
 	torznab: string[];
 	dataDirs?: string[];
 	matchMode: MatchMode;
+	maxRemainingForResume: number;
 	linkDir?: string;
 	linkType: LinkType;
 	flatLinking: boolean;


### PR DESCRIPTION
This offers `cross-seed` the highly requested ability to resume partial matches without user intervention. Also, we will now recheck and resume all non torrent based searchees as well since we can't tell if a data/virtual searchee is completed.

Readded the skipRecheck option since we can now resume torrents after rechecking.

The maximum that we will resume is `50MB` remaining. This was chosen as it should resume all normal partial matches while never resuming those from ensemble and for the `inject-saved-torrents` feature to only download missing data once between partial matches on different trackers. We do not need to check for fuzzy ratio as the decide stage already has for partial matches.

In the worst case, say a user has 100 partial matches for a single tracker, the maximum download from this would be `5GB`. This will never happen however as 50% of my partial matches are below `1MB`, 80% under `10MB` and 95% under `20MB`. And that's from testing with an aggressive `fuzzySizeThreshold` of `0.1` and including ensemble matches. So a user would likely need at least 1,000+ partials on a single tracker for `5GB` of `cross-seed` download.

This was implemented in an extremely safe way:
1. After injecting a partial, start a background function to check the torrent status
2. Check every `15s`. If it's in a rechecking state, repeat. Timeout of 1 hour.
3. If it's not paused, early exit.
4. If size remaining greater than max, early exit.
5. Resume otherwise.

To cover the case where `cross-seed` has restarted or the timeout elapsed, we also check with the hourly inject job and can resume from there.