### PR TITLE
update(schema/cli): allow override with --no of config for exclude options

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -191,6 +191,14 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"Exclude torrents which have been searched more recently than n minutes ago. Bypasses the -a flag.",
 			fileConfig.excludeRecentSearch,
 		)
+		.option(
+			"--no-exclude-older",
+			"Don't Exclude torrents based on when they were first seen.",
+		)
+		.option(
+			"--no-exclude-recent-search",
+			"Don't Exclude torrents based on when they were last searched.",
+		)
 		.option("-v, --verbose", "Log verbose output", false)
 		.addOption(
 			new Option(

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -144,12 +144,30 @@ export const VALIDATION_SCHEMA = z
 			.string()
 			.min(1, { message: ZodErrorMessages.emptyString })
 			.transform(transformDurationString)
-			.nullish(),
+			.nullish()
+			.or(
+				z
+					.boolean()
+					.refine((value) => value !== true, {
+						message: "Expected string, received boolean (true)",
+					})
+					.transform(() => null),
+			),
+
 		excludeRecentSearch: z
 			.string()
 			.min(1, { message: ZodErrorMessages.emptyString })
 			.transform(transformDurationString)
-			.nullish(),
+			.nullish()
+			.or(
+				z
+					.boolean()
+					.refine((value) => value !== true, {
+						message: "Expected string, received boolean (true)",
+					})
+					.transform(() => null),
+			),
+
 		action: z.nativeEnum(Action),
 		qbittorrentUrl: z.string().url().nullish(),
 		rtorrentRpcUrl: z.string().url().nullish(),


### PR DESCRIPTION
for many users, overriding the exclude time-based variables via cli has been valuable for searching, with zod this is not possible due to requiring ms formatting.

this PR allows the `--no` prefix to be used in commander (cli) for the cli parameters

`--no-exclude-older`
`--no-exclude-recent-search`