### PR TITLE
fix(torznab/ebook): filter calibre library index from tail of data-based search titles

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -13,15 +13,9 @@ import {
 	isTruthy,
 	MediaType,
 	sanitizeUrl,
-	stripExtension,
+	stripMetaFromName,
 } from "./utils.js";
-import {
-	RELEASE_GROUP_REGEX,
-	REPACK_PROPER_REGEX,
-	RESOLUTION_REGEX,
-	SCENE_TITLE_REGEX,
-	sourceRegexRemove,
-} from "./constants.js";
+import { SCENE_TITLE_REGEX } from "./constants.js";
 
 export interface ExternalIds {
 	imdbId?: string;
@@ -250,14 +244,7 @@ export async function scanAllArrsForMedia(
 	const title =
 		mediaType !== MediaType.VIDEO
 			? searcheeTitle.match(SCENE_TITLE_REGEX)!.groups!.title
-			: cleanseSeparators(
-					sourceRegexRemove(
-						stripExtension(searcheeTitle)
-							.replace(RELEASE_GROUP_REGEX, "")
-							.replace(RESOLUTION_REGEX, "")
-							.replace(REPACK_PROPER_REGEX, ""),
-					),
-				).match(SCENE_TITLE_REGEX)!.groups!.title;
+			: cleanseSeparators(stripMetaFromName(searcheeTitle));
 	let error = new Error(
 		`No ids found for ${title} | MediaType: ${mediaType.toUpperCase()}`,
 	);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -236,10 +236,16 @@ export default class QBittorrent implements TorrentClient {
 		await this.request("/torrents/add", formData);
 	}
 
-	async recheckTorrent(torrentInfo: TorrentInfo): Promise<void> {
+	async recheckTorrent(infoHash: string): Promise<void> {
+		// Pause first as it may resume after recheck automatically
+		await this.request(
+			"/torrents/pause",
+			`hashes=${infoHash}`,
+			X_WWW_FORM_URLENCODED,
+		);
 		await this.request(
 			"/torrents/recheck",
-			`hashes=${torrentInfo.hash}`,
+			`hashes=${infoHash}`,
 			X_WWW_FORM_URLENCODED,
 		);
 	}
@@ -334,9 +340,25 @@ export default class QBittorrent implements TorrentClient {
 			if (torrentInfo) {
 				return torrentInfo;
 			}
-			await wait(ms("1 second") * 2 ** i);
+			if (i < retries) {
+				await wait(ms("1 second") * 2 ** i);
+			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * @param infoHash the infohash of the torrent
+	 * @returns whether the torrent is complete
+	 */
+	async isTorrentComplete(
+		infoHash: string,
+	): Promise<Result<boolean, "NOT_FOUND">> {
+		const torrentInfo = await this.getTorrentInfo(infoHash);
+		if (!torrentInfo) {
+			return resultOfErr("NOT_FOUND");
+		}
+		return resultOf(this.isTorrentInfoComplete(torrentInfo));
 	}
 
 	isTorrentInfoComplete(torrentInfo: TorrentInfo): boolean {
@@ -382,7 +404,7 @@ export default class QBittorrent implements TorrentClient {
 						`Searchee torrent may have been deleted: ${getLogString(searchee)}`,
 					);
 				} else if (searchee.infoHash) {
-					logger.warning({
+					logger.warn({
 						label: Label.QBITTORRENT,
 						message: `Searchee torrent may have been deleted, tagging may not meet expectations: ${getLogString(searchee)}`,
 					});
@@ -449,14 +471,14 @@ export default class QBittorrent implements TorrentClient {
 				throw new Error(`Failed to retrieve torrent after adding`);
 			}
 			if (toRecheck) {
-				await this.recheckTorrent(newInfo);
+				await this.recheckTorrent(newInfo.hash);
 			}
 
 			return InjectionResult.SUCCESS;
 		} catch (e) {
-			logger.debug({
+			logger.error({
 				label: Label.QBITTORRENT,
-				message: `Injection failed: ${e.message}`,
+				message: `Injection failed for ${getLogString(newTorrent)}: ${e.message}`,
 			});
 			logger.debug(e);
 			return InjectionResult.FAILURE;

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -11,6 +11,9 @@ import { Result } from "../Result.js";
 let activeClient: TorrentClient;
 
 export interface TorrentClient {
+	isTorrentComplete: (
+		infoHash: string,
+	) => Promise<Result<boolean, "NOT_FOUND">>;
 	getDownloadDir: (
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },
@@ -23,6 +26,7 @@ export interface TorrentClient {
 		decision: DecisionAnyMatch,
 		path?: string,
 	) => Promise<InjectionResult>;
+	recheckTorrent: (infoHash: string) => Promise<void>;
 	validateConfig: () => Promise<void>;
 }
 

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -15,6 +15,7 @@ import {
 import { db } from "./db.js";
 import { diffCmd } from "./diff.js";
 import { CrossSeedError, exitOnCrossSeedErrors } from "./errors.js";
+import { injectSavedTorrents } from "./inject.js";
 import { jobsLoop } from "./jobs.js";
 import { Label, initializeLogger, logger } from "./logger.js";
 import { main, scanRssFeeds } from "./pipeline.js";
@@ -432,6 +433,29 @@ createCommandWithSharedOptions("search", "Search for cross-seeds")
 			await db.migrate.latest();
 			await doStartupValidation();
 			await main();
+			await db.destroy();
+		} catch (e) {
+			exitOnCrossSeedErrors(e);
+			await db.destroy();
+		}
+	});
+
+createCommandWithSharedOptions(
+	"inject",
+	"Inject saved cross-seeds into your client (without filtering, see docs)",
+)
+	.addOption(
+		new Option(
+			"--inject-dir <dir>",
+			"Directory of torrent files to try to inject",
+		).default(fileConfig.outputDir),
+	)
+	.action(async (options) => {
+		try {
+			await validateAndSetRuntimeConfig(options);
+			await db.migrate.latest();
+			await doStartupValidation();
+			await injectSavedTorrents();
 			await db.destroy();
 		} catch (e) {
 			exitOnCrossSeedErrors(e);

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -135,6 +135,7 @@ export const VALIDATION_SCHEMA = z
 		maxDataDepth: z.number().gte(1),
 		torrentDir: z.string().nullable(),
 		outputDir: z.string(),
+		injectDir: z.string().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
 		fuzzySizeThreshold: z.number().positive().lte(1, {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,7 +33,7 @@ export const ARR_DIR_REGEX =
 export const SONARR_SUBFOLDERS_REGEX =
 	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
 export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
-
+export const CALIBRE_INDEXNUM_REGEX = /\s?\(\d+\)$/;
 // Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {
 	AMZN: /\b(amzn|amazon(hd)?)\b[ ._-]web[ ._-]?(dl|rip)?\b/i,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,6 +34,9 @@ export const SONARR_SUBFOLDERS_REGEX =
 	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
 export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
 export const CALIBRE_INDEXNUM_REGEX = /\s?\(\d+\)$/;
+export const SAVED_TORRENTS_INFO_REGEX =
+	/^\[(?<mediaType>.+?)\]\[(?<tracker>.+?)\](?<name>.+?)(?:\[[^\]]*?\])?\.torrent$/i;
+
 // Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {
 	AMZN: /\b(amzn|amazon(hd)?)\b[ ._-]web[ ._-]?(dl|rip)?\b/i,
@@ -103,6 +106,7 @@ export const ALL_EXTENSIONS = [
 
 export const TORRENT_CACHE_FOLDER = "torrent_cache";
 export const UNKNOWN_TRACKER = "UnknownTracker";
+export const LEVENSHTEIN_DIVISOR = 3;
 
 export enum Action {
 	SAVE = "save",
@@ -133,6 +137,16 @@ export enum Decision {
 	DOWNLOAD_FAILED = "DOWNLOAD_FAILED",
 	MAGNET_LINK = "MAGNET_LINK",
 	RATE_LIMITED = "RATE_LIMITED",
+	/**
+	 * Searchee and Candidate info hash matches. Usually happens with public
+	 * torrents and torrents added by radarr/sonarr before cross-seed on announces.
+	 * Useful for the inject job as we ignore INFO_HASH_ALREADY_EXISTS and
+	 * for reporting a 204 announe status code instead of 200 from exists.
+	 */
+	SAME_INFO_HASH = "SAME_INFO_HASH",
+	/**
+	 * Checked after SAME_INFO_HASH.
+	 */
 	INFO_HASH_ALREADY_EXISTS = "INFO_HASH_ALREADY_EXISTS",
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
 	RELEASE_GROUP_MISMATCH = "RELEASE_GROUP_MISMATCH",

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,0 +1,591 @@
+import chalk from "chalk";
+import { stat, unlink } from "fs/promises";
+import ms from "ms";
+import { basename, dirname } from "path";
+import { linkAllFilesInMetafile, performAction } from "./action.js";
+import { getClient } from "./clients/TorrentClient.js";
+import {
+	Decision,
+	DecisionAnyMatch,
+	InjectionResult,
+	isAnyMatchedDecision,
+	SaveResult,
+	UNKNOWN_TRACKER,
+} from "./constants.js";
+import { assessCandidate } from "./decide.js";
+import { Label, logger } from "./logger.js";
+import { Metafile } from "./parseTorrent.js";
+import { findAllSearchees } from "./pipeline.js";
+import { sendResultsNotification } from "./pushNotifier.js";
+import { Result, resultOf, resultOfErr } from "./Result.js";
+import { getRuntimeConfig } from "./runtimeConfig.js";
+import { SearcheeWithLabel } from "./searchee.js";
+import {
+	findAllTorrentFilesInDir,
+	parseMetadataFromFilename,
+	parseTorrentFromFilename,
+} from "./torrent.js";
+import {
+	areMediaTitlesSimilar,
+	comparing,
+	formatAsList,
+	getLogString,
+	isTruthy,
+	sanitizeInfoHash,
+} from "./utils.js";
+
+type AllMatches = {
+	searchee: SearcheeWithLabel;
+	decision: DecisionAnyMatch;
+}[];
+
+type InjectSummary = {
+	TOTAL: number;
+	INJECTED: number;
+	FULL_MATCHES: number;
+	PARTIAL_MATCHES: number;
+	BLOCKED: number;
+	ALREADY_EXISTS: number;
+	INCOMPLETE_CANDIDATES: number;
+	INCOMPLETE_SEARCHEES: number;
+	FAILED: number;
+	UNMATCHED: number;
+	FOUND_BAD_FORMAT: boolean;
+};
+
+type InjectionAftermath = {
+	summary: InjectSummary;
+	torrentFilePath: string;
+	meta: Metafile;
+	matchedDecision?: DecisionAnyMatch;
+	tracker: string;
+	progress: string;
+	injectionResult: InjectionResult;
+	matchedSearchee?: SearcheeWithLabel;
+	filePathLog: string;
+	matches: AllMatches;
+	linkedNewFiles: boolean;
+};
+
+function getTorrentFilePathLog(torrentFilePath: string): string {
+	return chalk.bold.magenta(
+		torrentFilePath.replace(/\[([a-z0-9]{40})].torrent$/i, (match, hash) =>
+			match.replace(hash, sanitizeInfoHash(hash)),
+		),
+	);
+}
+
+async function deleteTorrentFileIfSafe(torrentFilePath: string): Promise<void> {
+	const { tracker, name, mediaType } = parseMetadataFromFilename(
+		basename(torrentFilePath),
+	);
+
+	// we are confident cross-seed created the torrent,
+	// or it is intended for use with cross-seed
+	const isSafeToDelete = tracker && name && mediaType;
+	if (!isSafeToDelete) return;
+	const filePathLog = getTorrentFilePathLog(torrentFilePath);
+	logger.verbose({
+		label: Label.INJECT,
+		message: `Deleting ${filePathLog}`,
+	});
+	try {
+		await unlink(torrentFilePath);
+	} catch (e) {
+		if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+			logger.error({
+				label: Label.INJECT,
+				message: `Failed to delete ${filePathLog}`,
+			});
+			logger.debug(e);
+		}
+	}
+}
+
+async function whichSearcheesMatchTorrent(
+	meta: Metafile,
+	searchees: SearcheeWithLabel[],
+): Promise<{ matches: AllMatches; foundBlocked: boolean }> {
+	let foundBlocked = false;
+	const matches: AllMatches = [];
+	for (const searchee of searchees) {
+		const { decision } = await assessCandidate(meta, searchee, []);
+		if (decision === Decision.BLOCKED_RELEASE) {
+			foundBlocked = true;
+			continue;
+		} else if (!isAnyMatchedDecision(decision)) {
+			continue;
+		}
+
+		// If name or file names are not similar consider it a false positive
+		if (
+			!areMediaTitlesSimilar(searchee.title, meta.title) &&
+			!areMediaTitlesSimilar(searchee.title, meta.name) &&
+			!areMediaTitlesSimilar(searchee.name, meta.name) &&
+			!areMediaTitlesSimilar(searchee.name, meta.title) &&
+			!meta.files.some((metaFile) =>
+				searchee.files.some((searcheeFile) =>
+					areMediaTitlesSimilar(searcheeFile.name, metaFile.name),
+				),
+			)
+		) {
+			logger.warn({
+				label: Label.INJECT,
+				message: `Skipping likely false positive for ${getLogString(meta, chalk.bold.white)} from ${getLogString(searchee, chalk.bold.white)}`,
+			});
+			continue;
+		}
+
+		matches.push({ searchee, decision });
+	}
+
+	/**
+	 * full matches, then size only matches, then partial matches
+	 * torrent, then data, then virtual
+	 * prefer more files for partials
+	 */
+	matches.sort(
+		comparing(
+			(match) =>
+				// indexOf returns -1 for not found
+				-[Decision.MATCH_SIZE_ONLY, Decision.MATCH].indexOf(
+					match.decision,
+				),
+			(match) => !match.searchee.infoHash,
+			(match) => !match.searchee.path,
+			(match) => -match.searchee.files.length,
+		),
+	);
+	return { matches, foundBlocked };
+}
+
+async function injectInitialAction(
+	meta: Metafile,
+	matches: AllMatches,
+	tracker: string,
+): Promise<{
+	injectionResult: InjectionResult;
+	matchedSearchee?: SearcheeWithLabel;
+	matchedDecision?: DecisionAnyMatch;
+	linkedNewFiles: boolean;
+}> {
+	let injectionResult = InjectionResult.FAILURE;
+	let matchedSearchee: SearcheeWithLabel | undefined;
+	let matchedDecision: DecisionAnyMatch | undefined;
+	let linkedNewFiles = false;
+	for (const { searchee, decision } of matches) {
+		if (
+			injectionResult === InjectionResult.TORRENT_NOT_COMPLETE &&
+			!searchee.infoHash
+		) {
+			continue; // Data/virtual searchee doesn't know if torrent is complete
+		}
+		const res = await performAction(meta, decision, searchee, tracker);
+		const result = res.actionResult;
+		if (res.linkedNewFiles) {
+			linkedNewFiles = true;
+		}
+		if (
+			injectionResult === InjectionResult.SUCCESS ||
+			result === InjectionResult.FAILURE ||
+			result === SaveResult.SAVED
+		) {
+			continue;
+		}
+		if (result === InjectionResult.ALREADY_EXISTS) {
+			injectionResult = result;
+			continue;
+		}
+		if (result === InjectionResult.TORRENT_NOT_COMPLETE) {
+			if (injectionResult !== InjectionResult.ALREADY_EXISTS) {
+				injectionResult = result;
+				matchedSearchee = searchee;
+				matchedDecision = decision;
+			}
+			continue;
+		}
+		injectionResult = InjectionResult.SUCCESS;
+		matchedSearchee = searchee;
+		matchedDecision = decision;
+	}
+	return {
+		injectionResult,
+		matchedSearchee,
+		matchedDecision,
+		linkedNewFiles,
+	};
+}
+
+function injectionFailed({
+	progress,
+	injectionResult,
+	summary,
+	filePathLog,
+}: InjectionAftermath) {
+	logger.error({
+		label: Label.INJECT,
+		message: `${progress} Failed to inject ${filePathLog} - ${chalk.red(injectionResult)}`,
+	});
+	summary.FAILED++;
+}
+
+async function injectFromStalledTorrent({
+	meta,
+	matches,
+	tracker,
+	injectionResult,
+	progress,
+	filePathLog,
+}: InjectionAftermath) {
+	let linkedNewFiles = false;
+	let inClient = (await getClient().isTorrentComplete(meta.infoHash)).isOk();
+	let injected = false;
+	for (const { searchee, decision } of matches) {
+		const linkedFilesRootResult = await linkAllFilesInMetafile(
+			searchee,
+			meta,
+			tracker,
+			decision,
+			{ onlyCompleted: false },
+		);
+		const linkResult = linkedFilesRootResult.isOk()
+			? linkedFilesRootResult.unwrap()
+			: null;
+		if (linkResult && linkResult.linkedNewFiles) {
+			linkedNewFiles = true;
+		}
+		if (!inClient) {
+			if (linkedFilesRootResult.isOk()) {
+				const destinationDir = dirname(linkResult!.contentPath);
+				const result = await getClient().inject(
+					meta,
+					searchee,
+					Decision.MATCH_PARTIAL, // Should always be considered partial
+					destinationDir,
+				);
+				// result is only SUCCESS or FAILURE here but still log original injectionResult
+				if (result === InjectionResult.SUCCESS) {
+					logger.info({
+						label: Label.INJECT,
+						message: `${progress} Injected ${filePathLog} using stalled source, you will need to resume or remove from client - ${chalk.green(injectionResult)}`,
+					});
+					inClient = true;
+					injected = true;
+				} else {
+					logger.warn({
+						label: Label.INJECT,
+						message: `${progress} Failed to inject ${filePathLog} using stalled source - ${chalk.yellow(injectionResult)}`,
+					});
+				}
+			} else {
+				logger.warn({
+					label: Label.INJECT,
+					message: `${progress} Failed to link files for ${filePathLog}, ${linkedFilesRootResult.unwrapErr()} - ${chalk.yellow(injectionResult)}`,
+				});
+			}
+		}
+	}
+	if (inClient && !injected) {
+		if (linkedNewFiles) {
+			logger.info({
+				label: Label.INJECT,
+				message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
+			});
+			await getClient().recheckTorrent(meta.infoHash);
+		} else {
+			logger.warn({
+				label: Label.INJECT,
+				message: `${progress} No new files linked for ${filePathLog}, resume or remove from client - ${chalk.yellow(injectionResult)}`,
+			});
+		}
+	}
+}
+
+async function injectionTorrentNotComplete(
+	injectionAftermath: InjectionAftermath,
+) {
+	const { progress, torrentFilePath, injectionResult, summary, filePathLog } =
+		injectionAftermath;
+	const { linkDir } = getRuntimeConfig();
+	if (
+		!linkDir ||
+		(await stat(torrentFilePath)).mtimeMs >= Date.now() - ms("1 day")
+	) {
+		// Normal case where source is likely still downloading
+		logger.warn({
+			label: Label.INJECT,
+			message: `${progress} Unable to inject ${filePathLog} - ${chalk.yellow(injectionResult)}`,
+		});
+	} else {
+		// Since source is stalled, add to client paused so user can resume later if desired
+		// Try linking all possible matches as they may have different files
+		await injectFromStalledTorrent(injectionAftermath);
+	}
+	summary.INCOMPLETE_SEARCHEES++;
+}
+
+async function injectionAlreadyExists({
+	progress,
+	torrentFilePath,
+	injectionResult,
+	summary,
+	linkedNewFiles,
+	meta,
+	matches,
+	filePathLog,
+}: InjectionAftermath) {
+	const result = await getClient().isTorrentComplete(meta.infoHash);
+	let isComplete = result.isOk() ? result.unwrap() : false;
+	const anyFullMatch = matches.some(
+		(m) =>
+			m.decision === Decision.MATCH ||
+			m.decision === Decision.MATCH_SIZE_ONLY,
+	);
+	if (linkedNewFiles) {
+		logger.info({
+			label: Label.INJECT,
+			message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
+		});
+		await getClient().recheckTorrent(meta.infoHash);
+	} else if (anyFullMatch && !isComplete) {
+		logger.info({
+			label: Label.INJECT,
+			message: `${progress} Rechecking ${filePathLog} as it's not complete but has all files - ${chalk.green(injectionResult)}`,
+		});
+		await getClient().recheckTorrent(meta.infoHash);
+		isComplete = true; // Prevent infinite recheck in rare case of corrupted cross seed
+	} else {
+		logger.warn({
+			label: Label.INJECT,
+			message: `${progress} Unable to inject ${filePathLog} - ${chalk.yellow(injectionResult)}${isComplete ? "" : " (incomplete)"}`,
+		});
+	}
+	summary.ALREADY_EXISTS++;
+	summary.INCOMPLETE_CANDIDATES += isComplete ? 0 : 1;
+	if (isComplete) {
+		await deleteTorrentFileIfSafe(torrentFilePath);
+	}
+}
+
+async function injectionSuccess({
+	progress,
+	torrentFilePath,
+	injectionResult,
+	summary,
+	matchedSearchee,
+	matchedDecision,
+	meta,
+	tracker,
+	filePathLog,
+}: InjectionAftermath) {
+	logger.info({
+		label: Label.INJECT,
+		message: `${progress} Injected ${filePathLog} - ${chalk.green(injectionResult)}`,
+	});
+	sendResultsNotification(matchedSearchee!, [
+		[
+			{ decision: matchedDecision!, metafile: meta },
+			tracker,
+			injectionResult,
+		],
+	]);
+	summary.INJECTED++;
+	if (matchedDecision === Decision.MATCH_PARTIAL) {
+		summary.PARTIAL_MATCHES++;
+	} else {
+		summary.FULL_MATCHES++;
+	}
+
+	const result = await getClient().isTorrentComplete(meta.infoHash);
+	const isComplete = result.orElse(false);
+	if (isComplete) {
+		await deleteTorrentFileIfSafe(torrentFilePath);
+	}
+}
+
+async function loadMetafile(
+	torrentFilePath: string,
+	progress: string,
+	summary: InjectSummary,
+): Promise<Result<{ meta: Metafile; tracker: string }, "FAILED_TO_PARSE">> {
+	const filePathLog = getTorrentFilePathLog(torrentFilePath);
+	let meta: Metafile;
+	try {
+		meta = await parseTorrentFromFilename(torrentFilePath);
+	} catch (e) {
+		logger.error({
+			label: Label.INJECT,
+			message: `${progress} Failed to parse ${filePathLog}`,
+		});
+		logger.debug(e);
+		return resultOfErr("FAILED_TO_PARSE");
+	}
+
+	const { tracker: trackerFromFilename } = parseMetadataFromFilename(
+		basename(torrentFilePath),
+	);
+	summary.FOUND_BAD_FORMAT ||= !trackerFromFilename;
+	const tracker = trackerFromFilename ?? UNKNOWN_TRACKER;
+	return resultOf({ meta, tracker });
+}
+
+async function injectSavedTorrent(
+	progress: string,
+	torrentFilePath: string,
+	summary: InjectSummary,
+	searchees: SearcheeWithLabel[],
+) {
+	const metafileResult = await loadMetafile(
+		torrentFilePath,
+		progress,
+		summary,
+	);
+	if (metafileResult.isErr()) return;
+	const { meta, tracker } = metafileResult.unwrap();
+
+	const filePathLog = getTorrentFilePathLog(torrentFilePath);
+	const metaLog = getLogString(meta, chalk.bold.white);
+
+	const { matches, foundBlocked } = await whichSearcheesMatchTorrent(
+		meta,
+		searchees,
+	);
+
+	if (!matches.length && foundBlocked) {
+		logger.info({
+			label: Label.INJECT,
+			message: `${progress} ${metaLog} ${chalk.yellow("possibly blocklisted")}: ${filePathLog}`,
+		});
+		summary.BLOCKED++;
+		await deleteTorrentFileIfSafe(torrentFilePath);
+		return;
+	} else if (!matches.length) {
+		logger.info({
+			label: Label.INJECT,
+			message: `${progress} ${metaLog} ${chalk.red("has no matches")}: ${filePathLog}`,
+		});
+		summary.UNMATCHED++;
+		await deleteTorrentFileIfSafe(torrentFilePath);
+		return;
+	}
+
+	const {
+		injectionResult,
+		matchedSearchee,
+		matchedDecision,
+		linkedNewFiles,
+	} = await injectInitialAction(meta, matches, tracker);
+
+	const injectionAftermath: InjectionAftermath = {
+		progress,
+		torrentFilePath,
+		injectionResult,
+		summary,
+		meta,
+		tracker,
+		matches,
+		matchedSearchee,
+		matchedDecision,
+		linkedNewFiles,
+		filePathLog,
+	};
+
+	switch (injectionResult) {
+		case InjectionResult.SUCCESS:
+			await injectionSuccess(injectionAftermath);
+			break;
+		case InjectionResult.FAILURE:
+			injectionFailed(injectionAftermath);
+			break;
+		case InjectionResult.ALREADY_EXISTS:
+			await injectionAlreadyExists(injectionAftermath);
+			break;
+		case InjectionResult.TORRENT_NOT_COMPLETE:
+			await injectionTorrentNotComplete(injectionAftermath);
+			break;
+	}
+}
+
+function logInjectSummary(summary: InjectSummary, flatLinking: boolean) {
+	const incompleteMsg = `${chalk.bold.yellow(summary.ALREADY_EXISTS)} existed in client${
+		summary.INCOMPLETE_CANDIDATES
+			? chalk.dim(` (${summary.INCOMPLETE_CANDIDATES} were incomplete)`)
+			: ""
+	}`;
+	const resultMsg = formatAsList(
+		[
+			`Injected ${chalk.bold.green(summary.INJECTED)}/${chalk.bold.white(summary.TOTAL)} torrents`,
+			summary.FULL_MATCHES &&
+				`${chalk.bold.green(summary.FULL_MATCHES)} were full matches`,
+			summary.PARTIAL_MATCHES &&
+				`${chalk.bold.yellow(summary.PARTIAL_MATCHES)} were partial matches`,
+			summary.INCOMPLETE_SEARCHEES &&
+				`${chalk.bold.yellow(summary.INCOMPLETE_SEARCHEES)} had incomplete sources`,
+			summary.ALREADY_EXISTS && incompleteMsg,
+			summary.BLOCKED &&
+				`${chalk.bold.yellow(summary.BLOCKED)} were possibly blocklisted`,
+			summary.FAILED &&
+				`${chalk.bold.red(summary.FAILED)} failed to inject`,
+			summary.UNMATCHED &&
+				`${chalk.bold.red(summary.UNMATCHED)} had no matches`,
+		].filter(isTruthy),
+		{ sort: false, type: "unit" },
+	);
+	logger.info({ label: Label.INJECT, message: chalk.cyan(resultMsg) });
+
+	if (summary.UNMATCHED > 0) {
+		logger.info({
+			label: Label.INJECT,
+			message: `Use "${chalk.bold.white("cross-seed diff")}" to get the reasons two torrents are not considered matches`,
+		});
+	}
+
+	if (summary.FOUND_BAD_FORMAT && !flatLinking) {
+		logger.warn({
+			label: Label.INJECT,
+			message: `Some torrents could be linked to linkDir/${UNKNOWN_TRACKER} - follow .torrent naming format in the docs to avoid this`,
+		});
+	}
+}
+
+function createSummary(total: number): InjectSummary {
+	return {
+		TOTAL: total,
+		INJECTED: 0,
+		FULL_MATCHES: 0,
+		PARTIAL_MATCHES: 0,
+		BLOCKED: 0,
+		ALREADY_EXISTS: 0,
+		INCOMPLETE_CANDIDATES: 0,
+		INCOMPLETE_SEARCHEES: 0,
+		FAILED: 0,
+		UNMATCHED: 0,
+		FOUND_BAD_FORMAT: false,
+	};
+}
+
+export async function injectSavedTorrents(): Promise<void> {
+	const { flatLinking, injectDir, outputDir } = getRuntimeConfig();
+	const targetDir = injectDir ?? outputDir;
+	const targetDirLog = chalk.bold.magenta(targetDir);
+
+	const torrentFilePaths = await findAllTorrentFilesInDir(targetDir);
+	if (torrentFilePaths.length === 0) {
+		logger.info({
+			label: Label.INJECT,
+			message: `No torrent files found to inject in ${targetDirLog}`,
+		});
+		return;
+	}
+	logger.info({
+		label: Label.INJECT,
+		message: `Found ${chalk.bold.white(torrentFilePaths.length)} torrent file(s) to inject in ${targetDirLog}`,
+	});
+	const summary = createSummary(torrentFilePaths.length);
+	const searchees = await findAllSearchees(Label.INJECT);
+	for (const [i, torrentFilePath] of torrentFilePaths.entries()) {
+		const progress = chalk.blue(`(${i + 1}/${torrentFilePaths.length})`);
+		await injectSavedTorrent(progress, torrentFilePath, summary, searchees);
+	}
+	logInjectSummary(summary, flatLinking);
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,6 +11,7 @@ export enum Label {
 	TRANSMISSION = "transmission",
 	DELUGE = "deluge",
 	DECIDE = "decide",
+	INJECT = "inject",
 	PREFILTER = "prefilter",
 	CONFIGDUMP = "configdump",
 	TORZNAB = "torznab",

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -1,7 +1,7 @@
 import bencode from "bencode";
 import { createHash } from "crypto";
 import { join } from "path";
-import { File } from "./searchee.js";
+import { File, parseTitle } from "./searchee.js";
 import { fallback } from "./utils.js";
 
 interface TorrentDirent {
@@ -74,7 +74,6 @@ export class Metafile {
 		this.raw = raw;
 		this.infoHash = sha1(bencode.encode(raw.info));
 		this.name = fallback(raw.info["name.utf-8"], raw.info.name)!.toString();
-		this.title = this.name;
 		this.pieceLength = raw.info["piece length"];
 
 		if (!raw.info.files) {
@@ -112,6 +111,7 @@ export class Metafile {
 			this.length = this.files.reduce(sumLength, 0);
 			this.isSingleFileTorrent = false;
 		}
+		this.title = parseTitle(this.name, this.files) ?? this.name;
 	}
 
 	static decode(buf: Buffer) {

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -85,7 +85,7 @@ export function sendResultsNotification(
 			([assessment]) => assessment.metafile!.infoHash,
 		);
 		const trackers = notableSuccesses.map(([, tracker]) => tracker);
-		const trackersListStr = formatAsList(trackers);
+		const trackersListStr = formatAsList(trackers, { sort: true });
 		const performedAction =
 			notableSuccesses[0][2] === InjectionResult.SUCCESS
 				? "Injected"
@@ -110,7 +110,7 @@ export function sendResultsNotification(
 			([assessment]) => assessment.metafile!.infoHash,
 		);
 		const trackers = failures.map(([, tracker]) => tracker);
-		const trackersListStr = formatAsList(trackers);
+		const trackersListStr = formatAsList(trackers, { sort: true });
 
 		pushNotifier.notify({
 			body: `Failed to inject ${name} from ${numTrackers} trackers: ${trackersListStr}`,

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -12,6 +12,7 @@ export interface RuntimeConfig {
 	linkCategory: string;
 	torrentDir?: string;
 	outputDir: string;
+	injectDir?: string;
 	includeSingleEpisodes: boolean;
 	verbose: boolean;
 	includeNonVideos: boolean;

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -51,8 +51,15 @@ async function verifyPath(
  * @returns true (if paths are valid)
  */
 async function checkConfigPaths(): Promise<void> {
-	const { action, linkDir, dataDirs, torrentDir, outputDir, rtorrentRpcUrl } =
-		getRuntimeConfig();
+	const {
+		action,
+		dataDirs,
+		injectDir,
+		linkDir,
+		outputDir,
+		rtorrentRpcUrl,
+		torrentDir,
+	} = getRuntimeConfig();
 	const READ_ONLY = constants.R_OK;
 	const READ_AND_WRITE = constants.R_OK | constants.W_OK;
 	let pathFailure: number = 0;
@@ -79,6 +86,15 @@ async function checkConfigPaths(): Promise<void> {
 			if (!(await verifyPath(dataDir, "dataDirs", READ_ONLY))) {
 				pathFailure++;
 			}
+		}
+	}
+	if (injectDir) {
+		logger.warn({
+			label: Label.INJECT,
+			message: `Manually injecting torrents performs minimal filtering which slightly increases chances of false positives, see the docs for more info`,
+		});
+		if (!(await verifyPath(injectDir, "injectDir", READ_AND_WRITE))) {
+			pathFailure++;
 		}
 	}
 	if (pathFailure) {

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -42,6 +42,7 @@ import {
 	reformatTitleForSearching,
 	sanitizeUrl,
 	stripExtension,
+	stripMetaFromName,
 } from "./utils.js";
 import chalk from "chalk";
 import { inspect } from "util";
@@ -301,6 +302,13 @@ async function createTorznabSearchQueries(
 			t: "search",
 			q: animeQuery,
 		}));
+	} else if (mediaType === MediaType.VIDEO) {
+		return [
+			{
+				t: "search",
+				q: cleanTitle(stripMetaFromName(stem)),
+			},
+		] as const;
 	} else if (mediaType === MediaType.BOOK) {
 		return [
 			{
@@ -829,7 +837,7 @@ async function getAndLogIndexers(
 		timeFilteredIndexers.length > indexersToUse.length && "category",
 	].filter(isTruthy);
 	const reasonStr = filteringCauses.length
-		? ` (filtered by ${formatAsList(filteringCauses)})`
+		? ` (filtered by ${formatAsList(filteringCauses, { sort: true })})`
 		: "";
 	if (!indexersToSearch.length && !cachedSearch.indexerCandidates.length) {
 		cachedSearch.q = null; // Won't scan arrs for multiple skips in a row


### PR DESCRIPTION
[Calibre](https://calibre-ebook.com/) libraries (a popular ebooks manager) can append an index ID to the end of folder names, this PR removes that index if it is a databased match.

To accomplish this the query creation function now accepts a searchee rather than a stripped searchee title. This arg was changed elsewhere to accommodate this change for the ebook searchee check.

There is a debug function (unused) that currently will not work without some modifications, I've `ts-expect-error`'d it to prevent it without removing anything.

https://regex101.com/r/xUPDfI/1