### PR TITLE
fix(qbit/inject): catch terminate connection error and confirm if in client

### DIFF
--- a/.idea/dictionaries/zak.xml
+++ b/.idea/dictionaries/zak.xml
@@ -1,0 +1,22 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="zak">
+    <words>
+      <w>alac</w>
+      <w>amzn</w>
+      <w>arrs</w>
+      <w>atvp</w>
+      <w>bdmv</w>
+      <w>bdrom</w>
+      <w>concats</w>
+      <w>configdump</w>
+      <w>dsnp</w>
+      <w>exts</w>
+      <w>filedump</w>
+      <w>pcok</w>
+      <w>pmtp</w>
+      <w>radarr</w>
+      <w>tvmazeid</w>
+      <w>undici</w>
+    </words>
+  </dictionary>
+</component>

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -434,7 +434,15 @@ export default class QBittorrent implements TorrentClient {
 			// for some reason the parser parses the last kv pair incorrectly
 			// it concats the value and the sentinel
 			formData.append("foo", "bar");
-			await this.addTorrent(formData);
+			try {
+				await this.addTorrent(formData);
+			} catch (e) {
+				logger.error({
+					label: Label.QBITTORRENT,
+					message: `Failed to add torrent (polling client to confirm): ${e.message}`,
+				});
+				logger.debug(e);
+			}
 
 			const newInfo = await this.getTorrentInfo(newTorrent.infoHash, 5);
 			if (!newInfo) {


### PR DESCRIPTION
Sometimes qbit will throw a terminate error on the connection but the torrent is often still injected. Instead of immediately returning injection failure, run the confirmation check first.