### PR TITLE
enhancement(decide/cache): use fuzzy lookups for certain guids

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -435,6 +435,24 @@ async function assessAndSaveResults(
 	return assessment;
 }
 
+/**
+ * Some trackers have alt titles which get their own guid but resolve to same torrent
+ * @param guid The guid of the candidate
+ * @returns The info hash of the torrent if found
+ */
+async function fuzzyGuidLookup(guid: string): Promise<string | undefined> {
+	if (!guid.includes(".tv/torrent/")) return;
+	const torrentIdStr = guid.match(/\.tv\/torrent\/(\d+)\/group/)?.[1];
+	if (!torrentIdStr) return;
+	return (
+		await db("decision")
+			.select({ infoHash: "info_hash" })
+			.where("guid", "like", `%.tv/torrent/${torrentIdStr}/group%`)
+			.whereNotNull("info_hash")
+			.first()
+	)?.infoHash;
+}
+
 async function assessCandidateCaching(
 	candidate: Candidate,
 	searchee: SearcheeWithLabel,
@@ -453,13 +471,16 @@ async function assessCandidateCaching(
 		.join("searchee", "decision.searchee_id", "searchee.id")
 		.where({ name: searchee.title, guid })
 		.first();
-	const metaInfoHash: string | undefined = (
+	let metaInfoHash: string | undefined = (
 		await db("decision")
-			.select({ infoHash: "decision.info_hash" })
+			.select({ infoHash: "info_hash" })
 			.where({ guid })
 			.whereNotNull("info_hash")
 			.first()
 	)?.infoHash; // Can be from a previous similar searchee's snatch
+	if (!metaInfoHash) {
+		metaInfoHash = await fuzzyGuidLookup(guid);
+	}
 	const metaOrCandidate = metaInfoHash
 		? existsInTorrentCache(metaInfoHash)
 			? await getCachedTorrentFile(metaInfoHash)

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -471,16 +471,14 @@ async function assessCandidateCaching(
 		.join("searchee", "decision.searchee_id", "searchee.id")
 		.where({ name: searchee.title, guid })
 		.first();
-	let metaInfoHash: string | undefined = (
-		await db("decision")
-			.select({ infoHash: "info_hash" })
-			.where({ guid })
-			.whereNotNull("info_hash")
-			.first()
-	)?.infoHash; // Can be from a previous similar searchee's snatch
-	if (!metaInfoHash) {
-		metaInfoHash = await fuzzyGuidLookup(guid);
-	}
+	const metaInfoHash: string | undefined =
+		(
+			await db("decision")
+				.select({ infoHash: "info_hash" })
+				.where({ guid })
+				.whereNotNull("info_hash")
+				.first()
+		)?.infoHash ?? (await fuzzyGuidLookup(guid));
 	const metaOrCandidate = metaInfoHash
 		? existsInTorrentCache(metaInfoHash)
 			? await getCachedTorrentFile(metaInfoHash)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -61,6 +61,10 @@ function redactMessage(message: string | unknown, options?: RuntimeConfig) {
 		/(?:(?:auto|download)[./]\d+[./])([a-zA-Z0-9]+)/g,
 		(match, key) => match.replace(key, redactionMsg),
 	);
+	ret = ret.replace(
+		/(?:\d+[./](?:auto|download)[./])([a-zA-Z0-9]+)/g,
+		(match, key) => match.replace(key, redactionMsg),
+	);
 	ret = ret.replace(/apiKey: '.+'/g, `apiKey: ${redactionMsg}`);
 
 	ret = ret.replace(


### PR DESCRIPTION
Some trackers have a *really* unique guids. The same torrent can have different guids each corresponding to an alternate title. Fortunately, this guid contains the torrent id so we can fuzzy match against that to grab cached torrents.

Currently, we can have 4 snatches for the same torrent from a single searchee.