### PR TITLE
feat(clients/qbit): Add support for custom tagging of cross seed torrents

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -2,7 +2,6 @@ import ms from "ms";
 import {
 	DecisionAnyMatch,
 	InjectionResult,
-	TORRENT_TAG,
 	TORRENT_CATEGORY_SUFFIX,
 } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
@@ -55,7 +54,7 @@ type DelugeJSON<ResultType> = {
 
 export default class Deluge implements TorrentClient {
 	private delugeCookie: string | null = null;
-	private delugeLabel = TORRENT_TAG;
+	private delugeLabel = getRuntimeConfig().crossSeedTag;
 	private delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
 	private isLabelEnabled: boolean;
 	private delugeRequestId: number = 0;

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -6,7 +6,6 @@ import xmlrpc, { Client } from "xmlrpc";
 import {
 	DecisionAnyMatch,
 	InjectionResult,
-	TORRENT_TAG,
 } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
@@ -309,7 +308,7 @@ export default class RTorrent implements TorrentClient {
 		decision: DecisionAnyMatch,
 		path?: string,
 	): Promise<InjectionResult> {
-		const { outputDir } = getRuntimeConfig();
+		const { outputDir, crossSeedTag } = getRuntimeConfig();
 
 		if (await this.checkForInfoHashInClient(meta.infoHash)) {
 			return InjectionResult.ALREADY_EXISTS;
@@ -345,7 +344,7 @@ export default class RTorrent implements TorrentClient {
 					"",
 					torrentFilePath,
 					`d.directory_base.set="${directoryBase}"`,
-					`d.custom1.set="${TORRENT_TAG}"`,
+					`d.custom1.set="${crossSeedTag}"`,
 					`d.custom.set=addtime,${Math.round(Date.now() / 1000)}`,
 				]);
 				break;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -1,7 +1,6 @@
 import {
 	DecisionAnyMatch,
 	InjectionResult,
-	TORRENT_TAG,
 } from "../constants.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
@@ -211,6 +210,7 @@ export default class Transmission implements TorrentClient {
 		path?: string,
 	): Promise<InjectionResult> {
 		let downloadDir: string;
+		const { crossSeedTag } = getRuntimeConfig();
 		if (path) {
 			downloadDir = path;
 		} else {
@@ -234,7 +234,7 @@ export default class Transmission implements TorrentClient {
 					"download-dir": downloadDir,
 					metainfo: newTorrent.encode().toString("base64"),
 					paused: shouldRecheck(searchee, decision),
-					labels: [TORRENT_TAG],
+					labels: [crossSeedTag],
 				},
 			);
 		} catch (e) {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -127,6 +127,10 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"--link-category <cat>",
 			"Torrent client category to set on linked torrents",
 			fallback(fileConfig.linkCategory, "cross-seed-link"),
+		).option(
+			"--cross-seed-tag <tag>",
+			"Tag to add to torrents that are cross-seeded",
+			fallback(fileConfig.crossSeedTag, "cross-seed"),
 		)
 		.option(
 			"--link-dir <dir>",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -158,6 +158,13 @@ module.exports = {
 	linkCategory: "cross-seed-link",
 
 	/**
+	 * Defines what tag to set on linked torrents
+	 *
+	 * Default is "cross-seed".
+	 */
+	crossSeedTag: "cross-seed",
+
+	/**
 	 * If this is specified, cross-seed will create links to matched files in
 	 * the specified directory.
 	 * It will create a different link for every changed file name or directory

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -3,6 +3,7 @@ import { ErrorMapCtx, RefinementCtx, z, ZodIssueOptionalMessage } from "zod";
 import { Action, LinkType, MatchMode, NEWLINE_INDENT } from "./constants.js";
 import { logger } from "./logger.js";
 import { resolve, relative, isAbsolute } from "path";
+import { crossSeedTag } from "./config.template.cjs";
 
 /**
  * error messages and map returned upon Zod validation failure
@@ -126,6 +127,7 @@ export const VALIDATION_SCHEMA = z
 		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
 		linkCategory: z.string().nullish(),
+		crossSeedTag: z.string().nullish(),
 		linkDir: z.string().nullish(),
 		linkType: z.nativeEnum(LinkType),
 		flatLinking: z

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -27,6 +27,7 @@ export interface FileConfig {
 	flatLinking?: boolean;
 	maxDataDepth?: number;
 	linkCategory?: string;
+	crossSeedTag?: string;
 	torrentDir?: string;
 	torznab?: string[];
 	qbittorrentUrl?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,6 @@ const packageDotJson = require("../package.json");
 export const PROGRAM_NAME = packageDotJson.name;
 export const PROGRAM_VERSION = packageDotJson.version;
 export const USER_AGENT = `CrossSeed/${PROGRAM_VERSION}`;
-export const TORRENT_TAG = "cross-seed";
 export const TORRENT_CATEGORY_SUFFIX = `.cross-seed`;
 export const NEWLINE_INDENT = "\n\t\t\t\t";
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -10,6 +10,7 @@ export interface RuntimeConfig {
 	flatLinking: boolean;
 	maxDataDepth: number;
 	linkCategory: string;
+	crossSeedTag: string;
 	torrentDir?: string;
 	outputDir: string;
 	injectDir?: string;


### PR DESCRIPTION
Closes https://github.com/cross-seed/cross-seed/issues/362

Adds a new `--cross-seed-tag` config for providing custom tags to cross seed torrents.

Still need to validate the changes, but don't have a setup going yet, these clients still need to be validated if someone already has a good test env:
- [ ] qbitorrent
- [ ] deluge
- [ ] transmission


This is my first PR to this project so please let me now if anything needs to be modified 