### PR TITLE
update(config-template): Fix comment for disabling seasonFromEpisodes

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -291,7 +291,7 @@ module.exports = {
 	/**
 	 * Match season packs from the individual episodes you already have.
 	 *
-	 * undefined or null - disabled
+	 * null - disabled
 	 * 1 - must have all episodes
 	 * 0.8 - must have at least 80% of the episodes
 	 */


### PR DESCRIPTION
Fix comment to clarify that only `null` disables `seasonFromEpisodes`. Since it is set using [`fallback`](https://github.com/cross-seed/cross-seed/blob/19054f3b9424e6850c4ddc06c4fbeab091b3f488/src/cmd.ts#L195), `undefined` actually sets it to `1`.