### PR TITLE
run jobs with empty torznab so the user sees feedback

### DIFF
--- a/.idea/dictionaries/mmgoodnow.xml
+++ b/.idea/dictionaries/mmgoodnow.xml
@@ -30,6 +30,7 @@
       <w>tvdb</w>
       <w>tvdbid</w>
       <w>tvsearch</w>
+      <w>unraid</w>
       <w>upspeed</w>
       <w>xmlrpc</w>
     </words>

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -42,9 +42,9 @@ class Job {
 function getJobs(): Job[] {
 	const { action, rssCadence, searchCadence, torznab } = getRuntimeConfig();
 	const jobs: Job[] = [];
+	if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
+	if (searchCadence) jobs.push(new Job("search", searchCadence, main));
 	if (torznab.length > 0) {
-		if (rssCadence) jobs.push(new Job("rss", rssCadence, scanRssFeeds));
-		if (searchCadence) jobs.push(new Job("search", searchCadence, main));
 		jobs.push(new Job("updateIndexerCaps", ms("1 day"), updateCaps));
 	}
 	if (action === Action.INJECT) {


### PR DESCRIPTION
I noticed that an empty torznab array doesn't give any indication to the user that it's empty if you are using cross-seed for the first time. I removed this `torznab.length` check before installing the `search` and `rss` jobs so that the user gets feedback about `torznab` being empty. @buroa this undoes part of #627 but you can just set `searchCadence` and `rssCadence` to null to achieve the same thing.