### PR TITLE
enhancement(inject): skip recheck for complete data/ensemble

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -402,7 +402,7 @@ export async function performAction(
 	logActionResult(result, newMeta, searchee, tracker, decision);
 	if (result === InjectionResult.SUCCESS) {
 		// cross-seed may need to process these with the inject job
-		if (shouldRecheck(searchee, decision)) {
+		if (shouldRecheck(searchee, decision) || !searchee.infoHash) {
 			await saveTorrentFile(tracker, getMediaType(searchee), newMeta);
 		}
 	} else if (result !== InjectionResult.ALREADY_EXISTS) {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -134,7 +134,7 @@ export async function validateSavePaths(
 	for (const savePath of uniqueSavePaths) {
 		if (ABS_WIN_PATH_REGEX.test(savePath) === (path.sep === "/")) {
 			throw new CrossSeedError(
-				`Cannot use linkDir with cross platform cross-seed and torrent client: ${savePath}`,
+				`Cannot use linkDir with cross platform cross-seed and torrent client, please run cross-seed in docker or natively to match your torrent client (https://www.cross-seed.org/docs/basics/managing-the-daemon): ${savePath}`,
 			);
 		}
 		try {
@@ -170,7 +170,6 @@ export function shouldRecheck(
 	const { skipRecheck } = getRuntimeConfig();
 	if (!skipRecheck) return true;
 	if (decision === Decision.MATCH_PARTIAL) return true;
-	if (!searchee.infoHash) return true;
 	if (hasExt(searchee.files, VIDEO_DISC_EXTENSIONS)) return true;
 	return false; // Skip for MATCH | MATCH_SIZE_ONLY
 }

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -197,13 +197,17 @@ module.exports = {
 	flatLinking: false,
 
 	/**
-	 * Determines flexibility of naming during matching.
+	 * Determines flexibility of naming during matching, all options will have
+	 * no false positives. Using partial can double the amount of cross seeds found.
+	 * Options: "safe", "risky", "partial".
+	 *
 	 * "safe" will allow only perfect name/size matches using the standard
 	 * matching algorithm.
+	 *
 	 * "risky" uses filesize as its only comparison point.
+	 *
 	 * "partial" is like risky but allows matches if they are missing small
 	 * files like .nfo/.srt.
-	 * Options: "safe", "risky", "partial".
 	 *
 	 * We recommend reading the following FAQ entry:
 	 * https://www.cross-seed.org/docs/basics/options#matchmode
@@ -213,10 +217,8 @@ module.exports = {
 	matchMode: "safe",
 
 	/**
-	 * Skip rechecking on injection if unnecessary. Certain matches will
-	 * always be rechecked such as: partial, data based, and disc files.
-	 * Set to false to recheck all torrents before resuming, usually unnecessary.
-	 * Torrents will be resumed regardless of this setting per autoResumeMaxDownload.
+	 * Skip rechecking on injection if unnecessary. Certain matches, such as partial,
+	 * will always be rechecked. Set to false to recheck all torrents before resuming.
 	 */
 	skipRecheck: true,
 


### PR DESCRIPTION
This is primarily for racing ensemble from announce.

With the new `searchee.mtimeMs` for data/ensemble searchees, we should be able to tell if complete in most scenarios. The only exception is for stalled torrents, which should be rare. The inject job already handles and sometimes inject stalled torrents anyways.

Will always save data/ensemble .torrent files anyways in case there is an issue, the inject job will automatically resolve it.