### PR TITLE
enhancement(clear-cache): also clear search timestamps

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -301,7 +301,7 @@ program
 		"Clear the cache without causing torrents to be re-snatched and reset the timestamps for excludeOlder and excludeRecentSearch",
 	)
 	.action(async () => {
-		console.log("Clearing cache, this may take a few minutes...");
+		console.log("Clearing cache...");
 		await db("decision").whereNull("info_hash").del();
 		await db("timestamp").del();
 		await db.destroy();

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import chalk from "chalk";
 import { Option, program } from "commander";
+import ms from "ms";
 import { inspect } from "util";
 import { getApiKey, resetApiKey } from "./auth.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
@@ -25,7 +26,11 @@ import {
 	initializePushNotifier,
 	sendTestNotification,
 } from "./pushNotifier.js";
-import { RuntimeConfig, setRuntimeConfig } from "./runtimeConfig.js";
+import {
+	getRuntimeConfig,
+	RuntimeConfig,
+	setRuntimeConfig,
+} from "./runtimeConfig.js";
 import { createSearcheeFromMetafile } from "./searchee.js";
 import { serve } from "./server.js";
 import "./signalHandlers.js";
@@ -295,13 +300,31 @@ program
 	)
 	.action(() => void generateConfig());
 
-program
-	.command("clear-cache")
-	.description("Clear the cache of downloaded-and-rejected torrents")
-	.action(async () => {
-		await db("decision").whereNull("info_hash").del();
-		await db.destroy();
-	});
+createCommandWithSharedOptions(
+	"clear-cache",
+	"Clear the cache of downloaded-and-rejected torrents and re-search your library over a few weeks",
+).action(async (options) => {
+	validateAndSetRuntimeConfig(options);
+	const { excludeRecentSearch } = getRuntimeConfig();
+	console.log("Clearing cache, this may take a few minutes...");
+
+	await db("decision").whereNull("info_hash").del();
+	const now = Date.now();
+	const start = now - (excludeRecentSearch ?? 0);
+	const limit = ms("30 days");
+	const rows = await db("timestamp").select("searchee_id").distinct();
+	for (const row of rows) {
+		const offset = Math.floor(Math.random() * limit);
+		await db("timestamp")
+			.where({ searchee_id: row.searchee_id })
+			.update({
+				first_searched: now + offset,
+				last_searched: start + offset,
+			});
+	}
+
+	await db.destroy();
+});
 
 program
 	.command("clear-indexer-failures")

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -263,7 +263,7 @@ export async function filterTimestamps(searchee: Searchee): Promise<boolean> {
 		? nMsAgo(excludeOlder)
 		: Number.NEGATIVE_INFINITY;
 	// Don't exclude if new indexer was added
-	if (!latest_first_search || latest_first_search !== MAX_INT) {
+	if (latest_first_search !== MAX_INT) {
 		if (earliest_first_search && earliest_first_search < skipBefore) {
 			logReason(
 				`its first search timestamp ${humanReadableDate(

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -806,8 +806,12 @@ async function getAndLogIndexers(
 			(entry) => entry.indexerId === indexer.id,
 		);
 		if (!entry) return true;
-		if (entry.firstSearched < skipBefore) return false;
-		if (entry.lastSearched > skipAfter) return false;
+		if (entry.firstSearched && entry.firstSearched < skipBefore) {
+			return false;
+		}
+		if (entry.lastSearched && entry.lastSearched > skipAfter) {
+			return false;
+		}
 		return true;
 	});
 


### PR DESCRIPTION
`cross-seed clear-cache` will now also clear the search timestamps which will re-search the users library. To prevent all searches happening at once, they are each delayed randomly for up to `30 days`. `first_searched` is set to when the first new search will occur and `last_searched` starts at `nMsAgo(excludeRecentSearch ?? 0)`.

Users may need to use this command upon migrating to v6 or if they were on v6 pre-release due to incremental improvements. They should only need to do this once, unless we make significant improvements to `cross-seed` (unlikely).