### PR TITLE
fix(decide/cache): optimize query for using cached torrents

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -292,7 +292,7 @@ function sourceDoesMatch(searcheeTitle: string, candidateName: string) {
 export async function assessCandidate(
 	metaOrCandidate: Metafile | Candidate,
 	searchee: SearcheeWithLabel,
-	hashesToExclude: string[],
+	infoHashesToExclude: Set<string>,
 ): Promise<ResultAssessment> {
 	const { blockList, includeSingleEpisodes, matchMode } = getRuntimeConfig();
 
@@ -355,7 +355,7 @@ export async function assessCandidate(
 		return { decision: Decision.SAME_INFO_HASH, metafile };
 	}
 
-	if (hashesToExclude.includes(metafile.infoHash)) {
+	if (infoHashesToExclude.has(metafile.infoHash)) {
 		return { decision: Decision.INFO_HASH_ALREADY_EXISTS, metafile };
 	}
 
@@ -444,7 +444,7 @@ async function assessAndSaveResults(
 	metaOrCandidate: Metafile | Candidate,
 	searchee: SearcheeWithLabel,
 	guid: string,
-	infoHashesToExclude: string[],
+	infoHashesToExclude: Set<string>,
 	firstSeen: number,
 	guidInfoHashMap: Map<string, string>,
 ) {
@@ -521,7 +521,7 @@ async function guidLookup(
 export async function assessCandidateCaching(
 	candidate: Candidate,
 	searchee: SearcheeWithLabel,
-	infoHashesToExclude: string[],
+	infoHashesToExclude: Set<string>,
 	guidInfoHashMap: Map<string, string>,
 ): Promise<ResultAssessment> {
 	const { name, guid, link, tracker } = candidate;
@@ -564,7 +564,7 @@ export async function assessCandidateCaching(
 		);
 	} else if (
 		isAnyMatchedDecision(cacheEntry.decision) &&
-		infoHashesToExclude.includes(cacheEntry.infoHash)
+		infoHashesToExclude.has(cacheEntry.infoHash)
 	) {
 		// Already injected fast path, preserve match decision
 		assessment = { decision: Decision.INFO_HASH_ALREADY_EXISTS };

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -495,7 +495,7 @@ export async function getGuidInfoHashMap(): Promise<Map<string, string>> {
  * Some trackers have alt titles which get their own guid but resolve to same torrent
  * @param guid The guid of the candidate
  * @param link The link of the candidate
- * @param guidInfoHashMap The map of guids to info hashes
+ * @param guidInfoHashMap The map of guids to info hashes. Necessary for optimal fuzzy lookups.
  * @returns The info hash of the torrent if found
  */
 async function guidLookup(
@@ -517,7 +517,6 @@ async function guidLookup(
 			}
 		}
 	}
-	return;
 }
 
 export async function assessCandidateCaching(

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -71,7 +71,7 @@ function logDecision(
 		case Decision.MATCH:
 			return;
 		case Decision.FUZZY_SIZE_MISMATCH:
-			reason = `the total sizes are outside of the fuzzySizeThreshold range: ${Math.abs((candidate.size - searchee.length) / searchee.length).toFixed(3)} > ${getFuzzySizeFactor()}`;
+			reason = `the total sizes are outside of the fuzzySizeThreshold range: ${Math.abs((candidate.size! - searchee.length) / searchee.length).toFixed(3)} > ${getFuzzySizeFactor()}`;
 			break;
 		case Decision.SIZE_MISMATCH:
 			reason = `some files are missing or have different sizes${compareFileTreesPartial(metafile!, searchee) ? ` (will match in partial match mode)` : ""}`;
@@ -299,10 +299,8 @@ export async function assessCandidate(
 	// When metaOrCandidate is a Metafile, skip straight to the
 	// main matching algorithms as we don't need pre-download filtering.
 	const isCandidate = !(metaOrCandidate instanceof Metafile);
-	const name = metaOrCandidate.name;
-	const size = isCandidate ? metaOrCandidate.size : metaOrCandidate.length;
-
 	if (isCandidate) {
+		const name = metaOrCandidate.name;
 		if (!releaseGroupDoesMatch(searchee.title, name)) {
 			return { decision: Decision.RELEASE_GROUP_MISMATCH };
 		}
@@ -312,6 +310,7 @@ export async function assessCandidate(
 		if (!sourceDoesMatch(searchee.title, name)) {
 			return { decision: Decision.SOURCE_MISMATCH };
 		}
+		const size = metaOrCandidate.size;
 		if (size && !fuzzySizeDoesMatch(size, searchee)) {
 			return { decision: Decision.FUZZY_SIZE_MISMATCH };
 		}
@@ -493,23 +492,30 @@ export async function getGuidInfoHashMap(): Promise<Map<string, string>> {
 /**
  * Some trackers have alt titles which get their own guid but resolve to same torrent
  * @param guid The guid of the candidate
+ * @param link The link of the candidate
  * @param guidInfoHashMap The map of guids to info hashes
  * @returns The info hash of the torrent if found
  */
-async function fuzzyGuidLookup(
+async function guidLookup(
 	guid: string,
+	link: string,
 	guidInfoHashMap: Map<string, string>,
 ): Promise<string | undefined> {
-	if (!guid.includes(".tv/torrent/")) return;
-	const torrentIdRegex = /\.tv\/torrent\/(\d+)\/group/;
-	const torrentIdStr = guid.match(torrentIdRegex)?.[1];
-	if (!torrentIdStr) return;
-	for (const [key, value] of guidInfoHashMap) {
-		if (key.match(torrentIdRegex)?.[1] === torrentIdStr) {
-			return value;
+	const infoHash = guidInfoHashMap.get(guid) ?? guidInfoHashMap.get(link);
+	if (infoHash) return infoHash;
+
+	for (const guidOrLink of [guid, link]) {
+		if (!guidOrLink.includes(".tv/torrent/")) continue;
+		const torrentIdRegex = /\.tv\/torrent\/(\d+)\/group/;
+		const torrentIdStr = guidOrLink.match(torrentIdRegex)?.[1];
+		if (!torrentIdStr) continue;
+		for (const [key, value] of guidInfoHashMap) {
+			if (key.match(torrentIdRegex)?.[1] === torrentIdStr) {
+				return value;
+			}
 		}
 	}
-	return undefined;
+	return;
 }
 
 export async function assessCandidateCaching(
@@ -518,7 +524,7 @@ export async function assessCandidateCaching(
 	infoHashesToExclude: string[],
 	guidInfoHashMap: Map<string, string>,
 ): Promise<ResultAssessment> {
-	const { guid, name, tracker } = candidate;
+	const { name, guid, link, tracker } = candidate;
 
 	const cacheEntry = await db("decision")
 		.select({
@@ -531,9 +537,7 @@ export async function assessCandidateCaching(
 		.join("searchee", "decision.searchee_id", "searchee.id")
 		.where({ name: searchee.title, guid })
 		.first();
-	const metaInfoHash =
-		guidInfoHashMap.get(guid) ??
-		(await fuzzyGuidLookup(guid, guidInfoHashMap));
+	const metaInfoHash = await guidLookup(guid, link, guidInfoHashMap);
 	const metaOrCandidate = metaInfoHash
 		? existsInTorrentCache(metaInfoHash)
 			? (await getCachedTorrentFile(metaInfoHash)).orElse(candidate)

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -140,7 +140,7 @@ async function whichSearcheesMatchTorrent(
 	let foundBlocked = false;
 	const matches: AllMatches = [];
 	for (const searchee of searchees) {
-		const { decision } = await assessCandidate(meta, searchee, []);
+		const { decision } = await assessCandidate(meta, searchee, new Set());
 		if (decision === Decision.BLOCKED_RELEASE) {
 			if (isSimilar(searchee, meta)) foundBlocked = true;
 			continue;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -66,12 +66,12 @@ import {
 } from "./utils.js";
 
 export interface Candidate {
+	name: string;
 	guid: string;
 	link: string;
-	size: number;
-	name: string;
 	tracker: string;
-	pubDate: number;
+	size?: number;
+	pubDate?: number;
 	indexerId?: number;
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -16,7 +16,11 @@ import {
 	findSearcheesFromAllDataDirs,
 } from "./dataFiles.js";
 import { db } from "./db.js";
-import { assessCandidateCaching, ResultAssessment } from "./decide.js";
+import {
+	assessCandidateCaching,
+	getGuidInfoHashMap,
+	ResultAssessment,
+} from "./decide.js";
 import {
 	IndexerStatus,
 	updateIndexerStatus,
@@ -87,11 +91,13 @@ async function assessCandidates(
 	hashesToExclude: string[],
 ): Promise<AssessmentWithTracker[]> {
 	const assessments: AssessmentWithTracker[] = [];
+	const guidInfoHashMap = await getGuidInfoHashMap();
 	for (const result of candidates) {
 		const assessment = await assessCandidateCaching(
 			result,
 			searchee,
 			hashesToExclude,
+			guidInfoHashMap,
 		);
 		assessments.push({ assessment, tracker: result.tracker });
 	}
@@ -362,6 +368,7 @@ export async function checkNewCandidateMatch(
 			(searchee) => -searchee.files.length,
 		),
 	);
+	const guidInfoHashMap = await getGuidInfoHashMap();
 	for (const searchee of searchees) {
 		await db("searchee")
 			.insert({ name: searchee.title })
@@ -372,6 +379,7 @@ export async function checkNewCandidateMatch(
 			candidate,
 			searchee,
 			hashesToExclude,
+			guidInfoHashMap,
 		);
 
 		if (

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -241,9 +241,11 @@ export async function indexNewTorrents(): Promise<void> {
 	}
 }
 
-export async function getInfoHashesToExclude(): Promise<string[]> {
-	return (await db("torrent").select({ infoHash: "info_hash" })).map(
-		(t) => t.infoHash,
+export async function getInfoHashesToExclude(): Promise<Set<string>> {
+	return new Set(
+		(await db("torrent").select({ infoHash: "info_hash" })).map(
+			(t) => t.infoHash,
+		),
 	);
 }
 

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -374,11 +374,11 @@ export async function* rssPager(
 					apikey: indexer.apikey,
 					query: { t: "search", q: "", limit, offset: i * limit },
 				})
-			).sort(comparing((candidate) => -candidate.pubDate));
+			).sort(comparing((candidate) => -candidate.pubDate!));
 			if (i === 0) {
 				newLastSeenGuid = currentPageCandidates[0].guid;
 				pageBackUntil =
-					currentPageCandidates[0].pubDate - timeSinceLastRun;
+					currentPageCandidates[0].pubDate! - timeSinceLastRun;
 			}
 		} catch (e) {
 			logger.error({
@@ -400,7 +400,7 @@ export async function* rssPager(
 		}
 		if (!found) {
 			newCandidates = newCandidates.filter(
-				(candidate) => candidate.pubDate >= pageBackUntil,
+				(candidate) => candidate.pubDate! >= pageBackUntil,
 			);
 		}
 


### PR DESCRIPTION
The previous method for getting the infohash was extremely slow. It took `500ms` to retrieve per candidate for which there could be 2000. Meaning daemon mode is overloaded for 16 minutes.

Now the decision table is only queried once and stored in a hashmap for instant lookups. These same 2000 candidates are now processed in 15s instead of the 16 minutes currently. The `fuzzyGuidLookup` would take 1s if it was relevant so that is also using the hashmap for instant lookups as well.

After making an assessment, we will add the `guid: infoHash` to the map. This is to prevent duplicate snatches for the next candidate check if `fuzzyGuidLookup` is needed, and for the next searchee to use in the case of rss/announce.

Now checking the link instead of just the guid. Announce only uses the link (no access to guid), so so we may end up snatching the same torrent twice as on some trackers they are different.

Only caching decisions with snatches. The others were used only to "speed up" processing, but essentially just bloats the database.