### PR TITLE
hotfix(search/books): parse calibre index on data searches before cleaning title

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -309,13 +309,11 @@ async function createTorznabSearchQueries(
 				q: cleanTitle(stripMetaFromName(stem)),
 			},
 		] as const;
-	} else if (mediaType === MediaType.BOOK) {
+	} else if (mediaType === MediaType.BOOK && searchee.path) {
 		return [
 			{
 				t: "search",
-				q: searchee.path
-					? cleanTitle(stem).replace(CALIBRE_INDEXNUM_REGEX, "")
-					: cleanTitle(stem),
+				q: cleanTitle(stem).replace(CALIBRE_INDEXNUM_REGEX, ""),
 			},
 		] as const;
 	}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -313,7 +313,7 @@ async function createTorznabSearchQueries(
 		return [
 			{
 				t: "search",
-				q: cleanTitle(stem).replace(CALIBRE_INDEXNUM_REGEX, ""),
+				q: cleanTitle(stem.replace(CALIBRE_INDEXNUM_REGEX, "")),
 			},
 		] as const;
 	}


### PR DESCRIPTION
cleanTitle removes the parenthesis i regex'd - so the replace needs to be on the stem before cleaning the title