### PR TITLE
revert(includeSingleEpisode): remove exemption behavior with rss when false

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -26,7 +26,7 @@ const ZodErrorMessages = {
 	qBitAutoTMM:
 		"If using Automatic Torrent Management in qBittorrent, please read: https://www.cross-seed.org/docs/v6-migration#qbittorrent",
 	includeSingleEpisodes:
-		"includeSingleEpisodes is not recommended when using rss or announce, please read: https://www.cross-seed.org/docs/v6-migration#updated-includesingleepisodes-behavior",
+		"includeSingleEpisodes is not recommended when using announce, please read: https://www.cross-seed.org/docs/v6-migration#updated-includesingleepisodes-behavior",
 	needsInject: "You need to use the 'inject' action for partial matching.",
 	needsLinkDir:
 		"You need to set a linkDir (and have your data accessible) for risky or partial matching to work.",

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -35,7 +35,10 @@ function logReason(
 	});
 }
 
-function isSingleEpisode(searchee: Searchee, mediaType: MediaType): boolean {
+export function isSingleEpisode(
+	searchee: Searchee,
+	mediaType: MediaType,
+): boolean {
 	if (mediaType === MediaType.EPISODE) return true;
 	if (mediaType !== MediaType.ANIME) return false;
 	return filesWithExt(searchee.files, VIDEO_EXTENSIONS).length === 1;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -82,7 +82,7 @@ export function filterByContent(
 
 	if (
 		!includeSingleEpisodes &&
-		![Label.ANNOUNCE, Label.RSS].includes(searchee.label) &&
+		searchee.label !== Label.ANNOUNCE &&
 		isSingleEpisode(searchee, mediaType)
 	) {
 		logReason("it is a single episode", searchee, mediaType);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -131,7 +131,7 @@ export function findBlockedStringInReleaseMaybe(
 ): string | undefined {
 	return blockList.find((blockedStr) => {
 		return (
-			searchee.name.includes(blockedStr) ||
+			searchee.title.includes(blockedStr) ||
 			(searchee.path &&
 				basename(dirname(searchee.path)).includes(blockedStr)) ||
 			blockedStr === searchee.infoHash


### PR DESCRIPTION
due to the inability to configure specific exclusions from RSS and autobrr's ability to exclude things from announce in filters, it seems prudent to remove the exclusion of RSS when set to false and only have announce be exempt.

for users wishing to exclude single episodes from their announce, [this is configurable from autobrr](https://autobrr.com/filters/examples#only-season-packs) and is not reliant on this setting in cross-seed to accomplish the same goal.

this allows for announce to be used to cross-seed single episodes, when searching for single episodes is not desired the option can still be set to false to relieve stress on API calls to indexers during searches.