### PR TITLE
fix(rss): always check candidates from first page

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -510,6 +510,6 @@ export async function scanRssFeeds() {
 
 	logger.info({
 		label: Label.RSS,
-		message: `RSS scan complete - checked ${i} new candidates since ${humanReadableDate(lastRun)}`,
+		message: `RSS scan complete: checked ${i} candidates - previous run was at ${humanReadableDate(lastRun)}`,
 	});
 }


### PR DESCRIPTION
Indexer timestamps cannot be trusted. They could always report less than `pageBackUntil` which means no candidates gets checked. So now we always check candidates from the first page.

Also will now end paging early if a pubDate on the current page is already below pageBackUntil. This should prevent unnecessary queries when only a single page is needed.