### PR TITLE
enhancement(general): extract non feature functionality for upcoming features

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -203,9 +203,12 @@ export async function linkAllFilesInMetafile(
 	>
 > {
 	const { linkDir, flatLinking } = getRuntimeConfig();
-	const newMetaClientSavePathRes = await getClient().getDownloadDir(newMeta, {
-		onlyCompleted: false,
-	});
+	const newMetaClientSavePathRes = await getClient()!.getDownloadDir(
+		newMeta,
+		{
+			onlyCompleted: false,
+		},
+	);
 	const fullLinkDir = newMetaClientSavePathRes.isOk()
 		? newMetaClientSavePathRes.unwrap() // Use existing if ALREADY_EXISTS
 		: flatLinking
@@ -234,7 +237,7 @@ export async function linkAllFilesInMetafile(
 		}
 		sourceRoot = searchee.path;
 	} else {
-		const downloadDirResult = await getClient().getDownloadDir(
+		const downloadDirResult = await getClient()!.getDownloadDir(
 			searchee as SearcheeWithInfoHash,
 			{ onlyCompleted: options.onlyCompleted },
 		);
@@ -332,7 +335,7 @@ export async function performAction(
 		// should be a MATCH, as risky requires a linkDir to be set
 		destinationDir = dirname(searchee.path);
 	}
-	const result = await getClient().inject(
+	const result = await getClient()!.inject(
 		newMeta,
 		searchee,
 		decision,

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,7 +10,7 @@ import {
 	symlinkSync,
 } from "fs";
 import { dirname, join, resolve } from "path";
-import { getClient } from "./clients/TorrentClient.js";
+import { getClient, shouldRecheck } from "./clients/TorrentClient.js";
 import {
 	Action,
 	ActionResult,
@@ -339,8 +339,8 @@ export async function performAction(
 
 	logActionResult(result, newMeta, searchee, tracker, decision);
 	if (result === InjectionResult.SUCCESS) {
-		// For an easy re-injection user workflow when multiple MATCH_PARTIAL
-		if (decision === Decision.MATCH_PARTIAL) {
+		// cross-seed may need to process these with the inject job
+		if (shouldRecheck(searchee, decision)) {
 			await saveTorrentFile(tracker, getMediaType(searchee), newMeta);
 		}
 	} else if (result !== InjectionResult.ALREADY_EXISTS) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -203,17 +203,12 @@ export async function linkAllFilesInMetafile(
 	>
 > {
 	const { linkDir, flatLinking } = getRuntimeConfig();
-	const newMetaClientSavePathRes = await getClient()!.getDownloadDir(
-		newMeta,
-		{
-			onlyCompleted: false,
-		},
+	const clientSavePathRes = await getClient()!.getDownloadDir(newMeta, {
+		onlyCompleted: false,
+	});
+	const fullLinkDir = clientSavePathRes.orElse(
+		flatLinking ? linkDir : join(linkDir, tracker),
 	);
-	const fullLinkDir = newMetaClientSavePathRes.isOk()
-		? newMetaClientSavePathRes.unwrap() // Use existing if ALREADY_EXISTS
-		: flatLinking
-			? linkDir
-			: join(linkDir, tracker);
 
 	let sourceRoot: string;
 	if (searchee.path) {

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ms from "ms";
 import { join as posixJoin } from "node:path/posix";
 import { URLSearchParams } from "node:url";
-import { SCENE_TITLE_REGEX } from "./constants.js";
+import { MediaType, SCENE_TITLE_REGEX } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
 import { Caps } from "./indexers.js";
 import { Label, logger } from "./logger.js";
@@ -13,7 +13,6 @@ import {
 	cleanseSeparators,
 	getApikey,
 	isTruthy,
-	MediaType,
 	sanitizeUrl,
 	stripMetaFromName,
 } from "./utils.js";

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -13,7 +13,7 @@ import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { extractCredentialsFromUrl, getLogString, wait } from "../utils.js";
 import {
-	GenericTorrentInfo,
+	TorrentMetadataInClient,
 	shouldRecheck,
 	TorrentClient,
 } from "./TorrentClient.js";
@@ -500,7 +500,7 @@ export default class Deluge implements TorrentClient {
 	/**
 	 * @return All torrents in the client
 	 */
-	async getAllTorrents(): Promise<GenericTorrentInfo[]> {
+	async getAllTorrents(): Promise<TorrentMetadataInClient[]> {
 		const params = [["hash", "label"], {}];
 		const response = await this.call<TorrentStatus>(
 			"web.update_ui",

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -56,6 +56,7 @@ type DelugeJSON<ResultType> = {
 };
 
 export default class Deluge implements TorrentClient {
+	readonly type = Label.DELUGE;
 	private delugeCookie: string | null = null;
 	private delugeLabel = TORRENT_TAG;
 	private delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -11,13 +11,12 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { GenericTorrentInfo, TorrentClient } from "./TorrentClient.js";
+import { extractCredentialsFromUrl, getLogString, wait } from "../utils.js";
 import {
-	extractCredentialsFromUrl,
-	getLogString,
+	GenericTorrentInfo,
 	shouldRecheck,
-	wait,
-} from "../utils.js";
+	TorrentClient,
+} from "./TorrentClient.js";
 
 interface TorrentInfo {
 	name?: string;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -86,6 +86,7 @@ export default class QBittorrent implements TorrentClient {
 	url: { username: string; password: string; href: string };
 	version: string;
 	versionMajor: number;
+	readonly type = Label.QBITTORRENT;
 
 	constructor() {
 		const { qbittorrentUrl } = getRuntimeConfig();

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -21,7 +21,7 @@ import {
 	shouldRecheck,
 	wait,
 } from "../utils.js";
-import { TorrentClient } from "./TorrentClient.js";
+import { GenericTorrentInfo, TorrentClient } from "./TorrentClient.js";
 
 const X_WWW_FORM_URLENCODED = {
 	"Content-Type": "application/x-www-form-urlencoded",
@@ -271,9 +271,9 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	/*
-	@param searchee the Searchee we are generating off (in client)
-	@return either a string containing the path or an error message
-	*/
+	 * @param searchee the Searchee we are generating off (in client)
+	 * @return either a string containing the path or a error mesage
+	 */
 	async getDownloadDir(
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },
@@ -303,9 +303,9 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	/*
-	@param searchee the Searchee we are generating off (in client)
-	@param torrentInfo the torrent info from the searchee
-	@return string absolute location from client with content layout considered
+	 * @param searchee the Searchee we are generating off (in client)
+	 * @param torrentInfo the torrent info from the searchee
+	 * @return string absolute location from client with content layout considered
 	 */
 	getCorrectSavePath(searchee: Searchee, torrentInfo: TorrentInfo): string {
 		const subfolderContentLayout = this.isSubfolderContentLayout(
@@ -319,7 +319,7 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	/*
-	@return array of all torrents in the client
+	 * @return array of all torrents in the client
 	 */
 	async getAllTorrentInfo(): Promise<TorrentInfo[]> {
 		const responseText = await this.request("/torrents/info", "");
@@ -330,8 +330,8 @@ export default class QBittorrent implements TorrentClient {
 	}
 
 	/*
-	@param hash the hash of the torrent
-	@return the torrent if it exists
+	 * @param hash the hash of the torrent
+	 * @return the torrent if it exists
 	 */
 	async getTorrentInfo(
 		hash: string | undefined,
@@ -365,6 +365,19 @@ export default class QBittorrent implements TorrentClient {
 			}
 		}
 		return undefined;
+	}
+
+	/**
+	 * @return array of all torrents in the client
+	 */
+	async getAllTorrents(): Promise<GenericTorrentInfo[]> {
+		const torrents = await this.getAllTorrentInfo();
+		return torrents.map((torrent) => ({
+			infoHash: torrent.hash,
+			category: torrent.category,
+			tags: torrent.tags.split(","),
+			trackers: torrent.tracker.length ? [[torrent.tracker]] : undefined,
+		}));
 	}
 
 	/**

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -14,7 +14,7 @@ import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import {
-	GenericTorrentInfo,
+	TorrentMetadataInClient,
 	shouldRecheck,
 	TorrentClient,
 } from "./TorrentClient.js";
@@ -413,7 +413,7 @@ export default class QBittorrent implements TorrentClient {
 	/**
 	 * @return array of all torrents in the client
 	 */
-	async getAllTorrents(): Promise<GenericTorrentInfo[]> {
+	async getAllTorrents(): Promise<TorrentMetadataInClient[]> {
 		const torrents = await this.getAllTorrentInfo();
 		return torrents.map((torrent) => ({
 			infoHash: torrent.hash,

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -14,14 +14,17 @@ import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import {
+	GenericTorrentInfo,
+	shouldRecheck,
+	TorrentClient,
+} from "./TorrentClient.js";
+import {
 	extractCredentialsFromUrl,
 	extractInt,
 	getLogString,
 	sanitizeInfoHash,
-	shouldRecheck,
 	wait,
 } from "../utils.js";
-import { GenericTorrentInfo, TorrentClient } from "./TorrentClient.js";
 
 const X_WWW_FORM_URLENCODED = {
 	"Content-Type": "application/x-www-form-urlencoded",

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -14,13 +14,12 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { File, Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { GenericTorrentInfo, TorrentClient } from "./TorrentClient.js";
+import { extractCredentialsFromUrl, isTruthy, wait } from "../utils.js";
 import {
-	extractCredentialsFromUrl,
-	isTruthy,
+	GenericTorrentInfo,
 	shouldRecheck,
-	wait,
-} from "../utils.js";
+	TorrentClient,
+} from "./TorrentClient.js";
 
 const COULD_NOT_FIND_INFO_HASH = "Could not find info-hash.";
 

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -94,6 +94,7 @@ async function saveWithLibTorrentResume(
 
 export default class RTorrent implements TorrentClient {
 	client: Client;
+	readonly type = Label.RTORRENT;
 
 	constructor() {
 		const { rtorrentRpcUrl } = getRuntimeConfig();

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -10,7 +10,7 @@ import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
 import Transmission from "./Transmission.js";
 
-let activeClient: TorrentClient;
+let activeClient: TorrentClient | null = null;
 
 export interface TorrentClient {
 	isTorrentComplete: (
@@ -46,7 +46,7 @@ function instantiateDownloadClient() {
 	}
 }
 
-export function getClient(): TorrentClient {
+export function getClient(): TorrentClient | null {
 	if (!activeClient) {
 		instantiateDownloadClient();
 	}

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -25,7 +25,7 @@ export type TorrentClientType =
 	| Label.TRANSMISSION
 	| Label.DELUGE;
 
-export interface GenericTorrentInfo {
+export interface TorrentMetadataInClient {
 	infoHash: string;
 	category: string;
 	tags: string[];
@@ -37,7 +37,7 @@ export interface TorrentClient {
 	isTorrentComplete: (
 		infoHash: string,
 	) => Promise<Result<boolean, "NOT_FOUND">>;
-	getAllTorrents: () => Promise<GenericTorrentInfo[]>;
+	getAllTorrents: () => Promise<TorrentMetadataInClient[]>;
 	getDownloadDir: (
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -19,11 +19,19 @@ export type TorrentClientType =
 	| Label.TRANSMISSION
 	| Label.DELUGE;
 
+export interface GenericTorrentInfo {
+	infoHash: string;
+	category: string;
+	tags: string[];
+	trackers?: string[][];
+}
+
 export interface TorrentClient {
 	type: TorrentClientType;
 	isTorrentComplete: (
 		infoHash: string,
 	) => Promise<Result<boolean, "NOT_FOUND">>;
+	getAllTorrents: () => Promise<GenericTorrentInfo[]>;
 	getDownloadDir: (
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -38,6 +38,10 @@ export interface TorrentClient {
 	) => Promise<
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	>;
+	getAllDownloadDirs: (options: {
+		metas: SearcheeWithInfoHash[] | Metafile[];
+		onlyCompleted: boolean;
+	}) => Promise<Map<string, string>>;
 	inject: (
 		newTorrent: Metafile,
 		searchee: Searchee,

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -1,5 +1,6 @@
 import ms from "ms";
 import { DecisionAnyMatch, InjectionResult } from "../constants.js";
+import { Label } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
@@ -12,7 +13,14 @@ import Transmission from "./Transmission.js";
 
 let activeClient: TorrentClient | null = null;
 
+export type TorrentClientType =
+	| Label.QBITTORRENT
+	| Label.RTORRENT
+	| Label.TRANSMISSION
+	| Label.DELUGE;
+
 export interface TorrentClient {
+	type: TorrentClientType;
 	isTorrentComplete: (
 		infoHash: string,
 	) => Promise<Result<boolean, "NOT_FOUND">>;

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -1,8 +1,13 @@
 import ms from "ms";
-import { DecisionAnyMatch, InjectionResult } from "../constants.js";
 import { Label } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result } from "../Result.js";
+import {
+	Decision,
+	DecisionAnyMatch,
+	InjectionResult,
+	VIDEO_DISC_EXTENSIONS,
+} from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
 import { wait } from "../utils.js";
@@ -10,6 +15,7 @@ import Deluge from "./Deluge.js";
 import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
 import Transmission from "./Transmission.js";
+import { hasExt } from "../utils.js";
 
 let activeClient: TorrentClient | null = null;
 
@@ -86,4 +92,13 @@ export async function waitForTorrentToComplete(
 		}
 	}
 	return false;
+}
+
+export function shouldRecheck(
+	searchee: Searchee,
+	decision: DecisionAnyMatch,
+): boolean {
+	if (decision === Decision.MATCH_PARTIAL) return true;
+	if (hasExt(searchee.files, VIDEO_DISC_EXTENSIONS)) return true;
+	return false; // Skip for MATCH | MATCH_SIZE_ONLY
 }

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -47,6 +47,7 @@ function doesAlreadyExist(
 
 export default class Transmission implements TorrentClient {
 	xTransmissionSessionId: string;
+	readonly type = Label.TRANSMISSION;
 
 	private async request<T>(
 		method: Method,

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -186,6 +186,20 @@ export default class Transmission implements TorrentClient {
 			.mapErr((err) => (err === "FAILURE" ? "UNKNOWN_ERROR" : err));
 	}
 
+	async getAllDownloadDirs(options: {
+		onlyCompleted: boolean;
+	}): Promise<Map<string, string>> {
+		const res = await this.request<TorrentGetResponseArgs>("torrent-get", {
+			fields: ["hashString", "downloadDir", "percentDone"],
+		});
+		const downloadDirs = new Map<string, string>();
+		for (const { hashString, downloadDir, percentDone } of res.torrents) {
+			if (options.onlyCompleted && percentDone < 1) continue;
+			downloadDirs.set(hashString, downloadDir);
+		}
+		return downloadDirs;
+	}
+
 	async isTorrentComplete(
 		infoHash: string,
 	): Promise<Result<boolean, "NOT_FOUND">> {

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -9,8 +9,12 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { extractCredentialsFromUrl, shouldRecheck } from "../utils.js";
-import { GenericTorrentInfo, TorrentClient } from "./TorrentClient.js";
+import {
+	GenericTorrentInfo,
+	shouldRecheck,
+	TorrentClient,
+} from "./TorrentClient.js";
+import { extractCredentialsFromUrl } from "../utils.js";
 
 const XTransmissionSessionId = "X-Transmission-Session-Id";
 type Method =

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -119,9 +119,7 @@ export const VALIDATION_SCHEMA = z
 	.object({
 		delay: z
 			.number()
-			.nonnegative({
-				message: ZodErrorMessages.delayNegative,
-			})
+			.nonnegative(ZodErrorMessages.delayNegative)
 			.gte(process.env.DEV ? 0 : 30, ZodErrorMessages.delayUnsupported)
 			.lte(3600, ZodErrorMessages.delayUnsupported),
 		torznab: z.array(z.string().url()),
@@ -140,12 +138,13 @@ export const VALIDATION_SCHEMA = z
 		injectDir: z.string().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
-		fuzzySizeThreshold: z.number().positive().lte(1, {
-			message: ZodErrorMessages.fuzzySizeThreshold,
-		}),
+		fuzzySizeThreshold: z
+			.number()
+			.positive()
+			.lte(1, ZodErrorMessages.fuzzySizeThreshold),
 		excludeOlder: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish()
 			.or(
@@ -159,7 +158,7 @@ export const VALIDATION_SCHEMA = z
 
 		excludeRecentSearch: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish()
 			.or(
@@ -187,7 +186,7 @@ export const VALIDATION_SCHEMA = z
 		host: z.string().ip().nullish(),
 		rssCadence: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish()
 			.refine(
@@ -199,7 +198,7 @@ export const VALIDATION_SCHEMA = z
 			),
 		searchCadence: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish()
 			.refine(
@@ -209,12 +208,12 @@ export const VALIDATION_SCHEMA = z
 			),
 		snatchTimeout: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish(),
 		searchTimeout: z
 			.string()
-			.min(1, { message: ZodErrorMessages.emptyString })
+			.min(1, ZodErrorMessages.emptyString)
 			.transform(transformDurationString)
 			.nullish(),
 		searchLimit: z.number().nonnegative().nullish(),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,6 +114,17 @@ export const TORRENT_CACHE_FOLDER = "torrent_cache";
 export const UNKNOWN_TRACKER = "UnknownTracker";
 export const LEVENSHTEIN_DIVISOR = 3;
 
+export enum MediaType {
+	EPISODE = "episode",
+	SEASON = "pack",
+	MOVIE = "movie",
+	ANIME = "anime",
+	VIDEO = "video",
+	AUDIO = "audio",
+	BOOK = "book",
+	OTHER = "unknown",
+}
+
 export enum Action {
 	SAVE = "save",
 	INJECT = "inject",

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -268,9 +268,7 @@ async function injectFromStalledTorrent({
 			decision,
 			{ onlyCompleted: false },
 		);
-		const linkResult = linkedFilesRootResult.isOk()
-			? linkedFilesRootResult.unwrap()
-			: null;
+		const linkResult = linkedFilesRootResult.orElse(null);
 		if (linkResult && linkResult.linkedNewFiles) {
 			linkedNewFiles = true;
 		}
@@ -355,7 +353,7 @@ async function injectionAlreadyExists({
 	filePathLog,
 }: InjectionAftermath) {
 	const result = await getClient()!.isTorrentComplete(meta.infoHash);
-	let isComplete = result.isOk() ? result.unwrap() : false;
+	let isComplete = result.orElse(false);
 	const anyFullMatch = matches.some(
 		(m) =>
 			m.decision === Decision.MATCH ||

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -258,7 +258,7 @@ async function injectFromStalledTorrent({
 	filePathLog,
 }: InjectionAftermath) {
 	let linkedNewFiles = false;
-	let inClient = (await getClient().isTorrentComplete(meta.infoHash)).isOk();
+	let inClient = (await getClient()!.isTorrentComplete(meta.infoHash)).isOk();
 	let injected = false;
 	for (const { searchee, decision } of matches) {
 		const linkedFilesRootResult = await linkAllFilesInMetafile(
@@ -277,7 +277,7 @@ async function injectFromStalledTorrent({
 		if (!inClient) {
 			if (linkedFilesRootResult.isOk()) {
 				const destinationDir = dirname(linkResult!.contentPath);
-				const result = await getClient().inject(
+				const result = await getClient()!.inject(
 					meta,
 					searchee,
 					Decision.MATCH_PARTIAL, // Should always be considered partial
@@ -311,7 +311,7 @@ async function injectFromStalledTorrent({
 				label: Label.INJECT,
 				message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
 			});
-			await getClient().recheckTorrent(meta.infoHash);
+			await getClient()!.recheckTorrent(meta.infoHash);
 		} else {
 			logger.warn({
 				label: Label.INJECT,
@@ -354,7 +354,7 @@ async function injectionAlreadyExists({
 	matches,
 	filePathLog,
 }: InjectionAftermath) {
-	const result = await getClient().isTorrentComplete(meta.infoHash);
+	const result = await getClient()!.isTorrentComplete(meta.infoHash);
 	let isComplete = result.isOk() ? result.unwrap() : false;
 	const anyFullMatch = matches.some(
 		(m) =>
@@ -366,13 +366,13 @@ async function injectionAlreadyExists({
 			label: Label.INJECT,
 			message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
 		});
-		await getClient().recheckTorrent(meta.infoHash);
+		await getClient()!.recheckTorrent(meta.infoHash);
 	} else if (anyFullMatch && !isComplete) {
 		logger.info({
 			label: Label.INJECT,
 			message: `${progress} Rechecking ${filePathLog} as it's not complete but has all files - ${chalk.green(injectionResult)}`,
 		});
-		await getClient().recheckTorrent(meta.infoHash);
+		await getClient()!.recheckTorrent(meta.infoHash);
 		isComplete = true; // Prevent infinite recheck in rare case of corrupted cross seed
 	} else {
 		logger.warn({

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -14,6 +14,7 @@ import {
 	DecisionAnyMatch,
 	InjectionResult,
 	isAnyMatchedDecision,
+	MediaType,
 	SaveResult,
 	TORRENT_CACHE_FOLDER,
 	UNKNOWN_TRACKER,
@@ -37,7 +38,6 @@ import {
 	formatAsList,
 	getLogString,
 	isTruthy,
-	MediaType,
 	sanitizeInfoHash,
 } from "./utils.js";
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -196,6 +196,7 @@ export function filterDupesFromSimilar<T extends Searchee>(
 	const filteredSearchees: T[] = [];
 	for (const searchee of searchees) {
 		const isDupe = filteredSearchees.some((s) => {
+			if (searchee.title !== s.title) return false;
 			if (searchee.length !== s.length) return false;
 			if (searchee.files.length !== s.files.length) return false;
 			const potentialFiles = s.files.map((f) => f.length);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -16,6 +16,7 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee, SearcheeWithLabel } from "./searchee.js";
 import { indexerDoesSupportMediaType } from "./torznab.js";
 import {
+	comparing,
 	filesWithExt,
 	getLogString,
 	getMediaType,
@@ -194,7 +195,7 @@ export function filterDupesFromSimilar<T extends Searchee>(
 	searchees: T[],
 ): T[] {
 	const filteredSearchees: T[] = [];
-	for (const searchee of searchees) {
+	for (const searchee of [...searchees].sort(comparing((s) => !s.infoHash))) {
 		const isDupe = filteredSearchees.some((s) => {
 			if (searchee.title !== s.title) return false;
 			if (searchee.length !== s.length) return false;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -3,6 +3,7 @@ import ms from "ms";
 import { basename, dirname } from "path";
 import {
 	ARR_DIR_REGEX,
+	MediaType,
 	SEASON_REGEX,
 	SONARR_SUBFOLDERS_REGEX,
 	VIDEO_DISC_EXTENSIONS,
@@ -20,7 +21,6 @@ import {
 	getMediaType,
 	hasExt,
 	humanReadableDate,
-	MediaType,
 	nMsAgo,
 } from "./utils.js";
 

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -1,4 +1,5 @@
 import { readdirSync, statSync } from "fs";
+import { stat } from "fs/promises";
 import { basename, dirname, join, relative } from "path";
 import {
 	ANIME_GROUP_REGEX,
@@ -88,6 +89,23 @@ export function getSearcheeSource(searchee: Searchee): SearcheeSource {
 	} else {
 		return SearcheeSource.VIRTUAL;
 	}
+}
+
+export function getLargestFile(files: File[]): File {
+	return files.reduce((a, b) => (a.length > b.length ? a : b));
+}
+
+export async function getNewestFileAge(searchee: Searchee): Promise<number> {
+	if (searchee.infoHash || searchee.path) {
+		throw new Error("Only virtual searchees have absolute paths");
+	}
+	return Math.max(
+		...(await Promise.all(
+			searchee.files.map((file) =>
+				stat(file.path).then((s) => s.mtimeMs),
+			),
+		)),
+	);
 }
 
 function getFileNamesFromRootRec(root: string, isDirHint?: boolean): string[] {

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -6,6 +6,7 @@ import { extname, join, resolve } from "path";
 import { inspect } from "util";
 import {
 	LEVENSHTEIN_DIVISOR,
+	MediaType,
 	SAVED_TORRENTS_INFO_REGEX,
 	USER_AGENT,
 } from "./constants.js";
@@ -23,7 +24,7 @@ import {
 	getSeasonKey,
 	Searchee,
 } from "./searchee.js";
-import { createKeyTitle, MediaType, stripExtension } from "./utils.js";
+import { createKeyTitle, stripExtension } from "./utils.js";
 
 export interface TorrentLocator {
 	infoHash?: string;

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -317,7 +317,7 @@ export async function logQueries(
 		`RAW: ${inspect(await createTorznabSearchQueries(stem, mediaType, ALL_CAPS))}`,
 	);
 	const res = await scanAllArrsForMedia(searcheeTitle, mediaType);
-	const parsedMedia = res.isOk() ? res.unwrap() : undefined;
+	const parsedMedia = res.orElse(undefined);
 	logger.info(
 		// @ts-expect-error needs conversion to use searchee instead of stem
 		`ID: ${inspect(await createTorznabSearchQueries(stem, mediaType, ALL_CAPS, parsedMedia))}`,
@@ -832,7 +832,7 @@ async function getAndLogIndexers(
 	if (cachedSearch.q === searchStr) {
 		shouldScanArr = false;
 		const res = await scanAllArrsForMedia(name, mediaType);
-		parsedMedia = res.isOk() ? res.unwrap() : undefined;
+		parsedMedia = res.orElse(undefined);
 		const ids = parsedMedia?.movie ?? parsedMedia?.series;
 		if (!arrIdsEqual(ids, cachedSearch.ids)) {
 			cachedSearch.indexerCandidates.length = 0;
@@ -867,7 +867,7 @@ async function getAndLogIndexers(
 
 	if (shouldScanArr) {
 		const res = await scanAllArrsForMedia(name, mediaType);
-		parsedMedia = res.isOk() ? res.unwrap() : undefined;
+		parsedMedia = res.orElse(undefined);
 		cachedSearch.ids = parsedMedia?.movie ?? parsedMedia?.series;
 	}
 	const idsStr = cachedSearch.ids ? formatFoundIds(cachedSearch.ids) : "NONE";

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -13,6 +13,7 @@ import {
 import {
 	CALIBRE_INDEXNUM_REGEX,
 	EP_REGEX,
+	MediaType,
 	SEASON_REGEX,
 	UNKNOWN_TRACKER,
 	USER_AGENT,
@@ -45,7 +46,6 @@ import {
 	getLogString,
 	getMediaType,
 	isTruthy,
-	MediaType,
 	nMsAgo,
 	reformatTitleForSearching,
 	sanitizeUrl,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import chalk, { ChalkInstance } from "chalk";
 import { distance } from "fastest-levenshtein";
-import { statSync } from "fs";
 import path from "path";
 import {
 	ALL_EXTENSIONS,
@@ -360,17 +359,6 @@ export function escapeUnescapedQuotesInJsonValues(jsonStr: string): string {
 
 export function extractInt(str: string): number {
 	return parseInt(str.match(/\d+/)![0]);
-}
-
-export function getLargestFile(files: File[]): File {
-	return files.reduce((a, b) => (a.length > b.length ? a : b));
-}
-
-export function getNewestFileAge(files: File[]): number {
-	return files.reduce(
-		(acc, file) => Math.max(acc, statSync(file.path).mtimeMs),
-		0,
-	);
 }
 
 export function getFuzzySizeFactor(): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
 	EP_REGEX,
 	JSON_VALUES_REGEX,
 	LEVENSHTEIN_DIVISOR,
+	MediaType,
 	MOVIE_REGEX,
 	NON_UNICODE_ALPHANUM_REGEX,
 	RELEASE_GROUP_REGEX,
@@ -25,17 +26,6 @@ import {
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
-
-export enum MediaType {
-	EPISODE = "episode",
-	SEASON = "pack",
-	MOVIE = "movie",
-	ANIME = "anime",
-	VIDEO = "video",
-	AUDIO = "audio",
-	BOOK = "book",
-	OTHER = "unknown",
-}
 
 type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import chalk, { ChalkInstance } from "chalk";
 import { distance } from "fastest-levenshtein";
+import { statSync } from "fs";
 import path from "path";
 import {
 	ALL_EXTENSIONS,
@@ -366,6 +367,17 @@ export function escapeUnescapedQuotesInJsonValues(jsonStr: string): string {
 
 export function extractInt(str: string): number {
 	return parseInt(str.match(/\d+/)![0]);
+}
+
+export function getLargestFile(files: File[]): File {
+	return files.reduce((a, b) => (a.length > b.length ? a : b));
+}
+
+export function getNewestFileAge(files: File[]): number {
+	return files.reduce(
+		(acc, file) => Math.max(acc, statSync(file.path).mtimeMs),
+		0,
+	);
 }
 
 export function getFuzzySizeFactor(): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,6 @@ import {
 	ANIME_REGEX,
 	AUDIO_EXTENSIONS,
 	BOOK_EXTENSIONS,
-	Decision,
 	EP_REGEX,
 	JSON_VALUES_REGEX,
 	LEVENSHTEIN_DIVISOR,
@@ -98,18 +97,6 @@ export function getMediaType(searchee: Searchee): MediaType {
 			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
 		default:
 			return unsupportedMediaType(searchee);
-	}
-}
-
-export function shouldRecheck(searchee: Searchee, decision: Decision): boolean {
-	if (hasExt(searchee.files, VIDEO_DISC_EXTENSIONS)) return true;
-	switch (decision) {
-		case Decision.MATCH:
-		case Decision.MATCH_SIZE_ONLY:
-			return false;
-		case Decision.MATCH_PARTIAL:
-		default:
-			return true;
 	}
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,9 +50,15 @@ export function wait(n: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, n));
 }
 
-export function humanReadableSize(bytes: number) {
-	const k = 1000;
-	const sizes = ["B", "kB", "MB", "GB", "TB"];
+export function humanReadableSize(
+	bytes: number,
+	options?: { binary: boolean },
+) {
+	if (bytes === 0) return "0 B";
+	const k = options?.binary ? 1024 : 1000;
+	const sizes = options?.binary
+		? ["B", "KiB", "MiB", "GiB", "TiB"]
+		: ["B", "kB", "MB", "GB", "TB"];
 	// engineering notation: (coefficient) * 1000 ^ (exponent)
 	const exponent = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
 	const coefficient = bytes / Math.pow(k, exponent);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,11 +287,15 @@ export function getLogString(
 
 export function formatAsList(
 	strings: string[],
-	options: { sort: boolean; type?: Intl.ListFormatType },
+	options: {
+		sort: boolean;
+		style?: Intl.ListFormatStyle;
+		type?: Intl.ListFormatType;
+	},
 ) {
 	if (options.sort) strings.sort((a, b) => a.localeCompare(b));
 	return new Intl.ListFormat("en", {
-		style: "long",
+		style: options.style ?? "long",
 		type: options.type ?? "conjunction",
 	}).format(strings);
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,12 +2,11 @@ import { describe, expect, it } from "vitest";
 import { fileFactory } from "./factories/file";
 import { searcheeFactory } from "./factories/searchee";
 
-import { SEASON_REGEX } from "../src/constants";
+import { MediaType, SEASON_REGEX } from "../src/constants";
 import {
 	extractInt,
 	getMediaType,
 	humanReadableSize,
-	MediaType,
 	sanitizeUrl,
 } from "../src/utils";
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,12 +13,12 @@ import {
 describe("humanReadableSize", () => {
 	it("returns a human-readable size", () => {
 		expect(humanReadableSize(123)).toBe("123 B");
-		expect(humanReadableSize(1234)).toBe("1.23 kB");
+		expect(humanReadableSize(1234)).toBe("1.23 KB");
 		expect(humanReadableSize(1000 * 1234)).toBe("1.23 MB");
 	});
 
 	it("truncates number when byte size is exact", () => {
-		expect(humanReadableSize(1000)).toBe("1 kB");
+		expect(humanReadableSize(1000)).toBe("1 KB");
 	});
 });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,12 +13,15 @@ import {
 describe("humanReadableSize", () => {
 	it("returns a human-readable size", () => {
 		expect(humanReadableSize(123)).toBe("123 B");
-		expect(humanReadableSize(1234)).toBe("1.23 KB");
+		expect(humanReadableSize(1234)).toBe("1.23 kB");
 		expect(humanReadableSize(1000 * 1234)).toBe("1.23 MB");
+		expect(humanReadableSize(1024 * 1234, { binary: true })).toBe(
+			"1.21 MiB",
+		);
 	});
 
 	it("truncates number when byte size is exact", () => {
-		expect(humanReadableSize(1000)).toBe("1 KB");
+		expect(humanReadableSize(1000)).toBe("1 kB");
 	});
 });
 


### PR DESCRIPTION
This should make the feature PRs easier to review. Most of what was extracted won't have any immediate effect but will be necessary for the upcoming features.

Client type and `getClient()` being optional allows blocklisting using torrent data if available. Type allows handling qbit specifically since we read the data from fastresume usually.

`getAllTorrents()` is used to get the blocklisting information from the clients. Also updated `checkOriginalTorrent()` for rTorrent for this purpose.

`getAllDownloadDirs()` is to find the absolute file path of each episode torrent for ensemble. This prevents individual requests for each torrent.

`getLargestFile()` and `getNewestFileAge()` are for getting the episode file from a searchee and controlling when to search for ensemble.

Added binary for `humanReadableSize()` as the limit for resume is in binary since it more closely represents download data.

Others are code quality.