### PR TITLE
 update(regex/groups): check for improperly identified groups when group is missing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,8 @@ export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
 export const CALIBRE_INDEXNUM_REGEX = /\s?\(\d+\)$/;
 export const SAVED_TORRENTS_INFO_REGEX =
 	/^\[(?<mediaType>.+?)\]\[(?<tracker>.+?)\](?<name>.+?)(?:\[[^\]]*?\])?\.torrent$/i;
+export const BAD_GROUP_PARSE_REGEX =
+	/^(?<badmatch>(?:dl|DDP?|aac|eac3|atmos|dts|ma|hd|[heav.c]{3.5}|[xh.]{1,2}[2456]|[0-9]+[ip]?|dxva|full|blu|ray|s(?:eason)?\W\d+|\W){3,})$/i;
 
 // Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-import Knex from "knex";
+import { knex } from "knex";
 import { join } from "path";
 import { appDir } from "./configuration.js";
 import { migrations } from "./migrations/migrations.js";
@@ -9,7 +9,7 @@ const rawSqliteHandle = new Sqlite(filename);
 rawSqliteHandle.pragma("journal_mode = WAL");
 rawSqliteHandle.close();
 
-export const db = Knex.knex({
+export const db = knex({
 	client: "better-sqlite3",
 	connection: { filename },
 	migrations: { migrationSource: migrations },

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -6,7 +6,6 @@ import {
 	isAnyMatchedDecision,
 	isStaticDecision,
 	MatchMode,
-	RELEASE_GROUP_REGEX,
 	REPACK_PROPER_REGEX,
 	RES_STRICT_REGEX,
 	parseSource,
@@ -23,7 +22,12 @@ import {
 	isSingleEpisode,
 } from "./preFilter.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { File, Searchee, SearcheeWithLabel } from "./searchee.js";
+import {
+	File,
+	getReleaseGroup,
+	Searchee,
+	SearcheeWithLabel,
+} from "./searchee.js";
 import { parseTorrentFromFilename, snatch, SnatchError } from "./torrent.js";
 import {
 	extractInt,
@@ -95,13 +99,9 @@ function logDecision(
 			reason = `it has a different file tree${matchMode === MatchMode.SAFE ? " (will match in risky or partial match mode)" : ""}`;
 			break;
 		case Decision.RELEASE_GROUP_MISMATCH:
-			reason = `it has a different release group: ${stripExtension(
-				searchee.title,
-			)
-				.match(RELEASE_GROUP_REGEX)
-				?.groups?.group?.trim()} -> ${stripExtension(candidate.name)
-				.match(RELEASE_GROUP_REGEX)
-				?.groups?.group?.trim()}`;
+			reason = `it has a different release group: ${getReleaseGroup(
+				stripExtension(searchee.title),
+			)} -> ${getReleaseGroup(stripExtension(candidate.name))}`;
 			break;
 		case Decision.PROPER_REPACK_MISMATCH:
 			reason = `one is a different subsequent release: ${
@@ -230,14 +230,13 @@ function resolutionDoesMatch(searcheeTitle: string, candidateName: string) {
 	return extractInt(searcheeRes) === extractInt(candidateRes);
 }
 function releaseGroupDoesMatch(searcheeTitle: string, candidateName: string) {
-	const searcheeReleaseGroup = stripExtension(searcheeTitle)
-		.match(RELEASE_GROUP_REGEX)
-		?.groups?.group?.trim()
-		?.toLowerCase();
-	const candidateReleaseGroup = stripExtension(candidateName)
-		.match(RELEASE_GROUP_REGEX)
-		?.groups?.group?.trim()
-		?.toLowerCase();
+	const searcheeReleaseGroup = getReleaseGroup(
+		stripExtension(searcheeTitle),
+	)?.toLowerCase();
+	const candidateReleaseGroup = getReleaseGroup(
+		stripExtension(candidateName),
+	)?.toLowerCase();
+
 	if (!searcheeReleaseGroup || !candidateReleaseGroup) {
 		return true; // Pass if missing -GRP
 	}

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -12,6 +12,7 @@ import {
 	SONARR_SUBFOLDERS_REGEX,
 	MOVIE_REGEX,
 	VIDEO_EXTENSIONS,
+	BAD_GROUP_PARSE_REGEX,
 } from "./constants.js";
 import { Label, logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
@@ -246,7 +247,7 @@ export function getKeyMetaInfo(stem: string): string {
 	const res = resM ? `.${resM}` : "";
 	const sourceM = parseSource(stem);
 	const source = sourceM ? `.${sourceM}` : "";
-	const groupM = stem.match(RELEASE_GROUP_REGEX)?.groups?.group;
+	const groupM = getReleaseGroup(stem);
 	if (groupM) {
 		return `${res}${source}-${groupM}`.toLowerCase();
 	}
@@ -329,4 +330,15 @@ export function getAnimeKeys(stem: string): {
 	if (keyTitles.length === 0) return null;
 	const release = extractInt(match!.groups!.release);
 	return { ensembleTitles, keyTitles, release };
+}
+
+export function getReleaseGroup(stem: string): string | null {
+	const predictedGroupMatch = stem.match(RELEASE_GROUP_REGEX);
+	if (!predictedGroupMatch) {
+		return null;
+	}
+	const parsedGroupMatchString = predictedGroupMatch!.groups!.group.trim();
+	return BAD_GROUP_PARSE_REGEX.test(parsedGroupMatchString)
+		? null
+		: parsedGroupMatchString;
 }


### PR DESCRIPTION
When a group is missing from a release name, it is possible that a hyphen in the release name is determined to be a group delimiter erroneously. This can result in wrongly assuming that, for example, after the DL until the end of the release name if WEB-DL is present and no group exists on the release name is a valid group to use for comparison.

This PR creates a function that parses out the release group normally, and then checks for whether a new regex (`BAD_GROUP_PARSE_REGEX`) matches.

`BAD_GROUP_PARSE_REGEX` contains a variety of format tagging for audio and media formats, in addition to a few delimiters and other terms I found to be regularly present to ensure that, in the test cases I had, the entire suspected "group" was captured.

If `BAD_GROUP_PARSE_REGEX` matches, then the function returns `null`.

This replaces the inlined regex'ing we previously did in decide, searches, and utils for group parsing.

### note: this PR is dependent on #792 as tests will fail otherwise.