### PR TITLE
enhancement(search): remove year from series

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -19,6 +19,7 @@ import {
 	RELEASE_GROUP_REGEX,
 	REPACK_PROPER_REGEX,
 	RESOLUTION_REGEX,
+	SCENE_TITLE_REGEX,
 	sourceRegexRemove,
 } from "./constants.js";
 
@@ -248,7 +249,7 @@ export async function scanAllArrsForMedia(
 	}
 	const title =
 		mediaType !== MediaType.VIDEO
-			? searcheeTitle
+			? searcheeTitle.match(SCENE_TITLE_REGEX)!.groups!.title
 			: cleanseSeparators(
 					sourceRegexRemove(
 						stripExtension(searcheeTitle)
@@ -256,7 +257,7 @@ export async function scanAllArrsForMedia(
 							.replace(RESOLUTION_REGEX, "")
 							.replace(REPACK_PROPER_REGEX, ""),
 					),
-				);
+				).match(SCENE_TITLE_REGEX)!.groups!.title;
 	let error = new Error(
 		`No ids found for ${title} | MediaType: ${mediaType.toUpperCase()}`,
 	);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const RELEASE_GROUP_REGEX =
 export const ANIME_GROUP_REGEX = /^\s*\[(?<group>.+?)\]/i;
 export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[pix](?:\d{3,4}[pi]?)?)\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
-export const YEAR_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/i;
+export const YEARS_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/gi;
 export const REPACK_PROPER_REGEX =
 	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))\b/i;
 export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -11,21 +11,19 @@ import {
 	parseSource,
 	SONARR_SUBFOLDERS_REGEX,
 	MOVIE_REGEX,
-	NON_UNICODE_ALPHANUM_REGEX,
 	VIDEO_EXTENSIONS,
-	YEAR_REGEX,
 } from "./constants.js";
 import { Label, logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { parseTorrentFromFilename } from "./torrent.js";
 import {
+	createKeyTitle,
 	extractInt,
 	filesWithExt,
 	getLogString,
 	hasExt,
 	isBadTitle,
-	reformatTitleForSearching,
 	WithRequired,
 } from "./utils.js";
 
@@ -290,10 +288,8 @@ export function getMovieKey(stem: string): {
 } | null {
 	const match = stem.match(MOVIE_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match.groups!.title)
-		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
-		.toLowerCase();
-	if (!keyTitle.length) return null;
+	const keyTitle = createKeyTitle(match.groups!.title);
+	if (!keyTitle) return null;
 	const year = extractInt(match.groups!.year);
 	const ensembleTitle = `${match.groups!.title}.${year}`;
 	return { ensembleTitle, keyTitle, year };
@@ -306,11 +302,8 @@ export function getSeasonKey(stem: string): {
 } | null {
 	const match = stem.match(SEASON_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match.groups!.title)
-		.replace(YEAR_REGEX, "")
-		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
-		.toLowerCase();
-	if (!keyTitle.length) return null;
+	const keyTitle = createKeyTitle(match.groups!.title);
+	if (!keyTitle) return null;
 	const season = `S${extractInt(match.groups!.season)}`;
 	const ensembleTitle = `${match.groups!.title}.${season}`;
 	return { ensembleTitle, keyTitle, season };
@@ -324,11 +317,8 @@ export function getEpisodeKey(stem: string): {
 } | null {
 	const match = stem.match(EP_REGEX);
 	if (!match) return null;
-	const keyTitle = reformatTitleForSearching(match!.groups!.title)
-		.replace(YEAR_REGEX, "")
-		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
-		.toLowerCase();
-	if (!keyTitle.length) return null;
+	const keyTitle = createKeyTitle(match.groups!.title);
+	if (!keyTitle) return null;
 	const season = match!.groups!.season
 		? `S${extractInt(match!.groups!.season)}`
 		: match!.groups!.year
@@ -355,11 +345,8 @@ export function getAnimeKeys(stem: string): {
 	for (const title of [firstTitle, altTitle]) {
 		if (!title) continue;
 		if (isBadTitle(title)) continue;
-		const keyTitle = reformatTitleForSearching(title)
-			.replace(YEAR_REGEX, "")
-			.replace(NON_UNICODE_ALPHANUM_REGEX, "")
-			.toLowerCase();
-		if (!keyTitle.length) continue;
+		const keyTitle = createKeyTitle(title);
+		if (!keyTitle) return null;
 		keyTitles.push(keyTitle);
 		ensembleTitles.push(title);
 	}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -28,7 +28,7 @@ import { Candidate } from "./pipeline.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee, SearcheeWithLabel } from "./searchee.js";
 import {
-	cleanseSeparators,
+	cleanTitle,
 	extractInt,
 	formatAsList,
 	getAnimeQueries,
@@ -38,7 +38,7 @@ import {
 	isTruthy,
 	MediaType,
 	nMsAgo,
-	reformatNameForSearching,
+	reformatTitleForSearching,
 	sanitizeUrl,
 	stripExtension,
 } from "./utils.js";
@@ -257,7 +257,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "tvsearch",
-				q: useIds ? undefined : cleanseSeparators(groups.title),
+				q: useIds ? undefined : reformatTitleForSearching(stem),
 				season: groups.season ? extractInt(groups.season) : groups.year,
 				ep: groups.episode
 					? extractInt(groups.episode)
@@ -271,7 +271,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "tvsearch",
-				q: useIds ? undefined : cleanseSeparators(groups.title),
+				q: useIds ? undefined : reformatTitleForSearching(stem),
 				season: extractInt(groups.season),
 				...relevantIds,
 			},
@@ -280,7 +280,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "movie",
-				q: useIds ? undefined : reformatNameForSearching(stem),
+				q: useIds ? undefined : reformatTitleForSearching(stem),
 				...relevantIds,
 			},
 		] as const;
@@ -299,14 +299,13 @@ async function createTorznabSearchQueries(
 			t: "search",
 			q: animeQuery,
 		}));
-	} else {
-		return [
-			{
-				t: "search",
-				q: cleanseSeparators(stem),
-			},
-		] as const;
 	}
+	return [
+		{
+			t: "search",
+			q: cleanTitle(stem),
+		},
+	] as const;
 }
 
 export async function getSearchString(searchee: Searchee): Promise<string> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,9 +7,11 @@ import {
 	Decision,
 	EP_REGEX,
 	MOVIE_REGEX,
+	NON_UNICODE_ALPHANUM_REGEX,
 	SCENE_TITLE_REGEX,
 	SEASON_REGEX,
 	VIDEO_EXTENSIONS,
+	YEARS_REGEX,
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { File, Searchee } from "./searchee.js";
@@ -134,6 +136,36 @@ export function cleanseSeparators(str: string): string {
 		.trim();
 }
 
+export function cleanTitle(title: string): string {
+	return cleanseSeparators(title).match(SCENE_TITLE_REGEX)!.groups!.title;
+}
+
+export function reformatTitleForSearching(name: string): string {
+	const seriesTitle =
+		name.match(EP_REGEX)?.groups?.title ??
+		name.match(SEASON_REGEX)?.groups?.title;
+	if (seriesTitle) {
+		const title = cleanTitle(seriesTitle);
+		return title.length > 4
+			? replaceLastOccurrence(title, YEARS_REGEX, "")
+					.replace(/\s+/g, " ")
+					.trim()
+			: title;
+	}
+	return cleanTitle(name.match(MOVIE_REGEX)?.[0] ?? name);
+}
+
+export function createKeyTitle(title: string): string | null {
+	const key = cleanTitle(title)
+		.replace(NON_UNICODE_ALPHANUM_REGEX, "")
+		.toLowerCase();
+	return key.length > 4
+		? replaceLastOccurrence(key, YEARS_REGEX, "")
+		: key.length
+			? key
+			: null;
+}
+
 export function isBadTitle(title: string): boolean {
 	return ["season", "ep"].includes(title.toLowerCase());
 }
@@ -143,26 +175,13 @@ export function getAnimeQueries(name: string): string[] {
 	const animeQueries: string[] = [];
 	const { title, altTitle, release } = name.match(ANIME_REGEX)?.groups ?? {};
 	if (title) {
-		animeQueries.push(cleanseSeparators(`${title} ${release}`));
+		animeQueries.push(cleanTitle(`${title} ${release}`));
 	}
 	if (altTitle) {
 		if (isBadTitle(altTitle)) return animeQueries;
-		animeQueries.push(cleanseSeparators(`${altTitle} ${release}`));
+		animeQueries.push(cleanTitle(`${altTitle} ${release}`));
 	}
 	return animeQueries;
-}
-
-export function reformatTitleForSearching(title: string): string {
-	return cleanseSeparators(title).match(SCENE_TITLE_REGEX)!.groups!.title;
-}
-
-export function reformatNameForSearching(name: string): string {
-	return reformatTitleForSearching(
-		name.match(EP_REGEX)?.groups?.title ??
-			name.match(SEASON_REGEX)?.groups?.title ??
-			name.match(MOVIE_REGEX)?.[0] ??
-			name,
-	);
 }
 
 export const tap = (fn) => (value) => {
@@ -233,8 +252,31 @@ export function extractCredentialsFromUrl(
 	}
 }
 
-export function capitalizeFirstLetter(string) {
+export function capitalizeFirstLetter(string: string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Replaces the last occurrence of a GLOBAL regex match in a string
+ * @param str The string to replace the last occurrence in
+ * @param globalRegExp The regex to match (must be global)
+ * @param newStr The string to replace the last occurrence with
+ */
+export function replaceLastOccurrence(
+	str: string,
+	globalRegExp: RegExp,
+	newStr: string,
+): string {
+	const matches = Array.from(str.matchAll(globalRegExp));
+	if (matches.length === 0) return str;
+	const lastMatch = matches[matches.length - 1];
+	const lastMatchIndex = lastMatch.index!;
+	const lastMatchStr = lastMatch[0];
+	return (
+		str.slice(0, lastMatchIndex) +
+		newStr +
+		str.slice(lastMatchIndex + lastMatchStr.length)
+	);
 }
 
 export function extractInt(str: string): number {


### PR DESCRIPTION
This is often gets removed causing issues with non id search. Movies should keep it however since it's consistent and helps reduce results which may get cut off.

Also, removing scene prefix before sending to arr as it seems to help.