### PR TITLE
Always restrict fuzzySizeThreshold

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -19,7 +19,8 @@ const ZodErrorMessages = {
 		"excludeRecentSearch must be at least 3x searchCadence.",
 	excludeRecentOlder:
 		"excludeOlder and excludeRecentSearch must be defined for searching. excludeOlder must be 2-5x excludeRecentSearch.",
-	fuzzySizeThreshold: "fuzzySizeThreshold cannot be greater than 0.1",
+	fuzzySizeThreshold:
+		"fuzzySizeThreshold cannot be greater than 0.1 outside of `cross-seed inject`",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -139,7 +140,7 @@ export const VALIDATION_SCHEMA = z
 		injectDir: z.string().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
-		fuzzySizeThreshold: z.number().positive().lte(0.1, {
+		fuzzySizeThreshold: z.number().positive().lte(1, {
 			message: ZodErrorMessages.fuzzySizeThreshold,
 		}),
 		excludeOlder: z
@@ -249,6 +250,10 @@ export const VALIDATION_SCHEMA = z
 				config.excludeOlder >= 2 * config.excludeRecentSearch &&
 				config.excludeOlder <= 5 * config.excludeRecentSearch),
 		ZodErrorMessages.excludeRecentOlder,
+	)
+	.refine(
+		(config) => config.fuzzySizeThreshold <= 0.1 || config.injectDir,
+		ZodErrorMessages.fuzzySizeThreshold,
 	)
 	.refine((config) => {
 		if (

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -19,8 +19,7 @@ const ZodErrorMessages = {
 		"excludeRecentSearch must be at least 3x searchCadence.",
 	excludeRecentOlder:
 		"excludeOlder and excludeRecentSearch must be defined for searching. excludeOlder must be 2-5x excludeRecentSearch.",
-	fuzzySizeThreshold:
-		"fuzzySizeThreshold must be between 0 and 1 with a maximum of 0.1 when using searchCadence or rssCadence",
+	fuzzySizeThreshold: "fuzzySizeThreshold cannot be greater than 0.1",
 	injectUrl:
 		"You need to specify rtorrentRpcUrl, transmissionRpcUrl, qbittorrentUrl, or delugeRpcUrl when using 'inject'",
 	qBitAutoTMM:
@@ -140,7 +139,7 @@ export const VALIDATION_SCHEMA = z
 		injectDir: z.string().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
-		fuzzySizeThreshold: z.number().positive().lte(1, {
+		fuzzySizeThreshold: z.number().positive().lte(0.1, {
 			message: ZodErrorMessages.fuzzySizeThreshold,
 		}),
 		excludeOlder: z
@@ -250,12 +249,6 @@ export const VALIDATION_SCHEMA = z
 				config.excludeOlder >= 2 * config.excludeRecentSearch &&
 				config.excludeOlder <= 5 * config.excludeRecentSearch),
 		ZodErrorMessages.excludeRecentOlder,
-	)
-	.refine(
-		(config) =>
-			config.fuzzySizeThreshold <= 0.1 ||
-			(!config.searchCadence && !config.rssCadence),
-		ZodErrorMessages.fuzzySizeThreshold,
 	)
 	.refine((config) => {
 		if (


### PR DESCRIPTION
Not sure why we would want to have different rules for search vs daemon here. @ShanaryS was there a reason behind this? Otherwise I'll just make them consistent with this PR.