### PR TITLE
fix(config/seasonFromEpisodes): better validation

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -344,10 +344,7 @@ export async function performAction(
 ): Promise<{ actionResult: ActionResult; linkedNewFiles: boolean }> {
 	const { action, linkDir } = getRuntimeConfig();
 
-	if (
-		action === Action.SAVE ||
-		(!linkDir && !searchee.infoHash && !searchee.path)
-	) {
+	if (action === Action.SAVE) {
 		await saveTorrentFile(tracker, getMediaType(searchee), newMeta);
 		logActionResult(SaveResult.SAVED, newMeta, searchee, tracker, decision);
 		return { actionResult: SaveResult.SAVED, linkedNewFiles: false };

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -192,7 +192,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"--season-from-episodes <decimal>",
 			"Match season packs from episode torrents",
 			parseFloat,
-			fallback(fileConfig.seasonFromEpisodes, 1),
+			fallback(fileConfig.seasonFromEpisodes, null),
 		)
 		.option(
 			"--no-season-from-episodes",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -208,6 +208,7 @@ module.exports = {
 	 * We recommend reading the following FAQ entry:
 	 * https://www.cross-seed.org/docs/basics/options#matchmode
 	 * https://www.cross-seed.org/docs/tutorials/linking#hardlinks-vs-symlinks
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
 	matchMode: "safe",
 
@@ -215,13 +216,14 @@ module.exports = {
 	 * Skip rechecking on injection if unnecessary. Certain matches will
 	 * always be rechecked such as: partial, data based, and disc files.
 	 * Set to false to recheck all torrents before resuming, usually unnecessary.
-	 * Torrents will be resumed regardless of this setting.
+	 * Torrents will be resumed regardless of this setting per autoResumeMaxDownload.
 	 */
 	skipRecheck: true,
 
 	/**
 	 * The maximum size in bytes remaining for a torrent to be resumed.
 	 * Must be in the range of 0 to 52428800 (50 MiB).
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
 	autoResumeMaxDownload: 52428800,
 
@@ -290,6 +292,7 @@ module.exports = {
 
 	/**
 	 * Match season packs from the individual episodes you already have.
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 *
 	 * null - disabled
 	 * 1 - must have all episodes

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -522,7 +522,7 @@ export async function findAllSearchees(
 			...searcheeResults.filter(isOk).map((r) => r.unwrap()),
 		);
 	} else {
-		if (typeof torrentDir === "string") {
+		if (torrentDir) {
 			rawSearchees.push(...(await loadTorrentDirLight(torrentDir)));
 		}
 		if (Array.isArray(dataDirs)) {

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -635,10 +635,11 @@ export async function createEnsembleSearchees(
 		allSearchees,
 		options,
 	);
-	const torrentSavePaths = await getClient()!.getAllDownloadDirs({
-		metas: allSearchees.filter(hasInfoHash) as SearcheeWithInfoHash[],
-		onlyCompleted: false,
-	});
+	const torrentSavePaths =
+		(await getClient()?.getAllDownloadDirs({
+			metas: allSearchees.filter(hasInfoHash) as SearcheeWithInfoHash[],
+			onlyCompleted: false,
+		})) ?? new Map();
 
 	const seasonSearchees: SearcheeWithLabel[] = [];
 	for (const [key, episodeSearchees] of keyMap) {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -66,7 +66,7 @@ async function checkConfigPaths(): Promise<void> {
 	let pathFailure: number = 0;
 
 	if (
-		typeof torrentDir === "string" &&
+		torrentDir &&
 		!(await verifyPath(torrentDir, "torrentDir", READ_ONLY))
 	) {
 		pathFailure++;

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -289,7 +289,7 @@ export async function cacheEnsembleEntry(
 
 export async function indexNewTorrents(): Promise<void> {
 	const { seasonFromEpisodes, torrentDir } = getRuntimeConfig();
-	if (typeof torrentDir !== "string") return;
+	if (!torrentDir) return;
 
 	const dirContents = new Set(await findAllTorrentFilesInDir(torrentDir));
 
@@ -342,7 +342,7 @@ export async function indexNewTorrents(): Promise<void> {
 export async function indexEnsemble(): Promise<void> {
 	const { seasonFromEpisodes, torrentDir } = getRuntimeConfig();
 	if (!seasonFromEpisodes) return;
-	if (typeof torrentDir !== "string") return;
+	if (!torrentDir) return;
 	logger.info("Indexing torrents for ensemble lookup...");
 
 	const tableExists = await memDB.schema.hasTable("ensemble");


### PR DESCRIPTION
In case of `seasonFromEpisodes: undefined` (or missing from config), it will now default to `null`, preventing validation errors. Even though a default of `1` is fine for most users, the error has confused others.

Will now warn if using `action: save` due to the complexity of these matches.

Ensemble requires clients to be connectable if torrentDir is enabled, this will now be checked during validation.