### PR TITLE
Increase default searchLimit to 400

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -375,7 +375,7 @@ module.exports = {
 	 *
 	 * Set to null for no limit.
 	 */
-	searchLimit: 100,
+	searchLimit: 400,
 
 	/**
 	 * The list of infohashes or strings which are contained in torrents that
@@ -391,5 +391,5 @@ module.exports = {
 	 *    blocklist: ["Release.Name"],
 	 *    blocklist: ["3317e6485454354751555555366a8308c1e92093"],
 	 */
-	blockList: undefined,
+	blockList: [],
 };


### PR DESCRIPTION
This will satisfy people's instant gratification mindsets a little better and it seems like trackers are okay with pretty much anything as long as the `delay` is reasonable. This is worse for the feast vs famine use of API issue as described in https://github.com/cross-seed/cross-seed/issues/432, but users looking to resolve that can just set it lower. 