### PR TITLE
fix(prefilter): add check for non-video ratio in arr dir check

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -6,3 +6,5 @@
 /dataSources.local.xml
 # Editor-based HTTP Client requests
 /httpRequests/
+/git_toolbox_blame.xml
+/easycode.ignore

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -119,7 +119,8 @@ export function filterByContent(
 		ARR_DIR_REGEX.test(basename(searchee.path)) &&
 		!(
 			searchee.files.length > 1 &&
-			SONARR_SUBFOLDERS_REGEX.test(basename(searchee.path))
+			SONARR_SUBFOLDERS_REGEX.test(basename(searchee.path)) &&
+			nonVideoSizeRatio < 0.02
 		)
 	) {
 		logReason(


### PR DESCRIPTION
this PR validates that the folders we exclude for "arr movie/series folder" are video. 

this prevents poorly named non-video torrents/data from being included in this exclusion erroneously

- [x] consider using a constant percentage rather than fuzzysize?
   - using 0.02