### PR TITLE
fix(logging/webhook): log request before error in invalid webhook

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -107,8 +107,13 @@ async function search(
 				existsSync(criteria.path))
 		)
 	) {
+		logger.info({
+			label: Label.WEBHOOK,
+			message: `Received search request: ${inspect(criteria)}`,
+		});
+
 		const message =
-			"A valid infoHash or path must be provided (infoHash is preferred).";
+			"A valid infoHash or accessible path must be provided (infoHash is preferred).";
 		logger.error({ label: Label.WEBHOOK, message });
 		res.writeHead(400);
 		res.end(message);


### PR DESCRIPTION
when an invalid search request (bad infohash or inaccessible path) is provided, we return an error stating as much but did not report the search request itself.

this should be reported for debugging/troubleshooting

since neither the infohash or the path is valid, sanitizing this output is not necessary