### PR TITLE
enhancement(searchee): parse 'Season XX' or 'SXX' torrent titles

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -6,7 +6,6 @@ import { CrossSeedError } from "./errors.js";
 import { Label, logger } from "./logger.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Searchee } from "./searchee.js";
 import { Caps, IdSearchParams } from "./torznab.js";
 import {
 	cleanseSeparators,
@@ -240,7 +239,7 @@ function getRelevantArrInstances(mediaType: MediaType): string[] {
 }
 
 export async function scanAllArrsForMedia(
-	searchee: Searchee,
+	searcheeName: string,
 	mediaType: MediaType,
 ): Promise<Result<ParsedMedia, boolean>> {
 	const uArrLs = getRelevantArrInstances(mediaType);
@@ -249,10 +248,10 @@ export async function scanAllArrsForMedia(
 	}
 	const title =
 		mediaType !== MediaType.VIDEO
-			? searchee.name
+			? searcheeName
 			: cleanseSeparators(
 					sourceRegexRemove(
-						stripExtension(searchee.name)
+						stripExtension(searcheeName)
 							.replace(RELEASE_GROUP_REGEX, "")
 							.replace(RESOLUTION_REGEX, "")
 							.replace(REPACK_PROPER_REGEX, ""),
@@ -285,7 +284,7 @@ export async function scanAllArrsForMedia(
 			return resultOf(response);
 		}
 	}
-	logArrQueryResult({}, searchee.name, Label.ARRS, error);
+	logArrQueryResult({}, searcheeName, Label.ARRS, error);
 	return resultOfErr(false);
 }
 

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -239,7 +239,7 @@ function getRelevantArrInstances(mediaType: MediaType): string[] {
 }
 
 export async function scanAllArrsForMedia(
-	searcheeName: string,
+	searcheeTitle: string,
 	mediaType: MediaType,
 ): Promise<Result<ParsedMedia, boolean>> {
 	const uArrLs = getRelevantArrInstances(mediaType);
@@ -248,10 +248,10 @@ export async function scanAllArrsForMedia(
 	}
 	const title =
 		mediaType !== MediaType.VIDEO
-			? searcheeName
+			? searcheeTitle
 			: cleanseSeparators(
 					sourceRegexRemove(
-						stripExtension(searcheeName)
+						stripExtension(searcheeTitle)
 							.replace(RELEASE_GROUP_REGEX, "")
 							.replace(RESOLUTION_REGEX, "")
 							.replace(REPACK_PROPER_REGEX, ""),
@@ -284,7 +284,7 @@ export async function scanAllArrsForMedia(
 			return resultOf(response);
 		}
 	}
-	logArrQueryResult({}, searcheeName, Label.ARRS, error);
+	logArrQueryResult({}, searcheeTitle, Label.ARRS, error);
 	return resultOfErr(false);
 }
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -345,9 +345,10 @@ program
 	.description("Print a torrent's file tree")
 	.argument("torrent")
 	.action(async (fn) => {
-		console.log(
-			createSearcheeFromMetafile(await parseTorrentFromFilename(fn)),
+		const res = createSearcheeFromMetafile(
+			await parseTorrentFromFilename(fn),
 		);
+		res.isOk() ? console.log(res.unwrap()) : console.log(res.unwrapErr());
 	});
 
 program

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?!(?:19|20)\d{2})(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?(?!(?:19|20)\d{2})E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const IS_MULTI_EP_REGEX = /E\d+(?:[-.]?S\d+E\d|[-.]?E\d|[-.]\d)/i;
 export const SEASON_REGEX =
-	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s]?(?!E\d+))/i;
+	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s](?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:18|19|20)\d{2})[)\]]?(?![pix])/i;
 export const ANIME_REGEX =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?!(?:19|20)\d{2})(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?(?!(?:19|20)\d{2})E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const IS_MULTI_EP_REGEX = /E\d+(?:[-.]?S\d+E\d|[-.]?E\d|[-.]\d)/i;
 export const SEASON_REGEX =
-	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=[\]_.\s](?!E\d+))/i;
+	/^(?<title>.+?)[[_.\s-]+(?<season>S\d+)(?:[_.\s~-]*?(?<seasonmax>S?\d+))?(?=\b(?!E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:18|19|20)\d{2})[)\]]?(?![pix])/i;
 export const ANIME_REGEX =

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -15,8 +15,18 @@ function diff(thing1, thing2) {
 export async function diffCmd(first: string, second: string): Promise<void> {
 	const firstMeta = await parseTorrentFromFilename(first);
 	const secondMeta = await parseTorrentFromFilename(second);
-	const firstSearchee = createSearcheeFromMetafile(firstMeta);
-	const secondSearchee = createSearcheeFromMetafile(secondMeta);
+	const firstSearcheeRes = createSearcheeFromMetafile(firstMeta);
+	if (firstSearcheeRes.isErr()) {
+		console.log(firstSearcheeRes.unwrapErr());
+		return;
+	}
+	const secondSearcheeRes = createSearcheeFromMetafile(secondMeta);
+	if (secondSearcheeRes.isErr()) {
+		console.log(secondSearcheeRes.unwrapErr());
+		return;
+	}
+	const firstSearchee = firstSearcheeRes.unwrap();
+	const secondSearchee = secondSearcheeRes.unwrap();
 	delete firstSearchee.infoHash;
 	delete secondSearchee.infoHash;
 	diff(firstSearchee, secondSearchee);

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -47,6 +47,10 @@ export class Metafile {
 	infoHash: string;
 	length: number;
 	name: string;
+	/**
+	 * Always name, exists for compatibility with Searchee
+	 */
+	title: string;
 	pieceLength: number;
 	files: File[];
 	isSingleFileTorrent: boolean;
@@ -70,6 +74,7 @@ export class Metafile {
 		this.raw = raw;
 		this.infoHash = sha1(bencode.encode(raw.info));
 		this.name = fallback(raw.info["name.utf-8"], raw.info.name)!.toString();
+		this.title = this.name;
 		this.pieceLength = raw.info["piece length"];
 
 		if (!raw.info.files) {

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -21,7 +21,6 @@ import {
 	MediaType,
 	nMsAgo,
 } from "./utils.js";
-import chalk from "chalk";
 
 const MAX_INT = Number.MAX_SAFE_INTEGER;
 
@@ -32,14 +31,14 @@ function logReason(
 ): void {
 	logger.verbose({
 		label: Label.PREFILTER,
-		message: `${getLogString(searchee, chalk.reset)} | MediaType: ${mediaType.toUpperCase()} - was not selected for searching because ${reason}`,
+		message: `${getLogString(searchee)} | MediaType: ${mediaType.toUpperCase()} - was not selected for searching because ${reason}`,
 	});
 }
 
 function isSingleEpisode(searchee: Searchee, mediaType: MediaType): boolean {
 	if (mediaType === MediaType.EPISODE) return true;
 	if (mediaType !== MediaType.ANIME) return false;
-	return filesWithExt(searchee, VIDEO_EXTENSIONS).length === 1;
+	return filesWithExt(searchee.files, VIDEO_EXTENSIONS).length === 1;
 	// if (m === MediaType.EPISODE) return true;
 	// if (!(m === MediaType.ANIME || m === MediaType.VIDEO)) return false;
 	// if (searchee.files.length === 1 && m === MediaType.ANIME) return true;
@@ -148,20 +147,20 @@ export function findBlockedStringInReleaseMaybe(
  */
 export function filterDupesByName<T extends Searchee>(searchees: T[]): T[] {
 	const duplicateMap = searchees.reduce((acc, cur) => {
-		const entry = acc.get(cur.name);
+		const entry = acc.get(cur.title);
 		if (entry === undefined) {
-			acc.set(cur.name, cur);
+			acc.set(cur.title, cur);
 			return acc;
 		}
 		if (cur.files.length > entry.files.length) {
-			acc.set(cur.name, cur);
+			acc.set(cur.title, cur);
 			return acc;
 		}
 		if (cur.files.length < entry.files.length) {
 			return acc;
 		}
 		if (cur.infoHash && !entry.infoHash) {
-			acc.set(cur.name, cur);
+			acc.set(cur.title, cur);
 		}
 		return acc;
 	}, new Map());
@@ -223,7 +222,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			"timestamp.indexer_id": "indexer.id",
 			"timestamp.searchee_id": "searchee.id",
 		})
-		.where("searchee.name", searchee.name)
+		.where("searchee.name", searchee.title)
 		.whereIn(
 			"indexer.id",
 			enabledIndexers

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -235,7 +235,7 @@ function getKeysFromName(name: string): {
 	const episodeKey = getEpisodeKey(stem);
 	if (episodeKey) {
 		const keyTitles = [episodeKey.keyTitle];
-		const element = `${episodeKey.season}.${episodeKey.episode}`;
+		const element = `${episodeKey.season ? `${episodeKey.season}.` : ""}${episodeKey.episode}`;
 		return { keyTitles, element, useFallback: false };
 	}
 	const seasonKey = getSeasonKey(stem);

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -310,7 +310,7 @@ async function createTorznabSearchQueries(
 }
 
 export async function getSearchString(searchee: Searchee): Promise<string> {
-	const stem = stripExtension(searchee.name);
+	const stem = stripExtension(searchee.title);
 	const mediaType = getMediaType(searchee);
 	const params = (
 		await createTorznabSearchQueries(stem, mediaType, ALL_CAPS)
@@ -327,14 +327,14 @@ export async function getSearchString(searchee: Searchee): Promise<string> {
  * Ensure mediaType is what cross-seed would actually parse the item as.
  */
 export async function logQueries(
-	searcheeName: string,
+	searcheeTitle: string,
 	mediaType: MediaType,
 ): Promise<void> {
-	const stem = stripExtension(searcheeName);
+	const stem = stripExtension(searcheeTitle);
 	logger.info(
 		`RAW: ${inspect(await createTorznabSearchQueries(stem, mediaType, ALL_CAPS))}`,
 	);
-	const res = await scanAllArrsForMedia(searcheeName, mediaType);
+	const res = await scanAllArrsForMedia(searcheeTitle, mediaType);
 	const parsedMedia = res.isOk() ? res.unwrap() : undefined;
 	logger.info(
 		`ID: ${inspect(await createTorznabSearchQueries(stem, mediaType, ALL_CAPS, parsedMedia))}`,
@@ -400,7 +400,7 @@ export async function searchTorznab(
 				categories: JSON.parse(indexer.categories),
 			};
 			return await createTorznabSearchQueries(
-				stripExtension(searchee.name),
+				stripExtension(searchee.title),
 				mediaType,
 				caps,
 				parsedMedia,
@@ -746,7 +746,7 @@ async function getAndLogIndexers(
 	const enabledIndexers = await getEnabledIndexers();
 
 	// search history for name across all indexers
-	const name = searchee.name;
+	const name = searchee.title;
 	const timestampDataSql = await db("searchee")
 		.join("timestamp", "searchee.id", "timestamp.searchee_id")
 		.join("indexer", "timestamp.indexer_id", "indexer.id")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,6 @@ import {
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { File, Searchee } from "./searchee.js";
-import { Metafile } from "./parseTorrent.js";
 import chalk, { ChalkInstance } from "chalk";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 
@@ -58,8 +57,8 @@ export function humanReadableSize(bytes: number) {
 	const coefficient = bytes / Math.pow(k, exponent);
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
-export function filesWithExt(searchee: Searchee, exts: string[]): File[] {
-	return searchee.files.filter((f) => exts.includes(path.extname(f.name)));
+export function filesWithExt(files: File[], exts: string[]): File[] {
+	return files.filter((f) => exts.includes(path.extname(f.name)));
 }
 export function hasExt(searchee: Searchee, exts: string[]): boolean {
 	return searchee.files.some((f) => exts.includes(path.extname(f.name)));
@@ -77,16 +76,16 @@ export function getMediaType(searchee: Searchee): MediaType {
 
 	/* eslint-disable no-fallthrough */
 	switch (true) {
-		case EP_REGEX.test(searchee.name):
+		case EP_REGEX.test(searchee.title):
 			return MediaType.EPISODE;
-		case SEASON_REGEX.test(searchee.name):
+		case SEASON_REGEX.test(searchee.title):
 			return MediaType.SEASON;
 		case hasExt(searchee, VIDEO_EXTENSIONS):
-			if (MOVIE_REGEX.test(searchee.name)) return MediaType.MOVIE;
-			if (ANIME_REGEX.test(searchee.name)) return MediaType.ANIME;
+			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
+			if (ANIME_REGEX.test(searchee.title)) return MediaType.ANIME;
 			return MediaType.VIDEO;
 		case hasExt(searchee, [".rar"]):
-			if (MOVIE_REGEX.test(searchee.name)) return MediaType.MOVIE;
+			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
 		default:
 			return unsupportedMediaType(searchee);
 	}
@@ -174,17 +173,17 @@ export function humanReadableDate(timestamp: number): string {
 	return new Date(timestamp).toLocaleString("sv");
 }
 
-export function getLogString(data: Metafile | Searchee, color: ChalkInstance) {
-	if (data instanceof Metafile) {
-		return `${color(data.name)} ${chalk.dim(`[${data.infoHash.slice(0, 8)}...]`)}`;
-	}
-	return data.infoHash
-		? `${color(data.name)} ${chalk.dim(`[${data.infoHash.slice(0, 8)}...]`)}`
-		: !data.path
-			? color(data.name)
-			: data.name === path.basename(data.path)
-				? color(data.path)
-				: `${color(data.name)} ${chalk.dim(`[${data.path}]`)}`;
+export function getLogString(
+	searchee: Searchee,
+	color: ChalkInstance = chalk.reset,
+) {
+	return searchee.infoHash
+		? `${color(searchee.title)} ${chalk.dim(`[${searchee.infoHash.slice(0, 8)}...]`)}`
+		: !searchee.path
+			? color(searchee.title)
+			: searchee.title === searchee.name
+				? color(searchee.path)
+				: `${color(searchee.title)} ${chalk.dim(`[${searchee.path}]`)}`;
 }
 
 export function formatAsList(strings: string[]) {


### PR DESCRIPTION
Fixes:
1. `SEASON_REGEX` no longer matches episodes
2. `SEASON_REGEX` matches titles that end with the season

Now parsing `Season XX` or `SXX` titles from torrent based searchees as well. This required keeping track of the parsed title in the new `title` field. `title` is equal to `name` in all other scenarios.

The two places where `name` is now being used is for linking and client logging. Those require the original name. Otherwise `title` is better for searching, logging, and `searchee.name` in database (different shows won't collide).

As a bonus I added this for the anime releases that are just the show name. So if the torrent title is `Show` and it has a single episode, we will use the episode name as `Show SXXEYY`.