### PR TITLE
update(logging/webhook): warn on no indexers and verbose log the request

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -125,7 +125,6 @@ module.exports = {
 	 * for you and friendlier for trackers.
 	 * Minimum value of 30.
 	 */
-
 	delay: 30,
 
 	/**
@@ -144,7 +143,6 @@ module.exports = {
 	 * or for Windows users
 	 *     dataDirs: ["C:\\My Data\\Downloads\\Movies"],
 	 */
-
 	dataDirs: [],
 
 	/**

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,7 +12,6 @@ import {
 	InjectionResult,
 	SaveResult,
 } from "./constants.js";
-import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import {
 	Candidate,
@@ -99,22 +98,6 @@ async function search(
 		res.end(e.message);
 		return;
 	}
-	const { torznab } = getRuntimeConfig();
-	if (torznab.length === 0 || (await getEnabledIndexers()).length === 0) {
-		const searchFailureReason = `No ${torznab.length === 0 ? "configured" : "available"} Torznab indexers`;
-		logger.warn({
-			label: Label.WEBHOOK,
-			message: `Received request but did not search: ${searchFailureReason}`,
-		});
-		logger.verbose({
-			label: Label.WEBHOOK,
-			message: `Received search request: ${inspect(data)}`,
-		});
-		res.writeHead(503);
-		res.end(searchFailureReason);
-		return;
-	}
-
 	const criteria: TorrentLocator = pick(data, ["infoHash", "path"]);
 
 	if (

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -430,7 +430,11 @@ export async function searchTorznab(
 ): Promise<IndexerCandidates[]> {
 	const { torznab } = getRuntimeConfig();
 	if (torznab.length === 0) {
-		throw new Error("no indexers are available");
+		logger.warn({
+			label: Label.SEARCH,
+			message: "no indexers are available, skipping search",
+		});
+		return [];
 	}
 
 	const mediaType = getMediaType(searchee);


### PR DESCRIPTION
When a search is performed via the `/api/webhook` endpoint with no configured indexers, this throws an error. Since this workflow is potentially useful for autobrr-dependent instances and the error is somewhat vague, after discussions we decided to demote this to a simple warning.

In the case of no indexers with a webhook search, it will now warn, log verbosely the request, and return a 503 (service unavailable).

This leaves the opportunity for misconfigurations (albeit rare with Zod) or potentially adding this return to "all failing indexers", etc, to be warned of the issue more concisely so it can be handled, while also not leading users to think that there is a larger problem plaguing their instance.

Thoughts on messaging and status code returned by the API are needed. 

500, 501, and 503 all seem somewhat applicable. 

Notes:

Currently should be set for all failed indexers when a webhook is performed, but handling this condition in a searchCadence job is still untouched.

Zod could be used for when searchCadence is defined without indexers configured, however this would still need to be handled potentially in pipeline for instances where _ALL_ indexers are in a failure state.


- [x] Check if any torznab indexers are configured when receiving search (`/api/webhook`) call and early return
- [x] Check for all failing indexers (handled for `/api/webhook`)
- [ ] Check during search job