### PR TITLE
fix(zod/webhook): corrects bad logic on path validation in webhook api calls

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,7 @@ const ANNOUNCE_SCHEMA = z
 const WEBHOOK_SCHEMA = z
 	.object({
 		infoHash: z.string().length(40),
-		path: z.string().refine((path) => !path || existsSync(path)),
+		path: z.string().refine((path) => path && existsSync(path)),
 	})
 	.strict()
 	.partial()


### PR DESCRIPTION
This corrects bad logic on a throw which allows for falsey path (empty string) to not return 400.

Throws now on:

path string is falsy (e.g., '', null, or undefined)
file or directory specified does not exist