### PR TITLE
enhancement(action/linking): support multiple linkDirs

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -453,9 +453,11 @@ export function getLinkDir(path: string): string | null {
 		);
 		return null;
 	}
-	logger.warn(
-		`Cannot find any linkDir from linkDirs on the same drive, using first linkDir for symlink: ${path}`,
-	);
+	if (linkDirs.length > 1) {
+		logger.warn(
+			`Cannot find any linkDir from linkDirs on the same drive, using first linkDir for symlink: ${path}`,
+		);
+	}
 	return linkDirs[0];
 }
 

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -94,7 +94,7 @@ export async function validateSavePaths(
 	infoHashPathMap: Map<string, string>,
 	searchees: SearcheeWithInfoHash[],
 ): Promise<void> {
-	const { blockList, linkDir } = getRuntimeConfig();
+	const { blockList, linkDirs } = getRuntimeConfig();
 	logger.info(`Validating all existing torrent save paths...`);
 
 	const entryDir = searchees.find((s) => !infoHashPathMap.has(s.infoHash));
@@ -112,7 +112,7 @@ export async function validateSavePaths(
 			`Could not ensure all torrents from the torrent client are in torrentDir (missing ${entryClient} with savePath ${infoHashPathMap.get(entryClient)}): https://www.cross-seed.org/docs/basics/options#torrentdir`,
 		);
 	}
-	if (!linkDir) return;
+	if (!linkDirs.length) return;
 
 	const removedSavePaths = new Set<string>();
 	for (const searchee of searchees) {

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -142,8 +142,14 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		)
 		.option(
 			"--link-dir <dir>",
-			"Directory to output data-matched hardlinks to",
+			"Directory to link the data for matches to",
 			fileConfig.linkDir,
+		)
+		.option(
+			"--link-dirs <dirs...>",
+			"Directories to link the data for matches to",
+			// @ts-expect-error commander supports non-string defaults
+			fallback(fileConfig.linkDirs),
 		)
 		.option(
 			"--flat-linking",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -157,23 +157,24 @@ module.exports = {
 	linkCategory: "cross-seed-link",
 
 	/**
-	 * If this is specified, cross-seed will create links to matched files in
-	 * the specified directory.
-	 * It will create a different link for every changed file name or directory
-	 * structure.
+	 * cross-seed will create links to matched files in the specified directories.
+	 * If using hardlinks, you will need as many linkDirs as drives/partion/volumes
+	 * as your dataDirs and torrent client download directories.
 	 *
-	 * Unlike dataDirs, this is just a quoted string WITHOUT []'s around it.
+	 * Ideally, you should only have a single linkDir and use drive pooling.
+	 * Using multiple linkDirs is only for those with cache/temp drives or those that
+	 * cannot use drive pooling.
 	 *
 	 * If you are a Windows user you need to put double '\' (e.g. "C:\\links")
 	 *
-	 * IF YOU ARE USING HARDLINKS, THIS MUST BE UNDER THE SAME VOLUME AS YOUR
+	 * IF YOU ARE USING HARDLINKS, THIS MUST BE UNDER THE SAME VOLUMES AS YOUR
 	 * DATADIRS. THIS PATH MUST ALSO BE ACCESSIBLE VIA YOUR TORRENT CLIENT
 	 * USING THE SAME PATH.
 	 *
 	 * We recommend reading the following FAQ entry:
 	 * https://www.cross-seed.org/docs/tutorials/linking
 	 */
-	linkDir: undefined,
+	linkDirs: [],
 
 	/**
 	 * cross-seed will use links of this type to inject data-based matches into

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,6 +26,7 @@ export interface FileConfig {
 	skipRecheck?: boolean;
 	autoResumeMaxDownload?: number;
 	linkDir?: string;
+	linkDirs?: string[];
 	linkType?: string;
 	flatLinking?: boolean;
 	maxDataDepth?: number;

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -325,9 +325,9 @@ async function injectionTorrentNotComplete(
 ) {
 	const { progress, torrentFilePath, injectionResult, summary, filePathLog } =
 		injectionAftermath;
-	const { linkDir } = getRuntimeConfig();
+	const { linkDirs } = getRuntimeConfig();
 	if (
-		!linkDir ||
+		!linkDirs.length ||
 		(await stat(torrentFilePath)).mtimeMs >= Date.now() - ms("1 day")
 	) {
 		// Normal case where source is likely still downloading

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -630,14 +630,11 @@ async function findSearchableTorrents(): Promise<{
 }
 
 export async function main(): Promise<void> {
-	const { outputDir, linkDir } = getRuntimeConfig();
+	const { outputDir } = getRuntimeConfig();
 	const { searchees, infoHashesToExclude } = await findSearchableTorrents();
 
 	if (!fs.existsSync(outputDir)) {
 		fs.mkdirSync(outputDir, { recursive: true });
-	}
-	if (linkDir && !fs.existsSync(linkDir)) {
-		fs.mkdirSync(linkDir, { recursive: true });
 	}
 
 	const totalFound = await findMatchesBatch(searchees, infoHashesToExclude);

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -7,7 +7,7 @@ export interface RuntimeConfig {
 	matchMode: MatchMode;
 	skipRecheck: boolean;
 	autoResumeMaxDownload: number;
-	linkDir?: string;
+	linkDirs: string[];
 	linkType: LinkType;
 	flatLinking: boolean;
 	maxDataDepth: number;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -79,6 +79,7 @@ export interface Searchee {
 
 export type SearcheeWithInfoHash = WithRequired<Searchee, "infoHash">;
 export type SearcheeWithoutInfoHash = WithUndefined<Searchee, "infoHash">;
+export type SearcheeVirtual = WithUndefined<Searchee, "infoHash" | "path">;
 export type SearcheeWithLabel = WithRequired<Searchee, "label">;
 
 export function hasInfoHash(

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,3 +1,4 @@
+import { existsSync, mkdirSync } from "fs";
 import { access, constants, stat } from "fs/promises";
 import { sep } from "path";
 import { inspect } from "util";
@@ -56,7 +57,7 @@ async function checkConfigPaths(): Promise<void> {
 		action,
 		dataDirs,
 		injectDir,
-		linkDir,
+		linkDirs,
 		outputDir,
 		rtorrentRpcUrl,
 		torrentDir,
@@ -79,8 +80,14 @@ async function checkConfigPaths(): Promise<void> {
 		pathFailure++;
 	}
 
-	if (linkDir && !(await verifyPath(linkDir, "linkDir", READ_AND_WRITE))) {
-		pathFailure++;
+	for (const linkDir of linkDirs) {
+		if (!existsSync(linkDir)) {
+			logger.info(`Creating linkDir: ${linkDir}`);
+			mkdirSync(linkDir, { recursive: true });
+		}
+		if (!(await verifyPath(linkDir, "linkDir", READ_AND_WRITE))) {
+			pathFailure++;
+		}
 	}
 	if (dataDirs) {
 		for (const dataDir of dataDirs) {
@@ -98,7 +105,7 @@ async function checkConfigPaths(): Promise<void> {
 			pathFailure++;
 		}
 	}
-	if (linkDir && dataDirs) {
+	if (linkDirs.length && dataDirs) {
 		for (const dataDir of dataDirs) {
 			try {
 				testLinking(dataDir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import chalk, { ChalkInstance } from "chalk";
 import { distance } from "fastest-levenshtein";
-import { readdirSync } from "fs";
+import { readdirSync, statSync } from "fs";
 import path from "path";
 import {
 	ALL_EXTENSIONS,
@@ -10,6 +10,7 @@ import {
 	EP_REGEX,
 	JSON_VALUES_REGEX,
 	LEVENSHTEIN_DIVISOR,
+	LinkType,
 	MediaType,
 	MOVIE_REGEX,
 	NON_UNICODE_ALPHANUM_REGEX,
@@ -25,7 +26,8 @@ import {
 } from "./constants.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { File, Searchee } from "./searchee.js";
+import { File, Searchee, SearcheeVirtual } from "./searchee.js";
+import { logger } from "./logger.js";
 
 type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
 
@@ -36,6 +38,38 @@ export type WithUndefined<T, K extends keyof T> = Omit<T, K> & {
 
 export function isTruthy<T>(value: T): value is Truthy<T> {
 	return Boolean(value);
+}
+
+export function getLinkDir(path: string): string | null {
+	const { linkDirs, linkType } = getRuntimeConfig();
+	const pathDev = statSync(path).dev;
+	for (const linkDir of linkDirs) {
+		if (statSync(linkDir).dev === pathDev) return linkDir;
+	}
+	if (linkType === LinkType.HARDLINK) {
+		logger.error(
+			`Cannot find any linkDir from linkDirs on the same drive to hardlink ${path}`,
+		);
+		return null;
+	}
+	logger.warn(
+		`Cannot find any linkDir from linkDirs on the same drive, using first linkDir for symlink: ${path}`,
+	);
+	return linkDirs[0];
+}
+
+export function getLinkDirVirtual(searchee: SearcheeVirtual): string | null {
+	const linkDir = getLinkDir(searchee.files[0].path);
+	if (!linkDir) return null;
+	for (let i = 1; i < searchee.files.length; i++) {
+		if (getLinkDir(searchee.files[i].path) !== linkDir) {
+			logger.error(
+				`Cannot hardlink files to multiple linkDirs for seasonFromEpisodes aggregation, source episodes are spread across multiple drives.`,
+			);
+			return null;
+		}
+	}
+	return linkDir;
 }
 
 export function stripExtension(filename: string): string {


### PR DESCRIPTION
fixes #625 

`linkDir` is converted to `linkDirs: [linkDir]`.

We choose a linkDir by testing if stat.dev if between source path and any linkDir is the same. Hardlink requires this to have a match but symlink will only display and warning and use `linkDirs[0]`.

The only possible issue is with `seasonFromEpisodes`, these could be sourced from multiple drives. The ones that are will be logged as failures before attempting to link.