### PR TITLE
enhancement(blocklist): torrent categories, tags, labels, sizes, and tracker hosts

### DIFF
--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -118,8 +118,8 @@ export async function validateSavePaths(
 		try {
 			testLinking(savePath);
 		} catch (e) {
-			logger.error(e); // We need to check that this torrent wasn't blocklisted so only log for now
-			logger.error(
+			logger.error(e);
+			throw new CrossSeedError(
 				"Failed to link from torrent client save paths to linkDir.",
 			);
 		}

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -382,20 +382,42 @@ module.exports = {
 	searchLimit: 400,
 
 	/**
-	 * The list of infohashes or strings which are contained in torrents or data
-	 * searches that you want to be excluded from cross-seed. This is the same
-	 * format as torznab, surround the entire set of quoted strings in square
-	 * brackets.
+	 * The list of infohashes, categories, tags, labels, tracker urls, sizes, folders, and substrings
+	 * of names you want to be excluded from cross-seed.
 	 *
-	 * You can use any combination which must be entered on the one line.
-	 * Leave as undefined to disable.
+	 * IMPORTANT: The tracker urls are NOT the same as the website,
+	 * you need to look at the url in client which may be different.
+	 * If the announce url is https://user:pass@tracker.example.com:8080/announce/key,
+	 * you must use "tracker:tracker.example.com:8080".
+	 *
+	 * This is the same format as torznab, surround the entire set of
+	 * quoted strings in square brackets. You can use any combination
+	 * which must be entered on the one line. Leave as undefined to disable.
+	 *
+	 * Each string must be prefixed with the type of block you want to use,
+	 * followed by a colon. Labels are considered tags.
+	 * "name:", "folder:", "category:", "tag:", "tracker:", "hash:", "sizeBelow:", "sizeAbove:"
+	 * Note that sizes are an integer for the number of bytes.
+	 * There are additional prefixes that take in a regex for more complex matching.
+	 * Read more: https://www.cross-seed.org/docs/basics/options#blocklist
 	 *
 	 * examples:
 	 *
-	 *    blockList: ["-excludedGroup", "-excludedGroup2"],
-	 *    blocklist: ["x265"],
-	 *    blocklist: ["Release.Name"],
-	 *    blocklist: ["3317e6485454354751555555366a8308c1e92093"],
+	blockList: [
+		"name:Release.Name",
+		"name:-excludedGroup",
+		"name:x265",
+		"nameRegex:[Rr]elease[.\s][Nn]ame",
+		"folder:folderName",
+		"folderRegex:folder\d+",
+		"category:icycool",
+		"tag:everybody",
+		"tracker:tracker.example.com:8080",
+		"hash:3317e6485454354751555555366a8308c1e92093",
+		"sizeBelow:12345",
+		"sizeAbove:98765",
+	],
+	 * 
 	 */
 	blockList: [],
 };

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -2,13 +2,27 @@ import { readdirSync } from "fs";
 import ms from "ms";
 import { isAbsolute, relative, resolve } from "path";
 import { ErrorMapCtx, RefinementCtx, z, ZodIssueOptionalMessage } from "zod";
-import { Action, LinkType, MatchMode, NEWLINE_INDENT } from "./constants.js";
+import {
+	Action,
+	BlocklistType,
+	LinkType,
+	MatchMode,
+	NEWLINE_INDENT,
+	parseBlocklistEntry,
+} from "./constants.js";
 import { logger } from "./logger.js";
+import { formatAsList } from "./utils.js";
 
 /**
  * error messages and map returned upon Zod validation failure
  */
 const ZodErrorMessages = {
+	blocklistType: `Blocklist item does not start with a valid prefix. Must be of ${formatAsList(Object.values(BlocklistType), { sort: false, style: "narrow", type: "unit" })}`,
+	blocklistRegex: `Blocklist regex is not a valid regex.`,
+	blocklistFolder: `Blocklist folder must not contain path separators`,
+	blocklistTracker: `Blocklist tracker is not a valid URL host. If URL is https://user:pass@tracker.example.com:8080/announce/key, you must use "tracker:tracker.example.com:8080"`,
+	blocklistHash: `Blocklist hash must be 40 characters and alphanumeric`,
+	blocklistSize: `Blocklist size must be an integer for the number of bytes. You can only have one sizeBelow, one sizeAbove, and sizeBelow <= sizeAbove.`,
 	vercel: "format does not follow vercel's `ms` style ( https://github.com/vercel/ms#examples )",
 	emptyString:
 		"cannot have an empty string. If you want to unset it, use null or undefined.",
@@ -92,9 +106,10 @@ function addZodIssue(
 
 /**
  * helper function for ms time validation
+ * @param durationStr the duration string to validate
+ * @param ctx ZodError map
  * @return transformed duration (string -> milliseconds)
  */
-
 function transformDurationString(durationStr: string, ctx: RefinementCtx) {
 	const duration = ms(durationStr);
 	if (isNaN(duration)) {
@@ -105,9 +120,92 @@ function transformDurationString(durationStr: string, ctx: RefinementCtx) {
 }
 
 /**
- * check a potential child path being inside an array of parent paths
- * @param childDir path of the potential child (e.g. linkDir)
- * @param parentDirs array of parentDir paths (e.g. dataDirs)
+ * helper function for verifying blocklist types
+ * @param blockList the blocklist to validate
+ * @param ctx ZodError map
+ * @return blocklist (string array)
+ */
+function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
+	if (!Array.isArray(blockList)) {
+		return [];
+	}
+	const sizeTest = (value: string, existing: number) => {
+		if (!existing) {
+			const match = value.match(/^\d+$/);
+			if (match) return parseInt(match[0]);
+		}
+		addZodIssue(value, ZodErrorMessages.blocklistSize, ctx);
+		return existing;
+	};
+	let sizeBelow = 0;
+	let sizeAbove = 0;
+	for (const [index, blockRaw] of blockList.entries()) {
+		const entry = parseBlocklistEntry(blockRaw);
+		if (!entry) {
+			addZodIssue(blockRaw, ZodErrorMessages.blocklistType, ctx);
+			continue;
+		}
+		const { blocklistType, blocklistValue } = entry;
+		switch (blocklistType) {
+			case BlocklistType.NAME_REGEX:
+			case BlocklistType.FOLDER_REGEX:
+				try {
+					new RegExp(blocklistValue);
+				} catch (e) {
+					addZodIssue(blockRaw, ZodErrorMessages.blocklistRegex, ctx);
+				}
+				break;
+			case BlocklistType.TRACKER:
+				if (/[/@]|^[^.]*$/.test(blocklistValue)) {
+					addZodIssue(
+						blockRaw,
+						ZodErrorMessages.blocklistTracker,
+						ctx,
+					);
+				}
+				break;
+			case BlocklistType.FOLDER:
+				if (/[/\\]/.test(blocklistValue)) {
+					addZodIssue(
+						blockRaw,
+						ZodErrorMessages.blocklistFolder,
+						ctx,
+					);
+				}
+				break;
+			case BlocklistType.HASH:
+				if (!/^[a-z0-9]{40}$/i.test(blocklistValue)) {
+					addZodIssue(blockRaw, ZodErrorMessages.blocklistHash, ctx);
+				}
+				blockList[index] =
+					`${blocklistType}${blocklistValue.toLowerCase()}`;
+				break;
+			case BlocklistType.SIZE_BELOW: {
+				sizeBelow = sizeTest(blocklistValue, sizeBelow);
+				break;
+			}
+			case BlocklistType.SIZE_ABOVE: {
+				sizeAbove = sizeTest(blocklistValue, sizeAbove);
+				break;
+			}
+			default:
+				break;
+		}
+	}
+	if (sizeBelow && sizeAbove && sizeBelow > sizeAbove) {
+		addZodIssue(
+			"sizeBelow > sizeAbove",
+			ZodErrorMessages.blocklistSize,
+			ctx,
+		);
+	}
+	return blockList;
+}
+
+/**
+ * check a potential child path being inside a array of parent paths
+ * @param childDir path of the potential child (e.g linkDir)
+ * @param parentDirs array of parentDir paths (e.g dataDirs)
  * @returns true if `childDir` is inside any `parentDirs` at any nesting level, false otherwise.
  */
 function isChildPath(childDir: string, parentDirs: string[]): boolean {
@@ -234,10 +332,7 @@ export const VALIDATION_SCHEMA = z
 		searchLimit: z.number().nonnegative().nullish(),
 		verbose: z.boolean(),
 		torrents: z.array(z.string()).optional(),
-		blockList: z
-			.array(z.string())
-			.nullish()
-			.transform((value) => (Array.isArray(value) ? value : [])),
+		blockList: z.array(z.string()).nullish().transform(transformBlocklist),
 		apiKey: z.string().min(24).nullish(),
 		radarr: z
 			.array(z.string().url())

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -173,12 +173,12 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 					);
 				}
 				break;
-			case BlocklistType.HASH:
+			case BlocklistType.INFOHASH:
 				if (!/^[a-z0-9]{40}$/i.test(blocklistValue)) {
 					addZodIssue(blockRaw, ZodErrorMessages.blocklistHash, ctx);
 				}
 				blockList[index] =
-					`${blocklistType}${blocklistValue.toLowerCase()}`;
+					`${blocklistType}:${blocklistValue.toLowerCase()}`;
 				break;
 			case BlocklistType.SIZE_BELOW: {
 				sizeBelow = sizeTest(blocklistValue, sizeBelow);
@@ -189,7 +189,7 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 				break;
 			}
 			default:
-				break;
+				addZodIssue(blockRaw, ZodErrorMessages.blocklistType, ctx);
 		}
 	}
 	if (sizeBelow && sizeAbove && sizeBelow > sizeAbove) {

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -140,12 +140,11 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 	let sizeBelow = 0;
 	let sizeAbove = 0;
 	for (const [index, blockRaw] of blockList.entries()) {
-		const entry = parseBlocklistEntry(blockRaw);
-		if (!entry) {
+		if (!blockRaw.trim().length) {
 			addZodIssue(blockRaw, ZodErrorMessages.blocklistType, ctx);
 			continue;
 		}
-		const { blocklistType, blocklistValue } = entry;
+		const { blocklistType, blocklistValue } = parseBlocklistEntry(blockRaw);
 		switch (blocklistType) {
 			case BlocklistType.NAME_REGEX:
 			case BlocklistType.FOLDER_REGEX:
@@ -186,6 +185,12 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 			}
 			case BlocklistType.SIZE_ABOVE: {
 				sizeAbove = sizeTest(blocklistValue, sizeAbove);
+				break;
+			}
+			case BlocklistType.LEGACY: {
+				logger.error(
+					`Legacy style blocklist is deprecated, specify a specific type followed by a colon (e.g infoHash:) for ${blockRaw}`,
+				);
 				break;
 			}
 			default:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -221,17 +221,23 @@ export enum BlocklistType {
 	INFOHASH = "infoHash",
 	SIZE_BELOW = "sizeBelow",
 	SIZE_ABOVE = "sizeAbove",
+	LEGACY = "legacy",
 }
 const PARSE_BLOCKLIST_REGEX = /^(?<blocklistType>.+?):(?<blocklistValue>.+)$/;
 export function parseBlocklistEntry(blocklistEntry: string): {
 	blocklistType: BlocklistType;
 	blocklistValue: string;
-} | null {
+} {
 	const match = blocklistEntry.match(PARSE_BLOCKLIST_REGEX);
-	if (!match?.groups) return null;
+	if (match?.groups) {
+		return {
+			blocklistType: match.groups.blocklistType as BlocklistType,
+			blocklistValue: match.groups.blocklistValue,
+		};
+	}
 	return {
-		blocklistType: match.groups.blocklistType as BlocklistType,
-		blocklistValue: match.groups.blocklistValue,
+		blocklistType: BlocklistType.LEGACY,
+		blocklistValue: blocklistEntry,
 	};
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -210,6 +210,33 @@ export enum LinkType {
 	HARDLINK = "hardlink",
 }
 
+export enum BlocklistType {
+	NAME = "name:",
+	NAME_REGEX = "nameRegex:",
+	FOLDER = "folder:",
+	FOLDER_REGEX = "folderRegex:",
+	CATEGORY = "category:",
+	TAG = "tag:",
+	TRACKER = "tracker:",
+	HASH = "hash:",
+	SIZE_BELOW = "sizeBelow:",
+	SIZE_ABOVE = "sizeAbove:",
+}
+export function parseBlocklistEntry(blocklistEntry: string): {
+	blocklistType: BlocklistType;
+	blocklistValue: string;
+} | null {
+	try {
+		const blocklistType = blocklistEntry.match(
+			/^.+?:/,
+		)![0] as BlocklistType;
+		const blocklistValue = blocklistEntry.slice(blocklistType.length);
+		return { blocklistType, blocklistValue };
+	} catch (e) {
+		return null;
+	}
+}
+
 export const IGNORED_FOLDERS_SUBSTRINGS = [
 	"sample",
 	"proof",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -211,30 +211,28 @@ export enum LinkType {
 }
 
 export enum BlocklistType {
-	NAME = "name:",
-	NAME_REGEX = "nameRegex:",
-	FOLDER = "folder:",
-	FOLDER_REGEX = "folderRegex:",
-	CATEGORY = "category:",
-	TAG = "tag:",
-	TRACKER = "tracker:",
-	HASH = "hash:",
-	SIZE_BELOW = "sizeBelow:",
-	SIZE_ABOVE = "sizeAbove:",
+	NAME = "name",
+	NAME_REGEX = "nameRegex",
+	FOLDER = "folder",
+	FOLDER_REGEX = "folderRegex",
+	CATEGORY = "category",
+	TAG = "tag",
+	TRACKER = "tracker",
+	INFOHASH = "infoHash",
+	SIZE_BELOW = "sizeBelow",
+	SIZE_ABOVE = "sizeAbove",
 }
+const PARSE_BLOCKLIST_REGEX = /^(?<blocklistType>.+?):(?<blocklistValue>.+)$/;
 export function parseBlocklistEntry(blocklistEntry: string): {
 	blocklistType: BlocklistType;
 	blocklistValue: string;
 } | null {
-	try {
-		const blocklistType = blocklistEntry.match(
-			/^.+?:/,
-		)![0] as BlocklistType;
-		const blocklistValue = blocklistEntry.slice(blocklistType.length);
-		return { blocklistType, blocklistValue };
-	} catch (e) {
-		return null;
-	}
+	const match = blocklistEntry.match(PARSE_BLOCKLIST_REGEX);
+	if (!match?.groups) return null;
+	return {
+		blocklistType: match.groups.blocklistType as BlocklistType,
+		blocklistValue: match.groups.blocklistValue,
+	};
 }
 
 export const IGNORED_FOLDERS_SUBSTRINGS = [

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -25,9 +25,18 @@ export async function diffCmd(first: string, second: string): Promise<void> {
 		console.log(secondSearcheeRes.unwrapErr());
 		return;
 	}
+
 	const firstSearchee: Searchee = firstSearcheeRes.unwrap();
-	const secondSearchee: Searchee = secondSearcheeRes.unwrap();
 	delete firstSearchee.infoHash;
+	delete firstSearchee.category;
+	delete firstSearchee.tags;
+	delete firstSearchee.trackers;
+
+	const secondSearchee: Searchee = secondSearcheeRes.unwrap();
 	delete secondSearchee.infoHash;
+	delete secondSearchee.category;
+	delete secondSearchee.tags;
+	delete secondSearchee.trackers;
+
 	diff(firstSearchee, secondSearchee);
 }

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -3,7 +3,6 @@ import { createHash } from "crypto";
 import { join } from "path";
 import { File, parseTitle } from "./searchee.js";
 import { fallback, isTruthy } from "./utils.js";
-import { readFileSync } from "fs";
 
 interface TorrentDirent {
 	length: number;
@@ -39,22 +38,6 @@ interface TorrentMetadata {
 	trackers?: Buffer[][];
 	"qBt-category"?: Buffer;
 	"qBt-tags"?: Buffer;
-	custom1?: Buffer;
-	label?: Buffer;
-	labels?: Buffer;
-}
-
-interface DelugeLabelConf {
-	torrent_labels: {
-		[key: string]: string;
-	};
-}
-
-export function parseDelugeLabelConf(filepath: string): DelugeLabelConf {
-	const lines = readFileSync(filepath).toString().split("\n");
-	lines.splice(0, 3);
-	lines[0] = "{";
-	return JSON.parse(lines.join("\n"));
 }
 
 function sanitizeTrackerUrls(urls: Buffer[]): string[] {
@@ -74,19 +57,6 @@ export function updateMetafileMetadata(
 	metafile: Metafile,
 	metadata: TorrentMetadata,
 ): void {
-	if (metadata.label) {
-		metafile.tags = [metadata.label.toString()];
-		return; // Deluge
-	}
-	if (metadata.custom1) {
-		metafile.tags = [metadata.custom1.toString()];
-		return; // rTorrent
-	}
-	if (metadata.labels) {
-		metafile.tags = metadata.labels.toString().split(",");
-		return; // Transmission
-	}
-	// qBittorrent
 	if (metadata["qBt-category"]) {
 		metafile.category = metadata["qBt-category"].toString();
 	}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import { zip } from "lodash-es";
 import ms from "ms";
 import { performAction, performActions } from "./action.js";
+import { getClient } from "./clients/TorrentClient.js";
 import {
 	ActionResult,
 	Decision,
@@ -419,8 +420,11 @@ export async function findAllSearchees(
 	const { torrents, dataDirs, torrentDir } = getRuntimeConfig();
 	const rawSearchees: Searchee[] = [];
 	if (Array.isArray(torrents)) {
+		const torrentInfos = (await getClient()?.getAllTorrents()) ?? [];
 		const searcheeResults = await Promise.all(
-			torrents.map(createSearcheeFromTorrentFile), // Also create searchee from path
+			torrents.map((torrent) =>
+				createSearcheeFromTorrentFile(torrent, torrentInfos),
+			),
 		);
 		rawSearchees.push(
 			...searcheeResults.filter(isOk).map((r) => r.unwrap()),

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -166,7 +166,7 @@ export function findBlockedStringInReleaseMaybe(
 				return searchee.trackers?.some((tier) =>
 					tier.some((url) => url === blocklistValue),
 				);
-			case BlocklistType.HASH:
+			case BlocklistType.INFOHASH:
 				return blocklistValue === searchee.infoHash;
 			case BlocklistType.SIZE_BELOW:
 				return searchee.length < parseInt(blocklistValue);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -142,7 +142,7 @@ export function findBlockedStringInReleaseMaybe(
 ): string | undefined {
 	return blockList.find((blockedStr) => {
 		const { blocklistType, blocklistValue } =
-			parseBlocklistEntry(blockedStr)!;
+			parseBlocklistEntry(blockedStr);
 		switch (blocklistType) {
 			case BlocklistType.NAME:
 				return searchee.title.includes(blocklistValue);
@@ -172,6 +172,16 @@ export function findBlockedStringInReleaseMaybe(
 				return searchee.length < parseInt(blocklistValue);
 			case BlocklistType.SIZE_ABOVE:
 				return searchee.length > parseInt(blocklistValue);
+			case BlocklistType.LEGACY:
+				if (searchee.title.includes(blockedStr)) return true;
+				if (blocklistValue === searchee.infoHash) return true;
+				if (
+					searchee.path &&
+					dirname(searchee.path).includes(blockedStr)
+				) {
+					return true;
+				}
+				return false;
 			default:
 				throw new Error(`Unknown blocklist type: ${blockedStr}`);
 		}


### PR DESCRIPTION
qBittorrent strips everything from `BT_backup/abc.torrent` except for the info dict. So we need to read the tracker urls from the `BT_backup/abc.fastresume`. This is trivial since it's in the same directory. It also has every bit of information about the torrent so we read categories and tags at the same time.

All other clients use API calls to get the labels. They have fastresume like structures but aren't in torrentDir (except for rTorrent) and so would require another config option. qBittorrent will also fallback to use API in the case of `cross-seed search --torrents` as they might not be from `BT_backup`.

Labels are considered tags, since a client may support multiple in the future (transmission does). Categories and tags must match exactly while tracker urls require the host `https://user:pass@tracker.example.com:8080/announce/key` -> `tracker.example.com:8080`.

This metadata is only added when creating searchees for `search`, `rss`, `announce`, `webhook`, and `inject` except for reading trackers from .torrent files.

Each blocklist item now include a prefix of it's type. Supported are: `name:` `folder:` `category:` `tag:` `tracker:` `hash:` `sizeBelow:` `sizeAbove:`
There is also two additional fields for regex: `nameRegex:` `folderRegex:`. This takes in a regex string and does `.test()` giving users more flexibility at their own risk. Verification is done whenever possible to fail at config time.