### PR TITLE
update(mediatype/video): support for identifying mediatype of video disc images

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -324,6 +324,7 @@ export default class Deluge implements TorrentClient {
 				torrentFileName,
 				encodedTorrentData,
 				torrentPath,
+				searchee,
 				decision,
 			);
 
@@ -355,7 +356,7 @@ export default class Deluge implements TorrentClient {
 					this.calculateLabel(searchee, torrentInfo!),
 				);
 
-				if (shouldRecheck(decision)) {
+				if (shouldRecheck(searchee, decision)) {
 					// when paused, libtorrent doesnt start rechecking
 					// leaves torrent ready to download - ~99%
 					await wait(1000);
@@ -386,9 +387,10 @@ export default class Deluge implements TorrentClient {
 		filename: string,
 		filedump: string,
 		path: string,
+		searchee: Searchee,
 		decision: DecisionAnyMatch,
 	): InjectData {
-		const toRecheck = shouldRecheck(decision);
+		const toRecheck = shouldRecheck(searchee, decision);
 		return [
 			filename,
 			filedump,

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -407,7 +407,7 @@ export default class QBittorrent implements TorrentClient {
 			const buffer = new Blob([newTorrent.encode()], {
 				type: "application/x-bittorrent",
 			});
-			const toRecheck = shouldRecheck(decision);
+			const toRecheck = shouldRecheck(searchee, decision);
 
 			// ---------------------- Building form data ----------------------
 			const formData = new FormData();

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -313,7 +313,9 @@ export default class RTorrent implements TorrentClient {
 
 		await saveWithLibTorrentResume(meta, torrentFilePath, basePath);
 
-		const loadType = shouldRecheck(decision) ? "load" : "load.start";
+		const loadType = shouldRecheck(searchee, decision)
+			? "load"
+			: "load.start";
 
 		for (let i = 0; i < 5; i++) {
 			try {

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -201,7 +201,7 @@ export default class Transmission implements TorrentClient {
 				{
 					"download-dir": downloadDir,
 					metainfo: newTorrent.encode().toString("base64"),
-					paused: shouldRecheck(decision),
+					paused: shouldRecheck(searchee, decision),
 					labels: [TORRENT_TAG],
 				},
 			);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,7 @@ export function sourceRegexRemove(title: string): string {
 }
 
 export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
+export const VIDEO_DISC_EXTENSIONS = [".m2ts", ".ifo", ".vob", ".bup"];
 export const AUDIO_EXTENSIONS = [
 	".wav",
 	".aiff",
@@ -97,6 +98,7 @@ export const ALL_EXTENSIONS = [
 	...VIDEO_EXTENSIONS,
 	...AUDIO_EXTENSIONS,
 	...BOOK_EXTENSIONS,
+	...VIDEO_DISC_EXTENSIONS,
 ];
 
 export const TORRENT_CACHE_FOLDER = "torrent_cache";

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -1,11 +1,12 @@
 import ms from "ms";
-import { extname, basename, dirname } from "path";
+import { basename, dirname } from "path";
 import { statSync } from "fs";
 import {
 	ARR_DIR_REGEX,
 	SONARR_SUBFOLDERS_REGEX,
 	SEASON_REGEX,
 	VIDEO_EXTENSIONS,
+	VIDEO_DISC_EXTENSIONS,
 } from "./constants.js";
 import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
@@ -17,6 +18,7 @@ import {
 	filesWithExt,
 	getLogString,
 	getMediaType,
+	hasExt,
 	humanReadableDate,
 	MediaType,
 	nMsAgo,
@@ -94,7 +96,9 @@ export function filterByContent(
 
 	const nonVideoSizeRatio =
 		searchee.files.reduce((acc, cur) => {
-			if (!VIDEO_EXTENSIONS.includes(extname(cur.name))) {
+			if (
+				!hasExt([cur], [...VIDEO_EXTENSIONS, ...VIDEO_DISC_EXTENSIONS])
+			) {
 				return acc + cur.length;
 			}
 			return acc;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,7 +98,8 @@ export function getMediaType(searchee: Searchee): MediaType {
 			return unsupportedMediaType(searchee);
 	}
 }
-export function shouldRecheck(decision: Decision): boolean {
+export function shouldRecheck(searchee: Searchee, decision: Decision): boolean {
+	if (hasExt(searchee.files, VIDEO_DISC_EXTENSIONS)) return true;
 	switch (decision) {
 		case Decision.MATCH:
 		case Decision.MATCH_SIZE_ONLY:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
 	NON_UNICODE_ALPHANUM_REGEX,
 	SCENE_TITLE_REGEX,
 	SEASON_REGEX,
+	VIDEO_DISC_EXTENSIONS,
 	VIDEO_EXTENSIONS,
 	YEARS_REGEX,
 } from "./constants.js";
@@ -60,10 +61,12 @@ export function humanReadableSize(bytes: number) {
 	return `${parseFloat(coefficient.toFixed(2))} ${sizes[exponent]}`;
 }
 export function filesWithExt(files: File[], exts: string[]): File[] {
-	return files.filter((f) => exts.includes(path.extname(f.name)));
+	return files.filter((f) =>
+		exts.includes(path.extname(f.name.toLowerCase())),
+	);
 }
 export function hasExt(files: File[], exts: string[]): boolean {
-	return files.some((f) => exts.includes(path.extname(f.name)));
+	return files.some((f) => exts.includes(path.extname(f.name.toLowerCase())));
 }
 export function getMediaType(searchee: Searchee): MediaType {
 	function unsupportedMediaType(searchee: Searchee): MediaType {
@@ -85,6 +88,9 @@ export function getMediaType(searchee: Searchee): MediaType {
 		case hasExt(searchee.files, VIDEO_EXTENSIONS):
 			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
 			if (ANIME_REGEX.test(searchee.title)) return MediaType.ANIME;
+			return MediaType.VIDEO;
+		case hasExt(searchee.files, VIDEO_DISC_EXTENSIONS):
+			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
 			return MediaType.VIDEO;
 		case hasExt(searchee.files, [".rar"]):
 			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;


### PR DESCRIPTION
this PR adds a new array for file extensions found on Blu-ray and DVD disc images (excluding single image files - iso/img/etc) and adds a case to the switch in getMediaType for unparsable titles/folders that contain these to be identified as the VIDEO mediaType

in addition, all video discs will be rechecked and paused due to inconsistencies possible. resolving these will require manual user intervention if a conflict exists - the invalid files will need to be deleted manually to break links - and then resumed. this will otherwise overwrite the files and break the searchee's torrent.