### PR TITLE
hotfix(deps/knex): bad import for failing tests

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
-import { knex } from "knex";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import Knex, { knex } from "knex";
 import { join } from "path";
 import { appDir } from "./configuration.js";
 import { migrations } from "./migrations/migrations.js";
@@ -9,7 +10,7 @@ const rawSqliteHandle = new Sqlite(filename);
 rawSqliteHandle.pragma("journal_mode = WAL");
 rawSqliteHandle.close();
 
-export const db = knex({
+export const db = Knex.knex({
 	client: "better-sqlite3",
 	connection: { filename },
 	migrations: { migrationSource: migrations },


### PR DESCRIPTION
tests were failing, so in order to fix them changed the import method due to some complications with default exports.

this broke knex.

we have to do some weird stuff to get around this, but it should be fine.