### PR TITLE
add(api/status): introduce status endpoint for health checks

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -276,25 +276,33 @@ async function announce(
 		res.end(e.message);
 	}
 }
-
+async function statusCheck(
+	req: IncomingMessage,
+	res: ServerResponse,
+): Promise<void> {
+	res.writeHead(200);
+	res.end("OK");
+}
 async function handleRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 ): Promise<void> {
 	if (!(await authorize(req, res))) return;
+	const endpoint = req.url!.split("?")[0];
 
-	if (req.method !== "POST") {
+	if (req.method !== "POST" && endpoint !== "/api/status") {
 		res.writeHead(405);
 		res.end("Methods allowed: POST");
 		return;
 	}
 
-	const endpoint = req.url!.split("?")[0];
 	switch (endpoint) {
 		case "/api/webhook":
 			return search(req, res);
 		case "/api/announce":
 			return announce(req, res);
+		case "/api/status":
+			return statusCheck(req, res);
 		default: {
 			const message = `Unknown endpoint: ${endpoint}`;
 			logger.error({ label: Label.SERVER, message });

--- a/src/server.ts
+++ b/src/server.ts
@@ -290,7 +290,10 @@ async function handleRequest(
 	if (!(await authorize(req, res))) return;
 	const endpoint = req.url!.split("?")[0];
 
-	if (req.method !== "POST" && endpoint !== "/api/status") {
+	if (
+		(req.method === "POST" && endpoint === "/api/status") ||
+		(req.method === "GET" && endpoint !== "/api/status")
+	) {
 		res.writeHead(405);
 		res.end("Methods allowed: POST");
 		return;


### PR DESCRIPTION
There is no endpoint for checking health via the API.

This PR introduces a `/api/status` endpoint that returns "200 OK" and does not log to the terminal.

Health checks that are performed frequently would not need to be logged, as they are always going to succeed assuming cross-seed is running anyway, and would just be "spam".

Currently requires API auth same as any other API call.

Applications that could utilize this are things like uptimekuma and notifarr.

This could also be expanded in the future to return any current jobs down the road if that was something we desired to do (such as "performing search" type of status). Currently it just acts as a ping endpoint to check if cross-seed is operational.