### PR TITLE
Fix rTorrent injection for partial matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ torrents/
 config.js
 output/
 input/
+links/
 *.heapsnapshot
 qbit/
 docker/

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -287,6 +287,7 @@ export const VALIDATION_SCHEMA = z
 	)
 	.refine(
 		(config) =>
+			process.env.DEV ||
 			config.action === Action.INJECT ||
 			config.matchMode !== MatchMode.PARTIAL,
 		ZodErrorMessages.needsInject,


### PR DESCRIPTION
- when constructing the `libtorrent_resume` tree, skip files that don't exist
- use `priority: 1` to set priority to Normal (it's only for files that already exist so it's somewhat moot)
- resolve relative download dirs to absolute before sending them to rTorrent