### PR TITLE
enhancement(dataDirs): support rss/announce matching

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -32,6 +32,7 @@ import "./signalHandlers.js";
 import { doStartupValidation } from "./startup.js";
 import { indexEnsemble, parseTorrentFromFilename } from "./torrent.js";
 import { fallback } from "./utils.js";
+import { initializeDataDirs } from "./dataFiles.js";
 
 let fileConfig: FileConfig;
 try {
@@ -162,7 +163,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"--max-data-depth <depth>",
 			"Max depth to look for searchees in dataDirs",
 			(n) => parseInt(n),
-			fallback(fileConfig.maxDataDepth, 2),
+			fallback(fileConfig.maxDataDepth, 3),
 		)
 		.option(
 			"-i, --torrent-dir <dir>",
@@ -422,6 +423,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 			await db.migrate.latest();
 			await doStartupValidation();
 			await indexEnsemble();
+			await initializeDataDirs();
 			serve(options.port, options.host);
 			jobsLoop();
 		} catch (e) {
@@ -438,6 +440,7 @@ createCommandWithSharedOptions("rss", "Run an rss scan").action(
 			await db.migrate.latest();
 			await doStartupValidation();
 			await indexEnsemble();
+			await initializeDataDirs();
 			await scanRssFeeds();
 			await db.destroy();
 			await memDB.destroy();

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -233,8 +233,9 @@ module.exports = {
 	 * Determines how deep into the specified dataDirs to go to generate new
 	 * searchees. Setting this to higher values will result in more searchees
 	 * and more API hits to your indexers.
+	 * https://www.cross-seed.org/docs/tutorials/data-based-matching#setting-up-data-based-matching
 	 */
-	maxDataDepth: 2,
+	maxDataDepth: 3,
 
 	/**
 	 * Directory containing .torrent files.

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -1,8 +1,155 @@
-import { readdirSync, statSync } from "fs";
-import { basename, extname, join } from "path";
+import { existsSync, FSWatcher, readdirSync, statSync, watch } from "fs";
+import Fuse from "fuse.js";
+import { basename, dirname, extname, join } from "path";
 import { IGNORED_FOLDERS_SUBSTRINGS, VIDEO_EXTENSIONS } from "./constants.js";
+import { memDB } from "./db.js";
 import { logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
+import {
+	createSearcheeFromPath,
+	File,
+	getFilesFromDataRoot,
+	parseTitle,
+	SearcheeWithoutInfoHash,
+} from "./searchee.js";
+import { createEnsemblePieces, EnsembleEntry } from "./torrent.js";
+import { createKeyTitle } from "./utils.js";
+import { isOk } from "./Result.js";
+
+interface DataEntry {
+	title: string;
+	path: string;
+}
+
+const watchers: Map<string, FSWatcher | null> = new Map();
+
+function startWatcher(dataDir: string): FSWatcher {
+	return watch(dataDir, { recursive: true, persistent: false }, () => {
+		watchers.get(dataDir)!.close();
+		watchers.set(dataDir, null);
+	});
+}
+
+export async function initializeDataDirs(): Promise<void> {
+	const { dataDirs } = getRuntimeConfig();
+	if (await memDB.schema.hasTable("data")) return;
+	await memDB.schema.createTable("data", (table) => {
+		table.string("path").primary();
+		table.string("title");
+	});
+	if (!dataDirs?.length) return;
+	for (const dataDir of dataDirs) {
+		watchers.set(dataDir, null);
+	}
+	logger.info("Indexing dataDirs for reverse lookup...");
+	await indexDataDirs();
+}
+
+async function indexDataDir(
+	dataDir: string,
+	prevWatcher: FSWatcher | null,
+): Promise<void> {
+	const { maxDataDepth, seasonFromEpisodes } = getRuntimeConfig();
+	if (prevWatcher) return;
+	logger.verbose(`Indexing ${dataDir} due to recent changes...`);
+	watchers.set(dataDir, startWatcher(dataDir));
+	for (const dirent of readdirSync(dataDir)) {
+		const entry = join(dataDir, dirent);
+		const paths = findPotentialNestedRoots(entry, maxDataDepth);
+		const dataRows: DataEntry[] = [];
+		const ensembleRows: EnsembleEntry[] = [];
+		for (const path of paths) {
+			const files = getFilesFromDataRoot(path);
+			const title = parseTitle(basename(path), files, path);
+			if (!title) continue;
+			dataRows.push({ title, path });
+			if (seasonFromEpisodes) {
+				const ensembleEntry = await indexEnsembleDataEntry(
+					title,
+					path,
+					files,
+				);
+				if (ensembleEntry) ensembleRows.push(ensembleEntry);
+			}
+		}
+		const batchSize = 100;
+		for (let i = 0; i < dataRows.length; i += batchSize) {
+			const batch = dataRows.slice(i, i + batchSize);
+			if (!batch.length) break;
+			await memDB("data").insert(batch).onConflict("path").ignore();
+		}
+		for (let i = 0; i < ensembleRows.length; i += batchSize) {
+			const batch = ensembleRows.slice(i, i + batchSize);
+			if (!batch.length) break;
+			await memDB("ensemble").insert(batch).onConflict("path").ignore();
+		}
+	}
+}
+
+export async function indexDataDirs(): Promise<void> {
+	await Promise.all(
+		Array.from(watchers.entries()).map(([dataDir, prevWatcher]) =>
+			indexDataDir(dataDir, prevWatcher),
+		),
+	);
+}
+
+async function indexEnsembleDataEntry(
+	title: string,
+	path: string,
+	files: File[],
+): Promise<EnsembleEntry | null> {
+	const ensemblePieces = await createEnsemblePieces(title, files);
+	if (!ensemblePieces) return null;
+	const { key, element, largestFile } = ensemblePieces;
+	return {
+		path: join(dirname(path), largestFile.path),
+		ensemble: key,
+		element,
+	};
+}
+
+export async function getDataByFuzzyName(
+	name: string,
+): Promise<SearcheeWithoutInfoHash[]> {
+	const allDataEntries: { title: string; path: string }[] =
+		await memDB("data");
+	const fullMatch = createKeyTitle(name);
+
+	// Attempt to filter torrents in DB to match incoming data before fuzzy check
+	let filteredNames: typeof allDataEntries = [];
+	if (fullMatch) {
+		filteredNames = allDataEntries.filter((dbData) => {
+			const dbMatch = createKeyTitle(dbData.title);
+			return fullMatch === dbMatch;
+		});
+	}
+
+	// If none match, proceed with fuzzy name check on all names.
+	filteredNames = filteredNames.length > 0 ? filteredNames : allDataEntries;
+
+	const entriesToDelete: string[] = [];
+	// @ts-expect-error fuse types are confused
+	const potentialMatches = new Fuse(filteredNames, {
+		keys: ["title"],
+		distance: 6,
+		threshold: 0.25,
+	})
+		.search(name)
+		.filter((match) => {
+			const path = match.item.path;
+			if (existsSync(path)) return true;
+			entriesToDelete.push(path);
+			return false;
+		});
+	if (entriesToDelete.length > 0) {
+		await memDB("data").whereIn("path", entriesToDelete).del();
+	}
+	if (potentialMatches.length === 0) return [];
+	return [await createSearcheeFromPath(potentialMatches[0].item.path)]
+		.filter(isOk)
+		.map((r) => r.unwrap());
+}
 
 function shouldIgnorePathHeuristically(root: string, isDir: boolean) {
 	const searchBasename = basename(root);

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -29,11 +29,6 @@ const modifiedPaths: Map<string, Set<string>> = new Map();
  */
 export async function initializeDataDirs(): Promise<void> {
 	const { dataDirs } = getRuntimeConfig();
-	if (await memDB.schema.hasTable("data")) return;
-	await memDB.schema.createTable("data", (table) => {
-		table.string("path").primary();
-		table.string("title");
-	});
 	if (!dataDirs?.length) return;
 	for (const dataDir of dataDirs) {
 		modifiedPaths.set(dataDir, new Set());

--- a/src/db.ts
+++ b/src/db.ts
@@ -22,3 +22,12 @@ export const memDB = Knex.knex({
 	connection: ":memory:",
 	useNullAsDefault: true,
 });
+await memDB.schema.createTable("data", (table) => {
+	table.string("path").primary();
+	table.string("title");
+});
+await memDB.schema.createTable("ensemble", (table) => {
+	table.string("path").primary();
+	table.string("ensemble");
+	table.string("element");
+});

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -336,7 +336,7 @@ export async function assessCandidate(
 
 	let metafile: Metafile;
 	if (isCandidate) {
-		let res = await snatch(metaOrCandidate);
+		let res = await snatch(metaOrCandidate, searchee.label);
 		if (res.isErr()) {
 			const e = res.unwrapErr();
 			if (
@@ -344,7 +344,7 @@ export async function assessCandidate(
 				![SnatchError.RATE_LIMITED, SnatchError.MAGNET_LINK].includes(e)
 			) {
 				await wait(ms("30 seconds"));
-				res = await snatch(metaOrCandidate);
+				res = await snatch(metaOrCandidate, searchee.label);
 			}
 			if (res.isErr()) {
 				const err = res.unwrapErr();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -113,10 +113,11 @@ export function initializeLogger(options: RuntimeConfig): void {
 			winston.format.errors({ stack: true }),
 			winston.format.splat(),
 			winston.format.printf(
-				({ level, message, label, timestamp, stack }) => {
+				({ level, message, label, timestamp, stack, cause }) => {
+					const msg = `${message}${stack ? `\n${stack}` : ""}${cause ? `\n${cause}` : ""}`;
 					return `${timestamp} ${level}: ${
 						label ? `[${label}] ` : ""
-					}${stripAnsiChars(redactMessage(stack ? stack : message, options))}`;
+					}${stripAnsiChars(redactMessage(msg, options))}`;
 				},
 			),
 		),
@@ -151,13 +152,18 @@ export function initializeLogger(options: RuntimeConfig): void {
 					winston.format.splat(),
 					winston.format.colorize(),
 					winston.format.printf(
-						({ level, message, label, timestamp, stack }) => {
+						({
+							level,
+							message,
+							label,
+							timestamp,
+							stack,
+							cause,
+						}) => {
+							const msg = `${message}${stack ? `\n${stack}` : ""}${cause ? `\n${cause}` : ""}`;
 							return `${timestamp} ${level}: ${
 								label ? `[${label}] ` : ""
-							}${redactMessage(
-								stack ? stack : message,
-								options,
-							)}`;
+							}${redactMessage(msg, options)}`;
 						},
 					),
 				),

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import fs from "fs";
 import { zip } from "lodash-es";
 import ms from "ms";
+import { basename } from "path";
 import { performAction, performActions } from "./action.js";
 import { getClient } from "./clients/TorrentClient.js";
 import {
@@ -41,6 +42,7 @@ import {
 	createSearcheeFromMetafile,
 	createSearcheeFromPath,
 	createSearcheeFromTorrentFile,
+	File,
 	getNewestFileAge,
 	getSeasonKey,
 	Searchee,
@@ -49,9 +51,9 @@ import {
 } from "./searchee.js";
 import {
 	getInfoHashesToExclude,
-	getSimilarTorrentsByName,
+	getSimilarByName,
 	getTorrentByCriteria,
-	indexNewTorrents,
+	indexTorrentsAndDataDirs,
 	loadTorrentDirLight,
 	TorrentLocator,
 } from "./torrent.js";
@@ -332,20 +334,23 @@ async function getSearcheesForCandidate(
 	searcheeLabel: SearcheeLabel,
 ): Promise<{ searchees: SearcheeWithLabel[]; method: string } | null> {
 	const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
-	const { keys, metas } = await getSimilarTorrentsByName(candidate.name);
+	const { keys, metas, dataSearchees } = await getSimilarByName(
+		candidate.name,
+	);
 	const method = keys.length ? `[${keys}]` : "Fuse fallback";
-	if (!metas.length) {
+	if (!metas.length && !dataSearchees.length) {
 		logger.verbose({
 			label: searcheeLabel,
 			message: `Did not find an existing entry using ${method} for ${candidateLog}`,
 		});
 		return null;
 	}
+	const torrentSearchees = metas
+		.map(createSearcheeFromMetafile)
+		.filter(isOk)
+		.map((r) => r.unwrap());
 	const searchees = filterDupesFromSimilar(
-		metas
-			.map(createSearcheeFromMetafile)
-			.filter(isOk)
-			.map((r) => r.unwrap())
+		[...torrentSearchees, ...dataSearchees]
 			.map((searchee) => ({ ...searchee, label: searcheeLabel }))
 			.filter((searchee) => filterByContent(searchee)),
 	);
@@ -380,13 +385,25 @@ async function getEnsembleForCandidate(
 		});
 		return null;
 	}
-	const files = ensemble
-		.map((e) => ({
-			path: e.absolute_path,
-			name: e.name,
-			length: e.length,
-		}))
-		.filter((f) => fs.existsSync(f.path));
+	const duplicateFiles = new Set<string>();
+	const entriesToDelete: string[] = [];
+	const files = ensemble.reduce<File[]>((acc, entry) => {
+		const path = entry.path;
+		if (!fs.existsSync(path)) {
+			entriesToDelete.push(path);
+			return acc;
+		}
+		const length = fs.statSync(path).size;
+		const name = basename(path);
+		const test = `${entry.element}-${length}`;
+		if (duplicateFiles.has(test)) return acc; // cross seeded file
+		duplicateFiles.add(test);
+		acc.push({ length, name, path });
+		return acc;
+	}, []);
+	if (entriesToDelete.length) {
+		await memDB("ensemble").whereIn("path", entriesToDelete).del();
+	}
 	if (files.length === 0) {
 		logger.verbose({
 			label: searcheeLabel,
@@ -398,14 +415,14 @@ async function getEnsembleForCandidate(
 	const uniqueElements = new Set(ensemble.map((e) => e.element));
 	const totalLength = Math.round(
 		[...uniqueElements].reduce((acc, cur) => {
-			const elements = ensemble.filter(
-				(e) =>
-					e.element === cur &&
-					files.some((f) => f.path === e.absolute_path),
-			);
-			const avg =
-				elements.reduce((a, c) => a + c.length, 0) / elements.length;
-			return acc + avg;
+			const lengths = ensemble.reduce<number[]>((lengths, e) => {
+				if (e.element !== cur) return lengths;
+				const file = files.find((f) => f.path === e.path);
+				if (!file) return lengths; // Was an ignored cross seeded file
+				lengths.push(file.length);
+				return lengths;
+			}, []);
+			return acc + lengths.reduce((a, b) => a + b) / lengths.length;
 		}, 0),
 	);
 	const searchees: SearcheeWithLabel[] = [
@@ -628,11 +645,12 @@ export async function main(): Promise<void> {
 }
 
 export async function scanRssFeeds() {
-	const { torrentDir, torznab } = getRuntimeConfig();
-	if (!torrentDir || !torznab.length) {
+	const { dataDirs, torrentDir, torznab } = getRuntimeConfig();
+	if (!torznab.length || (!torrentDir && !dataDirs?.length)) {
 		logger.error({
 			label: Label.RSS,
-			message: "RSS requires torrentDir and torznab to be set",
+			message:
+				"RSS requires torznab and at least one of torrentDir (recommended) or dataDirs to be set",
 		});
 		return;
 	}
@@ -643,7 +661,7 @@ export async function scanRssFeeds() {
 		label: Label.RSS,
 		message: "Indexing new torrents...",
 	});
-	await indexNewTorrents();
+	await indexTorrentsAndDataDirs();
 	logger.verbose({
 		label: Label.RSS,
 		message: "Querying RSS feeds...",

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -262,9 +262,11 @@ export async function searchForLocalTorrentByCriteria(
 		);
 		if (res.isOk()) rawSearchees.push(res.unwrap());
 	} else {
+		const memoizedPaths = new Map<string, string[]>();
+		const memoizedLengths = new Map<string, number>();
 		const searcheeResults = await Promise.all(
-			findPotentialNestedRoots(criteria.path, maxDataDepth).map(
-				createSearcheeFromPath,
+			findPotentialNestedRoots(criteria.path, maxDataDepth).map((path) =>
+				createSearcheeFromPath(path, memoizedPaths, memoizedLengths),
 			),
 		);
 		rawSearchees.push(
@@ -543,8 +545,16 @@ export async function findAllSearchees(
 			rawSearchees.push(...(await loadTorrentDirLight(torrentDir)));
 		}
 		if (Array.isArray(dataDirs)) {
+			const memoizedPaths = new Map<string, string[]>();
+			const memoizedLengths = new Map<string, number>();
 			const searcheeResults = await Promise.all(
-				findSearcheesFromAllDataDirs().map(createSearcheeFromPath),
+				findSearcheesFromAllDataDirs().map((path) =>
+					createSearcheeFromPath(
+						path,
+						memoizedPaths,
+						memoizedLengths,
+					),
+				),
 			);
 			rawSearchees.push(
 				...searcheeResults.filter(isOk).map((r) => r.unwrap()),

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -86,6 +86,7 @@ export function filterByContent(
 		(!includeEpisodes || !includeSingleEpisodes) &&
 		searchee.path &&
 		searchee.files.length === 1 &&
+		[Label.SEARCH, Label.WEBHOOK].includes(searchee.label) &&
 		(SEASON_REGEX.test(basename(dirname(searchee.path))) ||
 			SONARR_SUBFOLDERS_REGEX.test(basename(dirname(searchee.path))))
 	) {

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -124,7 +124,7 @@ export async function getNewestFileAge(
 		await Promise.all(
 			absoluteFilePaths.map((file) => stat(file).then((s) => s.mtimeMs)),
 		)
-	).reduce((a, b) => Math.max(a, b), 0);
+	).reduce((a, b) => Math.max(a, b));
 }
 
 export async function getSearcheeNewestFileAge(
@@ -158,7 +158,7 @@ function getFileNamesFromRootRec(root: string, isDirHint?: boolean): string[] {
 	}
 }
 
-function getFilesFromDataRoot(rootPath: string): File[] {
+export function getFilesFromDataRoot(rootPath: string): File[] {
 	const parentDir = dirname(rootPath);
 	try {
 		return getFileNamesFromRootRec(rootPath).map((file) => ({
@@ -270,7 +270,7 @@ export async function createSearcheeFromTorrentFile(
 
 export async function createSearcheeFromPath(
 	root: string,
-): Promise<Result<Searchee, Error>> {
+): Promise<Result<SearcheeWithoutInfoHash, Error>> {
 	const files = getFilesFromDataRoot(root);
 	if (files.length === 0) {
 		const msg = `Failed to retrieve files in ${root}`;
@@ -280,7 +280,7 @@ export async function createSearcheeFromPath(
 		});
 		return resultOfErr(new Error(msg));
 	}
-	const totalLength = files.reduce<number>(
+	const totalLength = files.reduce(
 		(runningTotal, file) => runningTotal + file.length,
 		0,
 	);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -377,17 +377,7 @@ async function indexNewTorrents(): Promise<void> {
 
 export async function indexEnsemble(): Promise<void> {
 	const { seasonFromEpisodes, torrentDir } = getRuntimeConfig();
-	if (!seasonFromEpisodes) return;
-
-	const tableExists = await memDB.schema.hasTable("ensemble");
-	if (!tableExists) {
-		await memDB.schema.createTable("ensemble", (table) => {
-			table.string("path").primary();
-			table.string("ensemble");
-			table.string("element");
-		});
-	}
-	if (!torrentDir) return;
+	if (!seasonFromEpisodes || !torrentDir) return;
 
 	logger.info("Indexing ensemble for reverse lookup...");
 	const dirContents = await findAllTorrentFilesInDir(torrentDir);


### PR DESCRIPTION
This uses `fs.watcher`, which recently supported recursive watch all on platforms in Node v19. This detects new/removed files and modified files, which is all we need. We do not run it all the time, as soon as a change is detected we cancel it for that dataDir. Then on next rss/announce we will reindex only the dataDirs with a change and restart the watcher.

The indexing is stored in memDB, essentially the same as the torrents table for lookup. But we parse the title instead of name so that media season folders and others are meaningful. As with ensemble, memDB makes the lookups much quicker and is only a couple megabytes (when on disk) for 20k entries. Also adds a few seconds for indexing at startup.

Recommended `maxDataDepth` is 3 if using on media libraries. This is so that `includeSingleEpisodes` and `seasonFromEpisodes` can reach individual episodes. The season pack episode filter (all tv library episodes) does not apply to rss/announce for data, only the normal `includeSingleEpisodes` does. `seasonFromEpisodes` is technically does not need `maxDataDepth` 3 as it's covered by the season searchee, however it can potentially source from torrents not currently imported.

Since we will be indexing dataDirs a lot, I tried to minimize the load on the disk, but of course it's far more intensive that torrentDir. I added memoization to the `File[]` creation as there is a lot of repeated work when creating searchees of parent folders. Full searchees are only created once the reverse lookup is successful.