### PR TITLE
Use JS comparison to prune indexed torrents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,12 +3482,12 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"commander": "^8.3.0",
 				"fastest-levenshtein": "^1.0.16",
 				"fuse.js": "^6.6.2",
-				"knex": "^2.4.2",
+				"knex": "^2.5.1",
 				"lodash-es": "^4.17.21",
 				"ms": "^2.1.3",
 				"strip-ansi": "^7.1.0",
@@ -43,7 +43,7 @@
 				"lint-staged": "^12.1.4",
 				"prettier": "^3.2.5",
 				"rimraf": "^3.0.2",
-				"typescript": "^5.3.3",
+				"typescript": "^5.6.2",
 				"vitest": "^2.0.5"
 			},
 			"engines": {
@@ -4736,9 +4736,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+			"integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"commander": "^8.3.0",
 				"fastest-levenshtein": "^1.0.16",
 				"fuse.js": "^6.6.2",
-				"knex": "^2.5.1",
+				"knex": "^3.1.0",
 				"lodash-es": "^4.17.21",
 				"ms": "^2.1.3",
 				"strip-ansi": "^7.1.0",
@@ -2960,9 +2960,9 @@
 			}
 		},
 		"node_modules/knex": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
-			"integrity": "sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
+			"integrity": "sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==",
 			"dependencies": {
 				"colorette": "2.0.19",
 				"commander": "^10.0.0",
@@ -2973,7 +2973,7 @@
 				"getopts": "2.3.0",
 				"interpret": "^2.2.0",
 				"lodash": "^4.17.21",
-				"pg-connection-string": "2.6.1",
+				"pg-connection-string": "2.6.2",
 				"rechoir": "^0.8.0",
 				"resolve-from": "^5.0.0",
 				"tarn": "^3.0.2",
@@ -2983,7 +2983,7 @@
 				"knex": "bin/cli.js"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=16"
 			},
 			"peerDependenciesMeta": {
 				"better-sqlite3": {
@@ -3832,9 +3832,9 @@
 			}
 		},
 		"node_modules/pg-connection-string": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
-			"integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+			"integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"commander": "^8.3.0",
 		"fastest-levenshtein": "^1.0.16",
 		"fuse.js": "^6.6.2",
-		"knex": "^2.4.2",
+		"knex": "^2.5.1",
 		"lodash-es": "^4.17.21",
 		"ms": "^2.1.3",
 		"strip-ansi": "^7.1.0",
@@ -59,7 +59,7 @@
 		"lint-staged": "^12.1.4",
 		"prettier": "^3.2.5",
 		"rimraf": "^3.0.2",
-		"typescript": "^5.3.3",
+		"typescript": "^5.6.2",
 		"vitest": "^2.0.5"
 	},
 	"prettier": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"commander": "^8.3.0",
 		"fastest-levenshtein": "^1.0.16",
 		"fuse.js": "^6.6.2",
-		"knex": "^2.5.1",
+		"knex": "^3.1.0",
 		"lodash-es": "^4.17.21",
 		"ms": "^2.1.3",
 		"strip-ansi": "^7.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"outDir": "./dist",
 		"allowJs": true,
 		"target": "es2022",
-		"lib": ["es2022"],
+		"lib": ["es2023"],
 		"module": "nodenext",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
fixes #411 by reading the entire contents of the `torrent` table into memory, then doing a set difference to determine which entries in the DB can be pruned. 


Also updated TS and knex due to some type issues I was having. 