### PR TITLE
enhancement(rss): support pagination for rss if gap longer than rssCadence

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -135,7 +135,10 @@ async function makeArrApiCall<ResponseType>(
 			headers: { "X-Api-Key": apikey },
 		});
 	} catch (networkError) {
-		if (networkError.name === "AbortError") {
+		if (
+			networkError.name === "AbortError" ||
+			networkError.name === "TimeoutError"
+		) {
 			return resultOfErr(new Error("connection timeout"));
 		}
 		return resultOfErr(networkError);

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -156,7 +156,10 @@ export default class Deluge implements TorrentClient {
 				signal: AbortSignal.timeout(ms("10 seconds")),
 			});
 		} catch (networkError) {
-			if (networkError.name === "AbortError") {
+			if (
+				networkError.name === "AbortError" ||
+				networkError.name === "TimeoutError"
+			) {
 				throw new Error(
 					`Deluge method ${method} timed out after 10 seconds`,
 				);

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -190,6 +190,7 @@ export const VALIDATION_SCHEMA = z
 			.nullish()
 			.refine(
 				(cadence) =>
+					process.env.DEV ||
 					!cadence ||
 					(cadence >= ms("10 minutes") && cadence <= ms("2 hours")),
 				ZodErrorMessages.rssCadenceUnsupported,
@@ -200,7 +201,8 @@ export const VALIDATION_SCHEMA = z
 			.transform(transformDurationString)
 			.nullish()
 			.refine(
-				(cadence) => !cadence || cadence >= ms("1 day"),
+				(cadence) =>
+					process.env.DEV || !cadence || cadence >= ms("1 day"),
 				ZodErrorMessages.searchCadenceUnsupported,
 			),
 		snatchTimeout: z

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -1,5 +1,6 @@
 import { db } from "./db.js";
 import { Label, logger } from "./logger.js";
+import { TorznabLimits } from "./torznab.js";
 import { humanReadableDate } from "./utils.js";
 
 export enum IndexerStatus {
@@ -27,6 +28,7 @@ export interface DbIndexer {
 	tvIdCaps: string;
 	movieIdCaps: string;
 	catCaps: string;
+	limitsCaps: string;
 }
 
 export interface IndexerCategories {
@@ -49,6 +51,7 @@ export interface Caps {
 	movieSearch: boolean;
 	movieIdSearch: IdSearchCaps;
 	tvIdSearch: IdSearchCaps;
+	limits: TorznabLimits;
 }
 
 export interface IdSearchCaps {
@@ -74,6 +77,7 @@ export interface Indexer {
 	tvIdCaps: IdSearchCaps;
 	movieIdCaps: IdSearchCaps;
 	categories: IndexerCategories;
+	limits: TorznabLimits;
 }
 
 const allFields = {
@@ -89,15 +93,17 @@ const allFields = {
 	tvIdCaps: "tv_id_caps",
 	movieIdCaps: "movie_id_caps",
 	catCaps: "cat_caps",
+	limitsCaps: "limits_caps",
 } as const;
 
 function deserialize(dbIndexer: DbIndexer): Indexer {
-	const { tvIdCaps, movieIdCaps, catCaps, ...rest } = dbIndexer;
+	const { tvIdCaps, movieIdCaps, catCaps, limitsCaps, ...rest } = dbIndexer;
 	return {
 		...rest,
 		tvIdCaps: JSON.parse(tvIdCaps),
 		movieIdCaps: JSON.parse(movieIdCaps),
 		categories: JSON.parse(catCaps),
+		limits: JSON.parse(limitsCaps),
 	};
 }
 
@@ -117,6 +123,7 @@ export async function getEnabledIndexers(): Promise<Indexer[]> {
 			tv_id_caps: null,
 			movie_id_caps: null,
 			cat_caps: null,
+			limits_caps: null,
 		})
 		.where({ active: true, search_cap: true })
 		.where((i) =>
@@ -185,6 +192,7 @@ export async function updateIndexerCapsById(indexerId: number, caps: Caps) {
 			movie_id_caps: JSON.stringify(caps.movieIdSearch),
 			tv_id_caps: JSON.stringify(caps.tvIdSearch),
 			cat_caps: JSON.stringify(caps.categories),
+			limits_caps: JSON.stringify(caps.limits),
 		});
 }
 

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -1,6 +1,5 @@
 import { db } from "./db.js";
 import { Label, logger } from "./logger.js";
-import { TorznabLimits } from "./torznab.js";
 import { humanReadableDate } from "./utils.js";
 
 export enum IndexerStatus {
@@ -44,14 +43,19 @@ export interface IndexerCategories {
 	additional: boolean;
 }
 
+export interface IndexerLimits {
+	default: number;
+	max: number;
+}
+
 export interface Caps {
 	search: boolean;
-	categories: IndexerCategories;
 	tvSearch: boolean;
 	movieSearch: boolean;
 	movieIdSearch: IdSearchCaps;
 	tvIdSearch: IdSearchCaps;
-	limits: TorznabLimits;
+	categories: IndexerCategories;
+	limits: IndexerLimits;
 }
 
 export interface IdSearchCaps {
@@ -77,7 +81,7 @@ export interface Indexer {
 	tvIdCaps: IdSearchCaps;
 	movieIdCaps: IdSearchCaps;
 	categories: IndexerCategories;
-	limits: TorznabLimits;
+	limits: IndexerLimits;
 }
 
 const allFields = {
@@ -95,6 +99,37 @@ const allFields = {
 	catCaps: "cat_caps",
 	limitsCaps: "limits_caps",
 } as const;
+
+export const ALL_CAPS: Caps = {
+	limits: {
+		default: 100,
+		max: 100,
+	},
+	search: true,
+	categories: {
+		tv: true,
+		movie: true,
+		anime: true,
+		xxx: true,
+		audio: true,
+		book: true,
+		additional: true,
+	},
+	tvSearch: true,
+	movieSearch: true,
+	movieIdSearch: {
+		tvdbId: true,
+		tmdbId: true,
+		imdbId: true,
+		tvMazeId: true,
+	},
+	tvIdSearch: {
+		tvdbId: true,
+		tmdbId: true,
+		imdbId: true,
+		tvMazeId: true,
+	},
+};
 
 function deserialize(dbIndexer: DbIndexer): Indexer {
 	const { tvIdCaps, movieIdCaps, catCaps, limitsCaps, ...rest } = dbIndexer;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -87,11 +87,17 @@ function stripAnsiChars(message: string | unknown) {
 	return stripAnsi(message);
 }
 
-const logOnceCache: string[] = [];
-export function logOnce(cacheKey: string, cb: () => void) {
-	if (!logOnceCache.includes(cacheKey)) {
-		logOnceCache.push(cacheKey);
+const logOnceCache: Set<string> = new Set();
+export function logOnce(cacheKey: string, cb: () => void, ttl?: number) {
+	if (!logOnceCache.has(cacheKey)) {
+		logOnceCache.add(cacheKey);
 		cb();
+
+		if (ttl) {
+			setTimeout(() => {
+				logOnceCache.delete(cacheKey);
+			}, ttl).unref();
+		}
 	}
 }
 

--- a/src/migrations/07-limits.ts
+++ b/src/migrations/07-limits.ts
@@ -1,0 +1,15 @@
+import Knex from "knex";
+
+async function up(knex: Knex.Knex): Promise<void> {
+	await knex.schema.alterTable("indexer", (table) => {
+		table.json("limits_caps");
+	});
+}
+
+async function down(knex: Knex.Knex): Promise<void> {
+	return knex.schema.table("indexer", function (table) {
+		table.dropColumn("limits_caps");
+	});
+}
+
+export default { name: "07-limits", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -5,6 +5,7 @@ import rateLimits from "./03-rateLimits.js";
 import auth from "./04-auth.js";
 import caps from "./05-caps.js";
 import uniqueDecisions from "./06-uniqueDecisions.js";
+import limits from "./07-limits.js";
 
 export const migrations = {
 	getMigrations: () =>
@@ -16,6 +17,7 @@ export const migrations = {
 			auth,
 			caps,
 			uniqueDecisions,
+			limits,
 		]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -43,8 +43,8 @@ import {
 } from "./searchee.js";
 import {
 	getInfoHashesToExclude,
-	getTorrentByCriteria,
 	getSimilarTorrentsByName,
+	getTorrentByCriteria,
 	indexNewTorrents,
 	loadTorrentDirLight,
 	TorrentLocator,
@@ -55,13 +55,7 @@ import {
 	queryRssFeeds,
 	searchTorznab,
 } from "./torznab.js";
-import {
-	getLogString,
-	humanReadableDate,
-	isTruthy,
-	wait,
-	WithRequired,
-} from "./utils.js";
+import { getLogString, humanReadableDate, isTruthy, wait } from "./utils.js";
 
 export interface Candidate {
 	guid: string;
@@ -72,7 +66,6 @@ export interface Candidate {
 	pubDate: number;
 	indexerId?: number;
 }
-type CandidateWithIndexerId = WithRequired<Candidate, "indexerId">;
 
 export interface AssessmentWithTracker {
 	assessment: ResultAssessment;
@@ -118,7 +111,7 @@ async function findOnOtherSites(
 	const searchedIndexers = response.length - cachedIndexers;
 	cachedSearch.indexerCandidates = response;
 
-	const results: CandidateWithIndexerId[] = response.flatMap((e) =>
+	const results: Candidate[] = response.flatMap((e) =>
 		e.candidates.map((candidate) => ({
 			...candidate,
 			indexerId: e.indexerId,
@@ -141,8 +134,8 @@ async function findOnOtherSites(
 		(acc, cur, idx) => {
 			const candidate = results[idx];
 			if (cur.assessment.decision === Decision.RATE_LIMITED) {
-				acc.rateLimited.add(candidate.indexerId);
-				acc.notRateLimited.delete(candidate.indexerId);
+				acc.rateLimited.add(candidate.indexerId!);
+				acc.notRateLimited.delete(candidate.indexerId!);
 			}
 			return acc;
 		},

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -18,6 +18,8 @@ import {
 import { db } from "./db.js";
 import { assessCandidateCaching, ResultAssessment } from "./decide.js";
 import {
+	getEnabledIndexers,
+	Indexer,
 	IndexerStatus,
 	updateIndexerStatus,
 	updateSearchTimestamps,
@@ -53,7 +55,13 @@ import {
 	queryRssFeeds,
 	searchTorznab,
 } from "./torznab.js";
-import { getLogString, isTruthy, wait } from "./utils.js";
+import {
+	getLogString,
+	humanReadableDate,
+	isTruthy,
+	wait,
+	WithRequired,
+} from "./utils.js";
 
 export interface Candidate {
 	guid: string;
@@ -64,6 +72,7 @@ export interface Candidate {
 	pubDate: number;
 	indexerId?: number;
 }
+type CandidateWithIndexerId = WithRequired<Candidate, "indexerId">;
 
 export interface AssessmentWithTracker {
 	assessment: ResultAssessment;
@@ -109,7 +118,7 @@ async function findOnOtherSites(
 	const searchedIndexers = response.length - cachedIndexers;
 	cachedSearch.indexerCandidates = response;
 
-	const results: Candidate[] = response.flatMap((e) =>
+	const results: CandidateWithIndexerId[] = response.flatMap((e) =>
 		e.candidates.map((candidate) => ({
 			...candidate,
 			indexerId: e.indexerId,
@@ -132,8 +141,8 @@ async function findOnOtherSites(
 		(acc, cur, idx) => {
 			const candidate = results[idx];
 			if (cur.assessment.decision === Decision.RATE_LIMITED) {
-				acc.rateLimited.add(candidate.indexerId!);
-				acc.notRateLimited.delete(candidate.indexerId!);
+				acc.rateLimited.add(candidate.indexerId);
+				acc.notRateLimited.delete(candidate.indexerId);
 			}
 			return acc;
 		},
@@ -480,10 +489,115 @@ export async function main(): Promise<void> {
 	});
 }
 
+/**
+ * Exclude indexers that don't support pagination
+ * only comparing indexers own time against itself.
+ */
+function filterRSSCandidates(
+	indexerId: number,
+	candidates: Candidate[],
+	page: number,
+	indexersToUse: Indexer[],
+	excludeIndexerIds: Set<number>,
+	oldestPerIndexer: Map<number, number>,
+	indexerParams: Map<number, { limit: number; offset: number }>,
+): CandidateWithIndexerId[] {
+	const prevOldest = oldestPerIndexer.get(indexerId) ?? Infinity;
+	const pagedCandidates = candidates.filter(
+		({ pubDate }) => pubDate < prevOldest,
+	);
+	const indexerUrl =
+		indexersToUse.find((i) => i.id === indexerId)?.url ??
+		indexerId.toString();
+	if (pagedCandidates.length) {
+		if (page > 1) {
+			logger.verbose({
+				label: Label.RSS,
+				message: `Indexer ${indexerUrl} returned ${pagedCandidates.length} new results for page #${page}`,
+			});
+		}
+		oldestPerIndexer.set(
+			indexerId,
+			pagedCandidates.reduce(
+				(acc, cur) => Math.min(acc, cur.pubDate),
+				Infinity,
+			),
+		);
+	} else {
+		logger.verbose({
+			label: Label.RSS,
+			message: `Indexer ${indexerUrl} returned no new results for page #${page}, no longer paging`,
+		});
+		excludeIndexerIds.add(indexerId);
+	}
+	const limit = candidates.length; // Override limit with what was actually returned
+	const offset = (indexerParams.get(indexerId)?.offset ?? 0) + limit;
+	indexerParams.set(indexerId, { limit, offset }); // For next page
+	return candidates.map((candidate) => ({
+		...candidate,
+		indexerId,
+	}));
+}
+
+async function parseRSSPage(
+	page: number,
+	lastRun: number,
+	indexersToUse: Indexer[],
+	excludeIndexerIds: Set<number>,
+	oldestPerIndexer: Map<number, number>,
+	indexerParams: Map<number, { limit: number; offset: number }>,
+): Promise<void> {
+	const indexerCandidates = await queryRssFeeds(indexersToUse, indexerParams);
+	const totalCandidates = indexerCandidates.reduce(
+		(acc, { candidates }) => acc + candidates.length,
+		0,
+	);
+	const candidatesSinceLastTime: Candidate[] = indexerCandidates
+		.flatMap(({ indexerId, candidates }) =>
+			filterRSSCandidates(
+				indexerId,
+				candidates,
+				page,
+				indexersToUse,
+				excludeIndexerIds,
+				oldestPerIndexer,
+				indexerParams,
+			),
+		)
+		.filter(({ indexerId, pubDate }) => {
+			if (pubDate < lastRun) {
+				excludeIndexerIds.add(indexerId);
+				return false;
+			}
+			return true;
+		})
+		.sort((a, b) => a.pubDate - b.pubDate);
+	logger.verbose({
+		label: Label.RSS,
+		message: `Scan returned ${
+			candidatesSinceLastTime.length
+		} new results, ignoring ${
+			totalCandidates - candidatesSinceLastTime.length
+		} already seen`,
+	});
+	logger.verbose({
+		label: Label.RSS,
+		message: "Indexing new torrents...",
+	});
+	await indexNewTorrents();
+	for (const [i, candidate] of candidatesSinceLastTime.entries()) {
+		const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
+		logger.verbose({
+			label: Label.RSS,
+			message: `(Page #${page}: ${i + 1}/${candidatesSinceLastTime.length}) ${humanReadableDate(candidate.pubDate)} - ${candidateLog}`,
+		});
+		await checkNewCandidateMatch(candidate, Label.RSS);
+	}
+}
+
 export async function scanRssFeeds() {
-	const { torznab } = getRuntimeConfig();
+	const { rssCadence, torznab } = getRuntimeConfig();
 	if (torznab.length > 0) {
-		const candidates = await queryRssFeeds();
 		const lastRun =
 			(
 				await db("job_log")
@@ -491,29 +605,42 @@ export async function scanRssFeeds() {
 					.where({ name: "rss" })
 					.first()
 			)?.last_run ?? 0;
-		const candidatesSinceLastTime = candidates.filter(
-			(c) => c.pubDate > lastRun,
-		);
-		logger.verbose({
-			label: Label.RSS,
-			message: `Scan returned ${
-				candidatesSinceLastTime.length
-			} new results, ignoring ${
-				candidates.length - candidatesSinceLastTime.length
-			} already seen`,
-		});
-		logger.verbose({
-			label: Label.RSS,
-			message: "Indexing new torrents...",
-		});
-		await indexNewTorrents();
-		for (const [i, candidate] of candidatesSinceLastTime.entries()) {
-			const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
-			logger.verbose({
-				label: Label.RSS,
-				message: `(${i + 1}/${candidatesSinceLastTime.length}) ${candidateLog}`,
-			});
-			await checkNewCandidateMatch(candidate, Label.RSS);
+		const pageLimit =
+			rssCadence && Date.now() - lastRun > rssCadence + ms("1 minute")
+				? 12
+				: 1;
+		const excludeIndexerIds: Set<number> = new Set();
+		const oldestPerIndexer: Map<number, number> = new Map();
+		const indexerParams: Map<number, { limit: number; offset: number }> =
+			new Map();
+		let indexersToUse: Indexer[] = [];
+		let prevSearchTime = 0;
+		for (let page = 1; page <= pageLimit; page++) {
+			const sleepTime = ms("5 minutes") - (Date.now() - prevSearchTime);
+			if (page > 1) {
+				logger.verbose({
+					label: Label.RSS,
+					message: `Getting page #${page} of RSS feeds ${sleepTime > 0 ? `in ${Math.round(sleepTime / 1000)}s` : "now"} (paging until #${pageLimit} or pubDate ${humanReadableDate(lastRun)})`,
+				});
+			}
+			if (sleepTime > 0) {
+				await wait(sleepTime);
+			}
+			const searchTime = Date.now();
+			indexersToUse = (await getEnabledIndexers()).filter(
+				(indexer) => !excludeIndexerIds.has(indexer.id),
+			);
+			if (!indexersToUse.length) break;
+			await parseRSSPage(
+				page,
+				lastRun,
+				indexersToUse,
+				excludeIndexerIds,
+				oldestPerIndexer,
+				indexerParams,
+			);
+			if (indexersToUse.every((i) => excludeIndexerIds.has(i.id))) break;
+			prevSearchTime = searchTime;
 		}
 		logger.info({ label: Label.RSS, message: "Scan complete" });
 	}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -20,6 +20,7 @@ import {
 import { db } from "./db.js";
 import { CrossSeedError } from "./errors.js";
 import {
+	ALL_CAPS,
 	Caps,
 	getAllIndexers,
 	getEnabledIndexers,
@@ -51,11 +52,6 @@ import {
 	stripMetaFromName,
 } from "./utils.js";
 
-export interface TorznabLimits {
-	default: number;
-	max: number;
-}
-
 export interface IdSearchParams {
 	tvdbid?: string;
 	tmdbid?: string;
@@ -72,37 +68,6 @@ export interface TorznabParams extends IdSearchParams {
 	season?: number | string;
 	ep?: number | string;
 }
-
-const ALL_CAPS: Caps = {
-	limits: {
-		default: 100,
-		max: 100,
-	},
-	search: true,
-	categories: {
-		tv: true,
-		movie: true,
-		anime: true,
-		xxx: true,
-		audio: true,
-		book: true,
-		additional: true,
-	},
-	tvSearch: true,
-	movieSearch: true,
-	movieIdSearch: {
-		tvdbId: true,
-		tmdbId: true,
-		imdbId: true,
-		tvMazeId: true,
-	},
-	tvIdSearch: {
-		tvdbId: true,
-		tmdbId: true,
-		imdbId: true,
-		tvMazeId: true,
-	},
-};
 
 type TorznabSearchTechnique =
 	| []
@@ -225,13 +190,13 @@ function parseTorznabCaps(xml: TorznabCaps): Caps {
 	}
 
 	return {
-		limits,
 		search: Boolean(isAvailable(searchingSection?.search)),
 		tvSearch: Boolean(isAvailable(searchingSection?.["tv-search"])),
 		movieSearch: Boolean(isAvailable(searchingSection?.["movie-search"])),
 		movieIdSearch: getSupportedIds(searchingSection?.["movie-search"]),
 		tvIdSearch: getSupportedIds(searchingSection?.["tv-search"]),
 		categories: getCatCaps(categoryCaps),
+		limits,
 	};
 }
 
@@ -412,13 +377,13 @@ export async function searchTorznab(
 		indexersToSearch,
 		async (indexer) => {
 			const caps = {
-				limits: indexer.limits,
 				search: indexer.searchCap,
 				tvSearch: indexer.tvSearchCap,
 				movieSearch: indexer.movieSearchCap,
 				tvIdSearch: indexer.tvIdCaps,
 				movieIdSearch: indexer.movieIdCaps,
 				categories: indexer.categories,
+				limits: indexer.limits,
 			};
 			return await createTorznabSearchQueries(
 				searchee,


### PR DESCRIPTION
If the `lastRun` for the rss job is more than `rssCadence + ms("1 minute")`, will page back until it's caught up or a maximum of 12 pages. Each rss request has a delay of 5 minute. Will detect if an indexer does not support pagination by comparing the candidates to the previous "page".

This should cover at least 3 hours to a few days depending on how many results the tracker returns each time and frequency of uploads. But unfortunately, it seems quite a few indexers don't support this. In that scenario it will only cost a single extra rss query regardless of how long `cross-seed` was down for.

Added a migration as we are now using indexer limits for rss scan.