### PR TITLE
fix(zod/linkdir): do not require linkdir for risky or partial when action is save

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -315,7 +315,10 @@ export const VALIDATION_SCHEMA = z
 		ZodErrorMessages.needsTorrentDir,
 	)
 	.refine(
-		(config) => config.linkDir || config.matchMode === MatchMode.SAFE,
+		(config) =>
+			config.linkDir ||
+			config.matchMode === MatchMode.SAFE ||
+			config.action !== Action.INJECT,
 		ZodErrorMessages.needsLinkDir,
 	)
 	.refine((config) => {


### PR DESCRIPTION
using save should allow for `linkDir` to not be set, as it doesn't link.

this also prevents users who use things like autotorrent, or manually add the torrents and links (if needed) from using risky or partial.

there is no reason to require a setting that is not used for `matchMode`.