### PR TITLE
fix(torznab-validation): checks hosts for connectivity before validating

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -7,6 +7,7 @@ import {
 	getRelevantArrIds,
 	ParsedMedia,
 	formatFoundIds,
+	checkArrIsActive,
 } from "./arr.js";
 import {
 	EP_REGEX,
@@ -631,6 +632,14 @@ export async function validateTorznabUrls() {
 			);
 		}
 	}
+
+	const uniqueUrls = new Set(
+		urls.map((url) => url.origin + "?" + url.searchParams.toString()),
+	);
+	for (const host of uniqueUrls) {
+		await checkArrIsActive(host, "Torznab");
+	}
+
 	await syncWithDb();
 	await updateCaps();
 


### PR DESCRIPTION
this checks all unique hostnames from the validated torznab array for connectivity prior to validating each individual indexer.

if prowlarr/jackett is not available at all -> `CrossSeedError`