### PR TITLE
enhancement(blocklist): matches directory name of files for data-based searches

### DIFF
--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -133,6 +133,8 @@ export function findBlockedStringInReleaseMaybe(
 	return blockList.find((blockedStr) => {
 		return (
 			searchee.name.includes(blockedStr) ||
+			(searchee.path &&
+				basename(dirname(searchee.path)).includes(blockedStr)) ||
 			blockedStr === searchee.infoHash
 		);
 	});


### PR DESCRIPTION
this PR adds the ability for data-based searches to match the directory a file resides in

this is particularly useful for "Extras", "Trailers" and "Featurette" folders often associated with media servers such as plex, JF, and emby.

this also allows for blocking of entire directories in data based searches rather than requiring each individual file be added to the blocklist