### PR TITLE
enhancement(torrentDir): verify contents against client

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -31,8 +31,6 @@ const ZodErrorMessages = {
 		"includeSingleEpisodes is not recommended when using announce, please read: https://www.cross-seed.org/docs/v6-migration#updated-includesingleepisodes-behavior",
 	invalidOutputDir:
 		"outputDir should only contain .torrent files, cross-seed will populate and manage (https://www.cross-seed.org/docs/basics/options#outputdir)",
-	invalidTorrentDir:
-		"torrentDir must contain at least one .torrent file (https://www.cross-seed.org/docs/basics/options#torrentdir). If no torrents are in client, set to null for now.",
 	needsTorrentDir:
 		"You need to set torrentDir for rss and announce matching to work.",
 	needsInject: "You need to use the 'inject' action for partial matching.",
@@ -145,13 +143,7 @@ export const VALIDATION_SCHEMA = z
 			.nullish()
 			.transform((value) => (typeof value === "boolean" ? value : false)),
 		maxDataDepth: z.number().gte(1),
-		torrentDir: z
-			.string()
-			.nullable()
-			.refine(
-				(d) => !d || readdirSync(d).some((f) => f.endsWith(".torrent")),
-				ZodErrorMessages.invalidTorrentDir,
-			),
+		torrentDir: z.string().nullable(),
 		outputDir: z.string().refine((dir) => {
 			if (readdirSync(dir).some((f) => !f.endsWith(".torrent"))) {
 				logger.warn(ZodErrorMessages.invalidOutputDir);

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,5 +1,5 @@
 import { deepStrictEqual } from "assert";
-import { createSearcheeFromMetafile } from "./searchee.js";
+import { createSearcheeFromMetafile, Searchee } from "./searchee.js";
 import { parseTorrentFromFilename } from "./torrent.js";
 
 function diff(thing1, thing2) {
@@ -25,8 +25,8 @@ export async function diffCmd(first: string, second: string): Promise<void> {
 		console.log(secondSearcheeRes.unwrapErr());
 		return;
 	}
-	const firstSearchee = firstSearcheeRes.unwrap();
-	const secondSearchee = secondSearcheeRes.unwrap();
+	const firstSearchee: Searchee = firstSearcheeRes.unwrap();
+	const secondSearchee: Searchee = secondSearcheeRes.unwrap();
 	delete firstSearchee.infoHash;
 	delete secondSearchee.infoHash;
 	diff(firstSearchee, secondSearchee);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -464,7 +464,6 @@ async function findSearchableTorrents(): Promise<{
 		}
 		grouping.get(key)!.push(searchee);
 	}
-	const keysToDelete: string[] = [];
 	for (const [key, groupedSearchees] of grouping) {
 		// If one searchee needs to be searched, use the candidates for all
 		const filteredSearchees = filterDupesFromSimilar(groupedSearchees);
@@ -472,7 +471,7 @@ async function findSearchableTorrents(): Promise<{
 			filteredSearchees.map(filterTimestamps),
 		);
 		if (!results.some(isTruthy)) {
-			keysToDelete.push(key);
+			grouping.delete(key);
 			continue;
 		}
 		filteredSearchees.sort(
@@ -482,9 +481,6 @@ async function findSearchableTorrents(): Promise<{
 			),
 		);
 		grouping.set(key, filteredSearchees);
-	}
-	for (const key of keysToDelete) {
-		grouping.delete(key);
 	}
 	const finalSearchees = Array.from(grouping.values()).flat();
 

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -197,7 +197,7 @@ export function parseTitle(
 
 export function createSearcheeFromMetafile(
 	meta: Metafile,
-): Result<Searchee, Error> {
+): Result<SearcheeWithInfoHash, Error> {
 	const title = parseTitle(meta.name, meta.files);
 	if (title) {
 		return resultOf({
@@ -218,7 +218,7 @@ export function createSearcheeFromMetafile(
 
 export async function createSearcheeFromTorrentFile(
 	filepath: string,
-): Promise<Result<Searchee, Error>> {
+): Promise<Result<SearcheeWithInfoHash, Error>> {
 	try {
 		const meta = await parseTorrentFromFilename(filepath);
 		return createSearcheeFromMetafile(meta);

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -105,7 +105,7 @@ async function checkConfigPaths(): Promise<void> {
 			} catch (e) {
 				logger.error(e);
 				logger.error("Failed to link from dataDirs to linkDir.");
-				// pathFailure++; We need to check that this torrent wasn't blocklisted so only log for now
+				pathFailure++;
 			}
 		}
 	}

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -22,7 +22,7 @@ import {
 	getEpisodeKey,
 	getMovieKey,
 	getSeasonKey,
-	Searchee,
+	SearcheeWithInfoHash,
 } from "./searchee.js";
 import { createKeyTitle, stripExtension } from "./utils.js";
 
@@ -251,10 +251,10 @@ export async function getInfoHashesToExclude(): Promise<Set<string>> {
 
 export async function loadTorrentDirLight(
 	torrentDir: string,
-): Promise<Searchee[]> {
+): Promise<SearcheeWithInfoHash[]> {
 	const torrentFilePaths = await findAllTorrentFilesInDir(torrentDir);
 
-	const searchees: Searchee[] = [];
+	const searchees: SearcheeWithInfoHash[] = [];
 	for (const torrentFilePath of torrentFilePaths) {
 		const searcheeResult =
 			await createSearcheeFromTorrentFile(torrentFilePath);


### PR DESCRIPTION
This is better than simply checking for the presence of a single .torrent file. Users have frequently set `torrentDir` to the directory their client copies .torrent files to, instead of the one that mirrors the client state.

I also added the check for searchee blocklist before testing the save path. It's still only being logged until the new blocklist features are included.