### PR TITLE
fix(search): remove erroneous hyphens in torznab queries

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,9 +128,10 @@ export function getApikey(url: string) {
 }
 export function cleanseSeparators(str: string): string {
 	return str
-		.replace(/\[.*?\]|「.*?」|｢.*?｣|【.*?】/g, "")
-		.replace(/[._()[\]]/g, " ")
-		.replace(/\s+/g, " ")
+		.replace(/\[.*?\]|「.*?」|｢.*?｣|【.*?】/g, "") // bracketed text
+		.replace(/[._()[\]]/g, " ") // release delimiters (except '-')
+		.replace(/\s+/g, " ") // successive spaces
+		.replace(/^\s*-+|-+\s*$/g, "") // "trim()" hyphens
 		.trim();
 }
 


### PR DESCRIPTION
when certain release names, usually non-standard or unsupported media, end with a hyphen this can be appended to the search string erroneously. 

I've done the same for the beginning of the query as well for completeness.

example: `Gav Thorpe - Catechism Of Hate - [epub]`

[epub] is excluded in `cleanseSeparators` and thus a trailing - is appended to the string due to hyphens not being cleansed at all.

resulting query: `t=search&q=Gav+Thorpe+-+Catechism+Of+Hate+-`

this PR checks for preceding and trailing hyphens and removes them