### PR TITLE
fix(startup/perm): check config_dir exists before permissions check

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -40,8 +40,8 @@ module.exports = {
 	 *
 	 * Example: sonarr: ["http://sonarr:8989/?apikey=12345"],
 	 *
-	 *			sonarr: ["http://sonarr:8989/?apikey=12345",
-	 *					"http://sonarr4k:8989/?apikey=12345"],
+	 *      sonarr: ["http://sonarr:8989/?apikey=12345",
+	 *               "http://sonarr4k:8989/?apikey=12345"],
 	 */
 	sonarr: undefined,
 
@@ -56,8 +56,8 @@ module.exports = {
 	 *
 	 * Example: radarr: ["http://radarr:7878/?apikey=12345"],
 	 *
-	 * 			radarr: ["http://radarr:7878/?apikey=12345",
-	 * 					"http://radarr4k:7878/?apikey=12345"],
+	 *       radarr: ["http://radarr:7878/?apikey=12345",
+	 *                "http://radarr4k:7878/?apikey=12345"],
 	 */
 	radarr: undefined,
 
@@ -260,18 +260,18 @@ module.exports = {
 	 *
 	 * To search for all video media except individual episodes, use:
 	 *
-	 *		includeSingleEpisodes: false
-	 *		includeNonVideos: false
+	 *    includeSingleEpisodes: false
+	 *    includeNonVideos: false
 	 *
 	 * To search for all video media including individual episodes, use:
 	 *
-	 *		includeSingleEpisodes: true
-	 *		includeNonVideos: false
+	 *    includeSingleEpisodes: true
+	 *    includeNonVideos: false
 	 *
 	 * To search for absolutely ALL types of content, including non-video, configure
 	 * your episode settings based on the above examples and use:
 	 *
-	 * 		includeNonVideos: true
+	 *     includeNonVideos: true
 	 */
 	includeNonVideos: false,
 
@@ -388,10 +388,10 @@ module.exports = {
 	 *
 	 * examples:
 	 *
-	 *		blockList: ["-excludedGroup", "-excludedGroup2"],
-	 *		blocklist: ["x265"],
-	 *		blocklist: ["Release.Name"],
-	 *		blocklist: ["3317e6485454354751555555366a8308c1e92093"],
+	 *    blockList: ["-excludedGroup", "-excludedGroup2"],
+	 *    blocklist: ["x265"],
+	 *    blocklist: ["Release.Name"],
+	 *    blocklist: ["3317e6485454354751555555366a8308c1e92093"],
 	 */
 	blockList: undefined,
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -65,6 +65,9 @@ export function appDir(): string {
 	try {
 		accessSync(appDir, constants.R_OK | constants.W_OK);
 	} catch (e) {
+		if (e.code === "ENOENT") {
+			return appDir;
+		}
 		const dockerMessage =
 			process.env.DOCKER_ENV === "true"
 				? ` Use chown to set the owner to ${process.getuid!()}:${process.getgid!()}`


### PR DESCRIPTION
in windows, permissions check using accessSync in appDir() fails when the directory does not exist, have no received reports of this on linux but potentially could apply to it as well.

for users installing v6 fresh, when there is no config path in the appDir accessSync will throw erroneously failing to launch and generate any config directory.

this PR addresses this by checking if a path exists before running accessSync() on it. enabling the config path to be made if it does not exist rather than throw and terminate

fixes #766 
