### PR TITLE
update(blocklist/deluge): change labels to be category rather than tag

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -603,8 +603,8 @@ export default class Deluge implements TorrentClient {
 		}
 		return Object.entries(torrents).map(([hash, torrent]) => ({
 			infoHash: hash,
-			category: "",
-			tags: torrent.label ? [torrent.label] : [],
+			category: torrent.label ?? "",
+			tags: [],
 		}));
 	}
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -487,7 +487,7 @@ export default class QBittorrent implements TorrentClient {
 		return torrents.map((torrent) => ({
 			infoHash: torrent.hash,
 			category: torrent.category,
-			tags: torrent.tags.split(","),
+			tags: torrent.tags.length ? torrent.tags.split(",") : [],
 			trackers: torrent.tracker.length ? [[torrent.tracker]] : undefined,
 		}));
 	}

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -457,10 +457,8 @@ export default class RTorrent implements TorrentClient {
 			// response: [ [tag1], [tag2], ... ], assuming infoHash order is preserved
 			return infoHashes.map((hash, index) => ({
 				infoHash: hash.toLowerCase(),
-				category: "",
-				tags: response[index][0].length
-					? (response[index] as string[])
-					: [],
+				category: response[index][0],
+				tags: [],
 			}));
 		} catch (e) {
 			logger.error({

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -457,9 +457,16 @@ export default class RTorrent implements TorrentClient {
 			// response: [ [tag1], [tag2], ... ], assuming infoHash order is preserved
 			return infoHashes.map((hash, index) => ({
 				infoHash: hash.toLowerCase(),
-				category: response[index][0],
-				tags: [],
-			}));
+				category: "",
+				tags:
+					(response[index] as string[]).length !== 1
+						? response[index]
+						: response[index][0].length
+							? decodeURIComponent(response[index][0])
+									.split(",")
+									.map((tag) => tag.trim())
+							: [],
+			})) as TorrentMetadataInClient[];
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -405,43 +405,8 @@ module.exports = {
 	searchLimit: 400,
 
 	/**
-	 * The list of infohashes, categories, tags, labels, tracker urls, sizes, folders, and substrings
-	 * of names you want to be excluded from cross-seed.
-	 *
-	 * IMPORTANT: The tracker urls are NOT the same as the website,
-	 * you need to look at the url in client which may be different.
-	 * If the announce url is https://user:pass@tracker.example.com:8080/announce/key,
-	 * you must use "tracker:tracker.example.com:8080".
-	 *
-	 * This is the same format as torznab, surround the entire set of
-	 * quoted strings in square brackets. You can use any combination
-	 * which must be entered on the one line. Leave as undefined to disable.
-	 *
-	 * Each string must be prefixed with the type of block you want to use,
-	 * followed by a colon. Labels are considered as category: for deluge and rTorrent,
-	 * and as tag: for transmission.
-	 * "name:", "folder:", "category:", "tag:", "tracker:", "infoHash:", "sizeBelow:", "sizeAbove:"
-	 * Note that sizes are an integer for the number of bytes.
-	 * There are additional prefixes that take in a regex for more complex matching.
-	 * Read more: https://www.cross-seed.org/docs/basics/options#blocklist
-	 *
-	 * examples:
-	 *
-	blockList: [
-		"name:Release.Name",
-		"name:-excludedGroup",
-		"name:x265",
-		"nameRegex:[Rr]elease[.\s][Nn]ame",
-		"folder:folderName",
-		"folderRegex:folder\d+",
-		"category:icycool",
-		"tag:everybody",
-		"tracker:tracker.example.com:8080",
-		"infoHash:3317e6485454354751555555366a8308c1e92093",
-		"sizeBelow:12345",
-		"sizeAbove:98765",
-	],
-	 * 
+	 * Ignore torrents or data containing these properties:
+	 * https://www.cross-seed.org/docs/basics/options#blocklist
 	 */
 	blockList: [],
 };

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -418,7 +418,8 @@ module.exports = {
 	 * which must be entered on the one line. Leave as undefined to disable.
 	 *
 	 * Each string must be prefixed with the type of block you want to use,
-	 * followed by a colon. Labels are considered tags.
+	 * followed by a colon. Labels are considered as category: for deluge and rTorrent,
+	 * and as tag: for transmission.
 	 * "name:", "folder:", "category:", "tag:", "tracker:", "infoHash:", "sizeBelow:", "sizeAbove:"
 	 * Note that sizes are an integer for the number of bytes.
 	 * There are additional prefixes that take in a regex for more complex matching.

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -154,6 +154,8 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 		}
 		const { blocklistType, blocklistValue } = parseBlocklistEntry(blockRaw);
 		switch (blocklistType) {
+			case BlocklistType.NAME:
+				break;
 			case BlocklistType.FOLDER:
 				if (/[/\\]/.test(blocklistValue)) {
 					addZodIssue(
@@ -169,6 +171,20 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 					new RegExp(blocklistValue);
 				} catch (e) {
 					addZodIssue(blockRaw, ZodErrorMessages.blocklistRegex, ctx);
+				}
+				break;
+			case BlocklistType.CATEGORY:
+				if (blocklistValue.length === 0) {
+					logger.info(
+						`Blocklisting all torrents without a category due to empty ${blockRaw}`,
+					);
+				}
+				break;
+			case BlocklistType.TAG:
+				if (blocklistValue.length === 0) {
+					logger.info(
+						`Blocklisting all torrents without a tag due to empty ${blockRaw}`,
+					);
 				}
 				break;
 			case BlocklistType.TRACKER:
@@ -201,10 +217,6 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 				);
 				break;
 			}
-			case BlocklistType.NAME:
-			case BlocklistType.CATEGORY:
-			case BlocklistType.TAG:
-				break;
 			default:
 				addZodIssue(blockRaw, ZodErrorMessages.blocklistType, ctx);
 		}

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -27,7 +27,7 @@ const ZodErrorMessages = {
 	emptyString:
 		"cannot have an empty string. If you want to unset it, use null or undefined.",
 	delayNegative: "delay is in seconds, you can't travel back in time.",
-	delayUnsupported: `delay must be 30 seconds to 1 hour.${NEWLINE_INDENT}To even out search loads please see the following documentation:${NEWLINE_INDENT}(https://www.cross-seed.org/docs/basics/daemon#set-up-periodic-searches)`,
+	delayUnsupported: `delay must be 30 seconds to 1 hour.${NEWLINE_INDENT}To even out search loads please see the following documentation:${NEWLINE_INDENT}(https://www.cross-seed.org/docs/basics/options#delay)`,
 	rssCadenceUnsupported: "rssCadence must be 10-120 minutes",
 	searchCadenceUnsupported: "searchCadence must be at least 1 day.",
 	searchCadenceExcludeRecent:

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -447,11 +447,11 @@ export const VALIDATION_SCHEMA = z
 	)
 	.refine((config) => {
 		if (
-			(config.delugeRpcUrl || config.rtorrentRpcUrl) &&
+			config.delugeRpcUrl &&
 			config.blockList.some((b) => b.startsWith(`${BlocklistType.TAG}:`))
 		) {
 			logger.error(
-				`${BlocklistType.TAG}: blocklisting is deprecated for this client, please use ${BlocklistType.CATEGORY}: instead (all ${BlocklistType.TAG}: blocklist items has being automatically converted to ${BlocklistType.CATEGORY}:).`,
+				`${BlocklistType.TAG}: blocklisting is deprecated for Deluge, please use ${BlocklistType.CATEGORY}: instead (all ${BlocklistType.TAG}: blocklist items has being automatically converted to ${BlocklistType.CATEGORY}:).`,
 			);
 			config.blockList = config.blockList.map((b) => {
 				if (b.startsWith(`${BlocklistType.TAG}:`)) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -223,7 +223,7 @@ export enum BlocklistType {
 	SIZE_ABOVE = "sizeAbove",
 	LEGACY = "legacy",
 }
-const PARSE_BLOCKLIST_REGEX = /^(?<blocklistType>.+?):(?<blocklistValue>.+)$/;
+const PARSE_BLOCKLIST_REGEX = /^(?<blocklistType>.+?):(?<blocklistValue>.*)$/;
 export function parseBlocklistEntry(blocklistEntry: string): {
 	blocklistType: BlocklistType;
 	blocklistValue: string;

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -97,7 +97,7 @@ export class Metafile {
 	files: File[];
 	isSingleFileTorrent: boolean;
 	category?: string;
-	tags: string[];
+	tags?: string[];
 	trackers: string[][];
 	raw: Torrent;
 
@@ -157,7 +157,6 @@ export class Metafile {
 			this.isSingleFileTorrent = false;
 		}
 		this.title = parseTitle(this.name, this.files) ?? this.name;
-		this.tags = [];
 		this.trackers =
 			raw["announce-list"]?.map((tier) => sanitizeTrackerUrls(tier)) ??
 			(raw.announce ? [sanitizeTrackerUrls([raw.announce])] : []);

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -166,7 +166,10 @@ export function findBlockedStringInReleaseMaybe(
 			case BlocklistType.CATEGORY:
 				return blocklistValue === searchee.category;
 			case BlocklistType.TAG:
-				return searchee.tags?.includes(blocklistValue);
+				if (!searchee.tags) return false; // Data based or snatched metafile
+				return blocklistValue.length
+					? searchee.tags.includes(blocklistValue)
+					: !searchee.tags.length;
 			case BlocklistType.TRACKER:
 				return searchee.trackers?.some((tier) =>
 					tier.some((url) => url === blocklistValue),

--- a/src/server.ts
+++ b/src/server.ts
@@ -132,7 +132,7 @@ async function search(
 	try {
 		criteria = WEBHOOK_SCHEMA.parse(criteria) as TorrentLocator;
 	} catch {
-		const message = `A valid infoHash or an accessible path must be provided (infoHash is recommended: see https://www.cross-seed.org/docs/basics/daemon#set-up-automatic-searches-for-finished-downloads): ${inspect(criteria)}`;
+		const message = `A valid infoHash or an accessible path must be provided (infoHash is recommended: see https://www.cross-seed.org/docs/reference/api): ${inspect(criteria)}`;
 		logger.error({ label: Label.WEBHOOK, message });
 		res.writeHead(400);
 		res.end(message);


### PR DESCRIPTION
Labels were previously associated with the `tag:` prefix in blocklist, the rationale was that there might be a time when labels are able to be applied in more than one and the type was a string.

This will not be the case, Deluge uses labels in the same way that qBit does, for save path, bandwidth and queue, etc. Multiple labels will not ever be a concern.

This changes labels to category. Tags are assigned empty array, since no tags exist in Deluge.


- [x] determine if No Label (and Uncategorized in qBit) need a constant to distinguish them, both return `""` for this assignment (or rather lack of)