### PR TITLE
enhancement(rss): mitigate RSS publishing lag with offset

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -489,11 +489,9 @@ export async function scanRssFeeds() {
 		});
 		return;
 	}
-	const lastRun_db =
+	const lastRun =
 		(await db("job_log").select("last_run").where({ name: "rss" }).first())
 			?.last_run ?? 0;
-	// mitigate RSS publishing lag with a 5 minutes delay
-	const lastRun = lastRun_db - 300000;
 	logger.verbose({
 		label: Label.RSS,
 		message: "Indexing new torrents...",

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -489,9 +489,11 @@ export async function scanRssFeeds() {
 		});
 		return;
 	}
-	const lastRun =
+	const lastRun_db =
 		(await db("job_log").select("last_run").where({ name: "rss" }).first())
 			?.last_run ?? 0;
+	// mitigate RSS publishing lag with a 5 minutes delay
+	const lastRun = lastRun_db - 300000;
 	logger.verbose({
 		label: Label.RSS,
 		message: "Indexing new torrents...",

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -415,11 +415,13 @@ export async function* rssPager(
 }
 
 export async function* queryRssFeeds(
-	pageBackUntil: number,
+	previousRunTime: number,
 ): AsyncGenerator<Candidate> {
 	const indexers = await getEnabledIndexers();
+	// offset -5m for delayed RSS -> publishing time
+	const timeWithOffset = previousRunTime - 300000;
 	yield* combineAsyncIterables(
-		indexers.map((indexer) => rssPager(indexer, pageBackUntil)),
+		indexers.map((indexer) => rssPager(indexer, timeWithOffset)),
 	);
 }
 


### PR DESCRIPTION
Indexers sometimes have a delay before publishing new torrents to their RSS feed.

Cross-seed only looks for new torrents published after the previous RSS run, and with the delay some releases might end up published in the past to the previous run and missed by Cross-seed.

This PR allows cross-seed to look for releases up to 5 minuntes prior to the previous RSS run, thus mitigating the delay of publishing.

Cross-seed might end up seing some releases twice, but as the processing is very fast this should not add much overhead.

I've been runing this for 8 hours without issus at the opening of this PR.
<hr>

note: conversation on discord can be found [here](https://discord.com/channels/880949701845872672/1301568641329926204) //zak