### PR TITLE
deserialize indexer objects

### DIFF
--- a/.idea/dictionaries/mmgoodnow.xml
+++ b/.idea/dictionaries/mmgoodnow.xml
@@ -4,14 +4,19 @@
       <w>backfill</w>
       <w>bencode</w>
       <w>caronc</w>
+      <w>correlator</w>
+      <w>correlators</w>
       <w>dlspeed</w>
+      <w>erro</w>
       <w>imdbid</w>
       <w>infohash</w>
       <w>jackett</w>
+      <w>jackettindexer</w>
       <w>jsified</w>
       <w>knexfile</w>
       <w>leechs</w>
       <w>metainfo</w>
+      <w>prowlarrindexer</w>
       <w>qbittorrent</w>
       <w>rtorrent</w>
       <w>savepath</w>

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import ms from "ms";
 import { join as posixJoin } from "node:path/posix";
 import { URLSearchParams } from "node:url";
+import { SCENE_TITLE_REGEX } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
 import { Caps } from "./indexers.js";
 import { Label, logger } from "./logger.js";
@@ -16,7 +17,6 @@ import {
 	sanitizeUrl,
 	stripMetaFromName,
 } from "./utils.js";
-import { SCENE_TITLE_REGEX } from "./constants.js";
 
 export interface ExternalIds {
 	imdbId?: string;

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -3,10 +3,11 @@ import ms from "ms";
 import { join as posixJoin } from "node:path/posix";
 import { URLSearchParams } from "node:url";
 import { CrossSeedError } from "./errors.js";
+import { Caps } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { Caps, IdSearchParams } from "./torznab.js";
+import { IdSearchParams } from "./torznab.js";
 import {
 	cleanseSeparators,
 	getApikey,

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -120,7 +120,7 @@ export const VALIDATION_SCHEMA = z
 			.nonnegative({
 				message: ZodErrorMessages.delayNegative,
 			})
-			.gte(30, ZodErrorMessages.delayUnsupported)
+			.gte(process.env.DEV ? 0 : 30, ZodErrorMessages.delayUnsupported)
 			.lte(3600, ZodErrorMessages.delayUnsupported),
 		torznab: z.array(z.string().url()),
 		dataDirs: z.array(z.string()).nullish(),

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -187,3 +187,10 @@ export async function updateIndexerCapsById(indexerId: number, caps: Caps) {
 			cat_caps: JSON.stringify(caps.categories),
 		});
 }
+
+export async function clearIndexerFailures() {
+	await db("indexer").update({
+		status: null,
+		retry_after: null,
+	});
+}

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -76,6 +76,21 @@ export interface Indexer {
 	categories: IndexerCategories;
 }
 
+const allFields = {
+	id: "id",
+	url: "url",
+	apikey: "apikey",
+	active: "active",
+	status: "status",
+	retryAfter: "retry_after",
+	searchCap: "search_cap",
+	tvSearchCap: "tv_search_cap",
+	movieSearchCap: "movie_search_cap",
+	tvIdCaps: "tv_id_caps",
+	movieIdCaps: "movie_id_caps",
+	catCaps: "cat_caps",
+} as const;
+
 function deserialize(dbIndexer: DbIndexer): Indexer {
 	const { tvIdCaps, movieIdCaps, catCaps, ...rest } = dbIndexer;
 	return {
@@ -87,20 +102,9 @@ function deserialize(dbIndexer: DbIndexer): Indexer {
 }
 
 export async function getAllIndexers(): Promise<Indexer[]> {
-	const rawIndexers = await db("indexer").where({ active: true }).select({
-		id: "id",
-		url: "url",
-		apikey: "apikey",
-		active: "active",
-		status: "status",
-		retryAfter: "retry_after",
-		searchCap: "search_cap",
-		tvSearchCap: "tv_search_cap",
-		movieSearchCap: "movie_search_cap",
-		tvIdCaps: "tv_id_caps",
-		movieIdCaps: "movie_id_caps",
-		catCaps: "cat_caps",
-	});
+	const rawIndexers = await db("indexer")
+		.where({ active: true })
+		.select(allFields);
 	return rawIndexers.map(deserialize);
 }
 
@@ -121,20 +125,7 @@ export async function getEnabledIndexers(): Promise<Indexer[]> {
 				.orWhere({ status: IndexerStatus.OK })
 				.orWhere("retry_after", "<", Date.now()),
 		)
-		.select({
-			id: "id",
-			url: "url",
-			apikey: "apikey",
-			active: "active",
-			status: "status",
-			retryAfter: "retry_after",
-			searchCap: "search_cap",
-			tvSearchCap: "tv_search_cap",
-			movieSearchCap: "movie_search_cap",
-			tvIdCaps: "tv_id_caps",
-			movieIdCaps: "movie_id_caps",
-			catCaps: "cat_caps",
-		});
+		.select(allFields);
 
 	return rawIndexers.map(deserialize);
 }

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -29,6 +29,44 @@ export interface Indexer {
 	categories: string;
 }
 
+export interface IndexerCategories {
+	tv: boolean;
+	movie: boolean;
+	anime: boolean;
+	xxx: boolean;
+	audio: boolean;
+	book: boolean;
+	/**
+	 * If the indexer has a category not covered by the above.
+	 */
+	additional: boolean;
+}
+
+export interface IdSearchCaps {
+	tvdbId?: boolean;
+	tmdbId?: boolean;
+	imdbId?: boolean;
+	tvMazeId?: boolean;
+}
+
+export interface HydratedIndexer {
+	id: number;
+	url: string;
+	apikey: string;
+	/**
+	 * Whether the indexer is currently specified in config
+	 */
+	active: boolean;
+	status: IndexerStatus;
+	retryAfter: number;
+	searchCap: boolean;
+	tvSearchCap: boolean;
+	movieSearchCap: boolean;
+	tvIdCaps: IdSearchCaps;
+	movieIdCaps: IdSearchCaps;
+	categories: IndexerCategories;
+}
+
 export async function getAllIndexers(): Promise<Indexer[]> {
 	return db("indexer").where({ active: true }).select({
 		id: "id",

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -235,10 +235,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 			"indexer.id",
 			enabledIndexers
 				.filter((indexer) =>
-					indexerDoesSupportMediaType(
-						mediaType,
-						JSON.parse(indexer.categories),
-					),
+					indexerDoesSupportMediaType(mediaType, indexer.categories),
 				)
 				.map((indexer) => indexer.id),
 		)

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -21,7 +21,6 @@ import { db } from "./db.js";
 import { CrossSeedError } from "./errors.js";
 import {
 	Caps,
-	DbIndexer,
 	getAllIndexers,
 	getEnabledIndexers,
 	IdSearchCaps,
@@ -408,22 +407,7 @@ export async function searchTorznab(
 export async function syncWithDb() {
 	const { torznab } = getRuntimeConfig();
 
-	const dbIndexers = await db<DbIndexer>("indexer")
-		.where({ active: true })
-		.select({
-			id: "id",
-			url: "url",
-			apikey: "apikey",
-			active: "active",
-			status: "status",
-			retryAfter: "retry_after",
-			searchCap: "search_cap",
-			tvSearchCap: "tv_search_cap",
-			tvIdCaps: "tv_id_caps",
-			movieSearchCap: "movie_search_cap",
-			movieIdCaps: "movie_id_caps",
-			catCaps: "cat_caps",
-		});
+	const dbIndexers = await getAllIndexers();
 
 	const inConfigButNotInDb = torznab.filter(
 		(configIndexer) =>

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -1,12 +1,14 @@
+import chalk from "chalk";
 import ms from "ms";
+import { inspect } from "util";
 import xml2js from "xml2js";
 import {
 	arrIdsEqual,
 	ExternalIds,
-	scanAllArrsForMedia,
+	formatFoundIds,
 	getRelevantArrIds,
 	ParsedMedia,
-	formatFoundIds,
+	scanAllArrsForMedia,
 } from "./arr.js";
 import {
 	CALIBRE_INDEXNUM_REGEX,
@@ -20,7 +22,9 @@ import { CrossSeedError } from "./errors.js";
 import {
 	getAllIndexers,
 	getEnabledIndexers,
+	IdSearchCaps,
 	Indexer,
+	IndexerCategories,
 	IndexerStatus,
 	updateIndexerStatus,
 } from "./indexers.js";
@@ -44,21 +48,6 @@ import {
 	stripExtension,
 	stripMetaFromName,
 } from "./utils.js";
-import chalk from "chalk";
-import { inspect } from "util";
-
-export interface TorznabCats {
-	tv: boolean;
-	movie: boolean;
-	anime: boolean;
-	xxx: boolean;
-	audio: boolean;
-	book: boolean;
-	/**
-	 * If the indexer has a category not covered by the above.
-	 */
-	additional: boolean;
-}
 
 export interface IdSearchParams {
 	tvdbid?: string;
@@ -76,16 +65,9 @@ export interface TorznabParams extends IdSearchParams {
 	ep?: number | string;
 }
 
-export interface IdSearchCaps {
-	tvdbId?: boolean;
-	tmdbId?: boolean;
-	imdbId?: boolean;
-	tvMazeId?: boolean;
-}
-
 export interface Caps {
 	search: boolean;
-	categories: TorznabCats;
+	categories: IndexerCategories;
 	tvSearch: boolean;
 	movieSearch: boolean;
 	movieIdSearch: IdSearchCaps;
@@ -362,7 +344,7 @@ export async function logQueries(
 
 export function indexerDoesSupportMediaType(
 	mediaType: MediaType,
-	caps: TorznabCats,
+	caps: IndexerCategories,
 ) {
 	switch (mediaType) {
 		case MediaType.EPISODE:


### PR DESCRIPTION
This PR consolidates all of the `JSON.parse` code we were doing for some indexer columns (cat_caps, movie_id_caps, tv_id_caps) into one place. From now on, all database calls for the `indexers` table should do so by calling functions in `indexers.ts`. We can add functions to `indexers.ts` as necessary to accomplish this.

- **define caps more rigorously**
- **use hydrated indexer objects everywhere**
- **consolidate field selection**
- **move last db call into indexers.ts**
