### PR TITLE
update(logging/checks): adds timeout on cap fetching and validates webhook params

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -138,12 +138,6 @@ export default class Deluge implements TorrentClient {
 		if (this.delugeCookie) headers.set("Cookie", this.delugeCookie);
 
 		let response: Response, json: DelugeJSON<ResultType>;
-		const abortController = new AbortController();
-
-		setTimeout(
-			() => void abortController.abort(),
-			ms("10 seconds"),
-		).unref();
 
 		try {
 			response = await fetch(href, {
@@ -154,7 +148,7 @@ export default class Deluge implements TorrentClient {
 				}),
 				method: "POST",
 				headers,
-				signal: abortController.signal,
+				signal: AbortSignal.timeout(ms("10 seconds")),
 			});
 		} catch (networkError) {
 			if (networkError.name === "AbortError") {

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -24,7 +24,6 @@ import {
 	filesWithExt,
 	getLogString,
 	isBadTitle,
-	isTruthy,
 	reformatTitleForSearching,
 	WithRequired,
 } from "./utils.js";

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -24,6 +24,7 @@ import {
 	filesWithExt,
 	getLogString,
 	isBadTitle,
+	isTruthy,
 	reformatTitleForSearching,
 	WithRequired,
 } from "./utils.js";

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import {
 } from "./pipeline.js";
 import { InjectionResult, SaveResult } from "./constants.js";
 import { indexNewTorrents, TorrentLocator } from "./torrent.js";
+import { existsSync } from "fs";
 
 function getData(req: IncomingMessage): Promise<string> {
 	return new Promise((resolve) => {
@@ -90,9 +91,16 @@ async function search(
 	}
 	const criteria: TorrentLocator = pick(data, ["infoHash", "path"]);
 
-	if (!("infoHash" in criteria || "path" in criteria)) {
+	if (
+		!(
+			(criteria.infoHash && criteria.infoHash.length === 40) ||
+			(criteria.path &&
+				criteria.path.length > 0 &&
+				existsSync(criteria.path))
+		)
+	) {
 		const message =
-			"An infoHash or path must be provided (infoHash is preferred).";
+			"A valid infoHash or path must be provided (infoHash is preferred).";
 		logger.error({ label: Label.WEBHOOK, message });
 		res.writeHead(400);
 		res.end(message);

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -523,8 +523,14 @@ async function fetchCaps(indexer: {
 }): Promise<Caps> {
 	let response;
 	try {
+		const abortController = new AbortController();
+		setTimeout(
+			() => void abortController.abort(),
+			ms("10 seconds"),
+		).unref();
 		response = await fetch(
 			assembleUrl(indexer.url, indexer.apikey, { t: "caps" }),
+			{ signal: abortController.signal },
 		);
 	} catch (e) {
 		const error = new Error(

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -523,14 +523,9 @@ async function fetchCaps(indexer: {
 }): Promise<Caps> {
 	let response;
 	try {
-		const abortController = new AbortController();
-		setTimeout(
-			() => void abortController.abort(),
-			ms("10 seconds"),
-		).unref();
 		response = await fetch(
 			assembleUrl(indexer.url, indexer.apikey, { t: "caps" }),
-			{ signal: abortController.signal },
+			{ signal: AbortSignal.timeout(ms("10 seconds")) },
 		);
 	} catch (e) {
 		const error = new Error(


### PR DESCRIPTION
there is no timeout set on fetchCaps - which depending on the number of indexers can delay config validation for what seems like indefinitely to a user with prowlarr/jackett not responding. this introduces a 10s timeout on cap fetching, which should be almost instant minus latency between cross-seed and prowlarr/jackett, as the indexer is not queried for this.

also added some sanity checking on webhook parameters, checks for correct length of infohash and the validity of a path on the fs before proceeding