### PR TITLE
fix(dep/knex): fixed failing tests on knex import

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import { knex } from "knex";
 import { join } from "path";
 import { appDir } from "./configuration.js";
 import { migrations } from "./migrations/migrations.js";
@@ -9,7 +9,7 @@ const rawSqliteHandle = new Sqlite(filename);
 rawSqliteHandle.pragma("journal_mode = WAL");
 rawSqliteHandle.close();
 
-export const db = Knex.knex({
+export const db = knex({
 	client: "better-sqlite3",
 	connection: { filename },
 	migrations: { migrationSource: migrations },


### PR DESCRIPTION
updates knex import in db.ts

knex does not have a default export, so importing it without destructuring can cause `vitest` to fail to resolve the deps (e.g. on a branch I was working on for a future PR) 

once the dep graph for vitest includes db.ts - it will always fail until the import is fixed