### PR TITLE
fix(utils/parsing): strip scene title before release group

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,11 +245,12 @@ export function getAnimeQueries(name: string): string[] {
 export function stripMetaFromName(name: string): string {
 	return sourceRegexRemove(
 		stripExtension(name)
-			.replace(RELEASE_GROUP_REGEX, "")
+			.match(SCENE_TITLE_REGEX)!
+			.groups!.title.replace(RELEASE_GROUP_REGEX, "")
 			.replace(/\s*-\s*$/, "")
 			.replace(RESOLUTION_REGEX, "")
 			.replace(REPACK_PROPER_REGEX, ""),
-	).match(SCENE_TITLE_REGEX)!.groups!.title;
+	);
 }
 
 export const tap = (fn) => (value) => {


### PR DESCRIPTION
`abc-...` the `...` would match as release group so we should remove the `abc-` scene prefix first.

Should we also add restrictions to release group?