### PR TITLE
feat(clients): option to use APIs instead of torrentDir

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,4 +1,5 @@
 import { readdirSync } from "fs";
+import { basename } from "path";
 import ms from "ms";
 import {
 	DecisionAnyMatch,
@@ -6,37 +7,52 @@ import {
 	TORRENT_CATEGORY_SUFFIX,
 	TORRENT_TAG,
 } from "../constants.js";
+import { memDB } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
+import {
+	createSearcheeFromDB,
+	parseTitle,
+	Searchee,
+	SearcheeClient,
+	SearcheeWithInfoHash,
+	updateSearcheeClientDB,
+} from "../searchee.js";
 import {
 	extractCredentialsFromUrl,
 	getLogString,
 	humanReadableSize,
+	Mutex,
 	sanitizeInfoHash,
 	wait,
+	withMutex,
 } from "../utils.js";
 import {
-	TorrentMetadataInClient,
+	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
+	organizeTrackers,
 	resumeErrSleepTime,
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
+	TorrentMetadataInClient,
 } from "./TorrentClient.js";
 
 interface TorrentInfo {
 	name?: string;
 	complete?: boolean;
-	save_path: string;
+	save_path?: string;
 	state?: string;
 	progress?: number;
 	label?: string;
+	total_size?: number;
 	total_remaining?: number;
+	files?: { path: string; size: number }[];
+	trackers?: { url: string; tier: number }[];
 }
 
 enum DelugeErrorCode {
@@ -404,7 +420,7 @@ export default class Deluge implements TorrentClient {
 
 			const torrentFileName = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
 			const encodedTorrentData = newTorrent.encode().toString("base64");
-			const torrentPath = path ? path : torrentInfo!.save_path;
+			const torrentPath = path ? path : torrentInfo!.save_path!;
 			const params = this.formatData(
 				torrentFileName,
 				encodedTorrentData,
@@ -528,7 +544,7 @@ export default class Deluge implements TorrentClient {
 		if (options.onlyCompleted && torrent.progress !== 100) {
 			return resultOfErr("TORRENT_NOT_COMPLETE");
 		}
-		return resultOf(torrent.save_path);
+		return resultOf(torrent.save_path!);
 	}
 
 	/**
@@ -557,7 +573,7 @@ export default class Deluge implements TorrentClient {
 		}
 		for (const [hash, torrent] of Object.entries(torrentResponse)) {
 			if (options.onlyCompleted && torrent.progress !== 100) continue;
-			dirs.set(hash, torrent.save_path);
+			dirs.set(hash, torrent.save_path!);
 		}
 		return dirs;
 	}
@@ -599,6 +615,110 @@ export default class Deluge implements TorrentClient {
 			category: torrent.label ?? "",
 			tags: [],
 		}));
+	}
+
+	/**
+	 * Get all searchees from the client and update the db
+	 * @param options.newSearcheesOnly only return searchees that are not in the db
+	 * @param options.refresh undefined uses the cache, [] refreshes all searchees, or a list of infoHashes to refresh
+	 * @return an object containing all searchees and new searchees (refreshed searchees are considered new)
+	 */
+	async getClientSearchees(options?: {
+		newSearcheesOnly?: boolean;
+		refresh?: string[];
+	}): Promise<ClientSearcheeResult> {
+		return withMutex(
+			Mutex.QUERY_CLIENT,
+			async () => {
+				const searchees: SearcheeClient[] = [];
+				const newSearchees: SearcheeClient[] = [];
+				const infoHashes = new Set<string>();
+				const torrentsRes = await this.call<TorrentStatus>(
+					"web.update_ui",
+					[
+						[
+							"name",
+							"label",
+							"save_path",
+							"total_size",
+							"files",
+							"trackers",
+						],
+						{},
+					],
+				);
+				if (torrentsRes.isErr()) {
+					logger.error({
+						label: Label.DELUGE,
+						message: "Failed to get torrents from client",
+					});
+					logger.debug(torrentsRes.unwrapErr());
+					return { searchees, newSearchees };
+				}
+				const torrents = torrentsRes.unwrap().torrents;
+				if (!torrents || !Object.keys(torrents).length) {
+					logger.verbose({
+						label: Label.DELUGE,
+						message: "No torrents found in client",
+					});
+					return { searchees, newSearchees };
+				}
+				for (const [hash, torrent] of Object.entries(torrents)) {
+					const infoHash = hash.toLowerCase();
+					infoHashes.add(infoHash);
+					const dbTorrent = await memDB("torrent")
+						.where("info_hash", infoHash)
+						.first();
+					const refresh =
+						options?.refresh === undefined
+							? false
+							: options.refresh.length === 0
+								? true
+								: options.refresh.includes(infoHash);
+					if (dbTorrent && !refresh) {
+						if (!options?.newSearcheesOnly) {
+							searchees.push(createSearcheeFromDB(dbTorrent));
+						}
+						continue;
+					}
+					const files = torrent.files!.map((file) => ({
+						name: basename(file.path),
+						path: file.path,
+						length: file.size,
+					}));
+					if (!files.length) {
+						logger.verbose({
+							label: Label.DELUGE,
+							message: `No files found for ${torrent.name} [${sanitizeInfoHash(infoHash)}]: skipping`,
+						});
+						continue;
+					}
+					const trackers = organizeTrackers(torrent.trackers!);
+					const name = torrent.name!;
+					const title = parseTitle(name, files) ?? name;
+					const length = torrent.total_size!;
+					const savePath = torrent.save_path!;
+					const category = torrent.label ?? "";
+					const tags = [];
+					const searchee: SearcheeClient = {
+						infoHash,
+						name,
+						title,
+						files,
+						length,
+						savePath,
+						category,
+						tags,
+						trackers,
+					};
+					newSearchees.push(searchee);
+					searchees.push(searchee);
+				}
+				await updateSearcheeClientDB(newSearchees, infoHashes);
+				return { searchees, newSearchees };
+			},
+			{ useQueue: true },
+		);
 	}
 
 	/**

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -479,7 +479,7 @@ export default class QBittorrent implements TorrentClient {
 			infoHash: torrent.hash,
 			category: torrent.category,
 			tags: torrent.tags.length ? torrent.tags.split(",") : [],
-			trackers: torrent.tracker.length ? [[torrent.tracker]] : undefined,
+			trackers: torrent.tracker.length ? [torrent.tracker] : undefined,
 		}));
 	}
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -366,7 +366,7 @@ export default class QBittorrent implements TorrentClient {
 		}
 	}
 
-	async getTrackers(infoHash: string): Promise<string[][] | null> {
+	async getTrackers(infoHash: string): Promise<string[] | null> {
 		const responseText = await this.request(
 			"/torrents/trackers",
 			`hash=${infoHash}`,

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -196,39 +196,43 @@ export default class RTorrent implements TorrentClient {
 			| Fault[];
 
 		let response: ReturnType;
+		const args = [
+			[
+				{
+					methodName: "d.name",
+					params: [hash],
+				},
+				{
+					methodName: "d.directory",
+					params: [hash],
+				},
+				{
+					methodName: "d.left_bytes",
+					params: [hash],
+				},
+				{
+					methodName: "d.hashing",
+					params: [hash],
+				},
+				{
+					methodName: "d.complete",
+					params: [hash],
+				},
+				{
+					methodName: "d.is_multi_file",
+					params: [hash],
+				},
+				{
+					methodName: "d.is_active",
+					params: [hash],
+				},
+			],
+		];
 		try {
-			response = await this.methodCallP<ReturnType>("system.multicall", [
-				[
-					{
-						methodName: "d.name",
-						params: [hash],
-					},
-					{
-						methodName: "d.directory",
-						params: [hash],
-					},
-					{
-						methodName: "d.left_bytes",
-						params: [hash],
-					},
-					{
-						methodName: "d.hashing",
-						params: [hash],
-					},
-					{
-						methodName: "d.complete",
-						params: [hash],
-					},
-					{
-						methodName: "d.is_multi_file",
-						params: [hash],
-					},
-					{
-						methodName: "d.is_active",
-						params: [hash],
-					},
-				],
-			]);
+			response = await this.methodCallP<ReturnType>(
+				"system.multicall",
+				args,
+			);
 		} catch (e) {
 			logger.debug(e);
 			return resultOfErr("FAILURE");
@@ -354,25 +358,29 @@ export default class RTorrent implements TorrentClient {
 		);
 		type ReturnType = string[][] | Fault[];
 		let response: ReturnType;
+		const args = [
+			infoHashes
+				.map((hash) => [
+					{
+						methodName: "d.directory",
+						params: [hash],
+					},
+					{
+						methodName: "d.is_multi_file",
+						params: [hash],
+					},
+					{
+						methodName: "d.complete",
+						params: [hash],
+					},
+				])
+				.flat(),
+		];
 		try {
-			response = await this.methodCallP<ReturnType>("system.multicall", [
-				infoHashes
-					.map((hash) => [
-						{
-							methodName: "d.directory",
-							params: [hash],
-						},
-						{
-							methodName: "d.is_multi_file",
-							params: [hash],
-						},
-						{
-							methodName: "d.complete",
-							params: [hash],
-						},
-					])
-					.flat(),
-			]);
+			response = await this.methodCallP<ReturnType>(
+				"system.multicall",
+				args,
+			);
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,
@@ -442,15 +450,19 @@ export default class RTorrent implements TorrentClient {
 		);
 		type ReturnType = string[][] | Fault[];
 		let response: ReturnType;
+		const args = [
+			infoHashes.map((hash) => {
+				return {
+					methodName: "d.custom1",
+					params: [hash],
+				};
+			}),
+		];
 		try {
-			response = await this.methodCallP<ReturnType>("system.multicall", [
-				infoHashes.map((hash) => {
-					return {
-						methodName: "d.custom1",
-						params: [hash],
-					};
-				}),
-			]);
+			response = await this.methodCallP<ReturnType>(
+				"system.multicall",
+				args,
+			);
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,
@@ -511,53 +523,44 @@ export default class RTorrent implements TorrentClient {
 				);
 				type ReturnType = any[][] | Fault[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 				let response: ReturnType;
+				const args = [
+					hashes
+						.map((hash) => [
+							{
+								methodName: "d.name",
+								params: [hash],
+							},
+							{
+								methodName: "d.size_bytes",
+								params: [hash],
+							},
+							{
+								methodName: "d.directory",
+								params: [hash],
+							},
+							{
+								methodName: "d.is_multi_file",
+								params: [hash],
+							},
+							{
+								methodName: "d.custom1",
+								params: [hash],
+							},
+							{
+								methodName: "f.multicall",
+								params: [hash, "", "f.path=", "f.size_bytes="],
+							},
+							{
+								methodName: "t.multicall",
+								params: [hash, "", "t.url=", "t.group="],
+							},
+						])
+						.flat(),
+				];
 				try {
 					response = await this.methodCallP<ReturnType>(
 						"system.multicall",
-						[
-							hashes
-								.map((hash) => [
-									{
-										methodName: "d.name",
-										params: [hash],
-									},
-									{
-										methodName: "d.size_bytes",
-										params: [hash],
-									},
-									{
-										methodName: "d.directory",
-										params: [hash],
-									},
-									{
-										methodName: "d.is_multi_file",
-										params: [hash],
-									},
-									{
-										methodName: "d.custom1",
-										params: [hash],
-									},
-									{
-										methodName: "f.multicall",
-										params: [
-											hash,
-											"",
-											"f.path=",
-											"f.size_bytes=",
-										],
-									},
-									{
-										methodName: "t.multicall",
-										params: [
-											hash,
-											"",
-											"t.url=",
-											"t.group=",
-										],
-									},
-								])
-								.flat(),
-						],
+						args,
 					);
 				} catch (e) {
 					logger.error({

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -1,6 +1,6 @@
 import { readdirSync, type Stats } from "fs";
 import { stat, unlink, writeFile } from "fs/promises";
-import { dirname, join, resolve, sep } from "path";
+import { basename, dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
 import xmlrpc, { Client } from "xmlrpc";
 import {
@@ -8,27 +8,40 @@ import {
 	InjectionResult,
 	TORRENT_TAG,
 } from "../constants.js";
+import { memDB } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { File, Searchee, SearcheeWithInfoHash } from "../searchee.js";
+import {
+	createSearcheeFromDB,
+	File,
+	parseTitle,
+	Searchee,
+	SearcheeClient,
+	SearcheeWithInfoHash,
+	updateSearcheeClientDB,
+} from "../searchee.js";
 import {
 	extractCredentialsFromUrl,
 	humanReadableSize,
 	isTruthy,
+	Mutex,
 	sanitizeInfoHash,
 	wait,
+	withMutex,
 } from "../utils.js";
 import {
-	TorrentMetadataInClient,
+	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
+	organizeTrackers,
 	resumeErrSleepTime,
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
+	TorrentMetadataInClient,
 } from "./TorrentClient.js";
 
 const COULD_NOT_FIND_INFO_HASH = "Could not find info-hash.";
@@ -333,14 +346,12 @@ export default class RTorrent implements TorrentClient {
 	}
 
 	async getAllDownloadDirs(options: {
-		metas: SearcheeWithInfoHash[] | Metafile[] | string[];
 		onlyCompleted: boolean;
 	}): Promise<Map<string, string>> {
-		if (options.metas.length === 0) return new Map();
-		const infoHashes: string[] =
-			typeof options.metas[0] === "string"
-				? options.metas
-				: options.metas.map((meta) => meta.infoHash);
+		const infoHashes = await this.methodCallP<string[]>(
+			"download_list",
+			[],
+		);
 		type ReturnType = string[][] | Fault[];
 		let response: ReturnType;
 		try {
@@ -353,6 +364,10 @@ export default class RTorrent implements TorrentClient {
 						},
 						{
 							methodName: "d.is_multi_file",
+							params: [hash],
+						},
+						{
+							methodName: "d.complete",
 							params: [hash],
 						},
 					])
@@ -382,15 +397,18 @@ export default class RTorrent implements TorrentClient {
 				return new Map();
 			}
 
-			return new Map(
-				infoHashes.map((hash, index) => {
-					const directory = response[index * 2][0];
-					const isMultiFile = Boolean(
-						Number(response[index * 2 + 1][0]),
+			return infoHashes.reduce((infoHashSavePathMap, hash, index) => {
+				const directory = response[index * 3][0];
+				const isMultiFile = Boolean(Number(response[index * 3 + 1][0]));
+				const isComplete = Boolean(Number(response[index * 3 + 2][0]));
+				if (!options.onlyCompleted || isComplete) {
+					infoHashSavePathMap.set(
+						hash,
+						isMultiFile ? dirname(directory) : directory,
 					);
-					return [hash, isMultiFile ? dirname(directory) : directory];
-				}),
-			);
+				}
+				return infoHashSavePathMap;
+			}, new Map<string, string>());
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,
@@ -476,6 +494,165 @@ export default class RTorrent implements TorrentClient {
 			logger.debug(e);
 			return [];
 		}
+	}
+
+	async getClientSearchees(options?: {
+		newSearcheesOnly?: boolean;
+		refresh?: string[];
+	}): Promise<ClientSearcheeResult> {
+		return withMutex(
+			Mutex.QUERY_CLIENT,
+			async () => {
+				const searchees: SearcheeClient[] = [];
+				const newSearchees: SearcheeClient[] = [];
+				const hashes = await this.methodCallP<string[]>(
+					"download_list",
+					[],
+				);
+				type ReturnType = any[][] | Fault[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+				let response: ReturnType;
+				try {
+					response = await this.methodCallP<ReturnType>(
+						"system.multicall",
+						[
+							hashes
+								.map((hash) => [
+									{
+										methodName: "d.name",
+										params: [hash],
+									},
+									{
+										methodName: "d.size_bytes",
+										params: [hash],
+									},
+									{
+										methodName: "d.directory",
+										params: [hash],
+									},
+									{
+										methodName: "d.is_multi_file",
+										params: [hash],
+									},
+									{
+										methodName: "d.custom1",
+										params: [hash],
+									},
+									{
+										methodName: "f.multicall",
+										params: [
+											hash,
+											"",
+											"f.path=",
+											"f.size_bytes=",
+										],
+									},
+									{
+										methodName: "t.multicall",
+										params: [
+											hash,
+											"",
+											"t.url=",
+											"t.group=",
+										],
+									},
+								])
+								.flat(),
+						],
+					);
+				} catch (e) {
+					logger.error({
+						Label: Label.RTORRENT,
+						message: "Failed to get torrent info for all torrents",
+					});
+					logger.debug(e);
+					return { searchees, newSearchees };
+				}
+
+				function isFault(response: ReturnType): response is Fault[] {
+					return "faultString" in response[0];
+				}
+				if (isFault(response)) {
+					logger.error({
+						Label: Label.RTORRENT,
+						message:
+							"Fault while getting torrent info for all torrents",
+					});
+					logger.debug(inspect(response));
+					return { searchees, newSearchees };
+				}
+				const infoHashes = new Set<string>();
+				for (let i = 0; i < hashes.length; i++) {
+					const infoHash = hashes[i].toLowerCase();
+					infoHashes.add(infoHash);
+					const dbTorrent = await memDB("torrent")
+						.where("info_hash", infoHash)
+						.first();
+					const refresh =
+						options?.refresh === undefined
+							? false
+							: options.refresh.length === 0
+								? true
+								: options.refresh.includes(infoHash);
+					if (dbTorrent && !refresh) {
+						if (!options?.newSearcheesOnly) {
+							searchees.push(createSearcheeFromDB(dbTorrent));
+						}
+						continue;
+					}
+					const name: string = response[i * 7][0];
+					const length = Number(response[i * 7 + 1][0]);
+					const directory: string = response[i * 7 + 2][0];
+					const isMultiFile = Boolean(Number(response[i * 7 + 3][0]));
+					const labels: string = response[i * 7 + 4][0];
+					const files: File[] = response[i * 7 + 5][0].map((arr) => ({
+						name: basename(arr[0]),
+						path: isMultiFile
+							? join(basename(directory), arr[0])
+							: arr[0],
+						length: Number(arr[1]),
+					}));
+					if (!files.length) {
+						logger.verbose({
+							label: Label.RTORRENT,
+							message: `No files found for ${name} [${sanitizeInfoHash(infoHash)}]: skipping`,
+						});
+						continue;
+					}
+					const trackers = organizeTrackers(
+						response[i * 7 + 6][0].map((arr) => ({
+							url: arr[0],
+							tier: arr[1],
+						})),
+					);
+					const title = parseTitle(name, files) ?? name;
+					const savePath = isMultiFile
+						? dirname(directory)
+						: directory;
+					const category = "";
+					const tags = labels.length
+						? decodeURIComponent(labels)
+								.split(",")
+								.map((tag) => tag.trim())
+						: [];
+					const searchee: SearcheeClient = {
+						infoHash,
+						name,
+						title,
+						files,
+						length,
+						savePath,
+						category,
+						tags,
+						trackers,
+					};
+					newSearchees.push(searchee);
+					searchees.push(searchee);
+				}
+				await updateSearcheeClientDB(newSearchees, infoHashes);
+				return { searchees, newSearchees };
+			},
+			{ useQueue: true },
+		);
 	}
 
 	async recheckTorrent(infoHash: string): Promise<void> {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -3,7 +3,7 @@ import ms from "ms";
 import { testLinking } from "../action.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
-import { Metafile } from "../parseTorrent.js";
+import { Metafile, sanitizeTrackerUrl } from "../parseTorrent.js";
 import { filterByContent } from "../preFilter.js";
 import { Result } from "../Result.js";
 import {
@@ -15,7 +15,7 @@ import {
 	VIDEO_DISC_EXTENSIONS,
 } from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
-import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
+import { Searchee, SearcheeClient, SearcheeWithInfoHash } from "../searchee.js";
 import { formatAsList, wait } from "../utils.js";
 import Deluge from "./Deluge.js";
 import QBittorrent from "./QBittorrent.js";
@@ -31,11 +31,17 @@ export type TorrentClientType =
 	| Label.TRANSMISSION
 	| Label.DELUGE;
 
+export type Tracker = { url: string; tier: number };
 export interface TorrentMetadataInClient {
 	infoHash: string;
 	category: string;
 	tags: string[];
 	trackers?: string[];
+}
+
+export interface ClientSearcheeResult {
+	searchees: SearcheeClient[];
+	newSearchees: SearcheeClient[];
 }
 
 export interface TorrentClient {
@@ -44,6 +50,16 @@ export interface TorrentClient {
 		infoHash: string,
 	) => Promise<Result<boolean, "NOT_FOUND">>;
 	getAllTorrents: () => Promise<TorrentMetadataInClient[]>;
+	/**
+	 * Get all searchees from the client and update the db
+	 * @param options.newSearcheesOnly only return searchees that are not in the db
+	 * @param options.refresh undefined uses the cache, [] refreshes all searchees, or a list of infoHashes to refresh
+	 * @return an object containing all searchees and new searchees (refreshed searchees are considered new)
+	 */
+	getClientSearchees: (options?: {
+		newSearcheesOnly?: boolean;
+		refresh?: string[];
+	}) => Promise<ClientSearcheeResult>;
 	getDownloadDir: (
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },
@@ -147,6 +163,19 @@ export async function validateClientSavePaths(
 			);
 		}
 	}
+}
+
+export function organizeTrackers(trackers: Tracker[]): string[][] {
+	return trackers
+		.reduce<string[][]>((acc, tracker) => {
+			if (tracker.tier < 0) return acc;
+			const url = sanitizeTrackerUrl(tracker.url);
+			if (!url) return acc;
+			if (!acc[tracker.tier]) acc[tracker.tier] = [];
+			acc[tracker.tier].push(url);
+			return acc;
+		}, [])
+		.filter((tier) => tier.length); // Cleanup sparse array
 }
 
 export async function waitForTorrentToComplete(

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -35,7 +35,7 @@ export interface TorrentMetadataInClient {
 	infoHash: string;
 	category: string;
 	tags: string[];
-	trackers?: string[][];
+	trackers?: string[];
 }
 
 export interface TorrentClient {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -16,7 +16,7 @@ import {
 } from "../constants.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeClient, SearcheeWithInfoHash } from "../searchee.js";
-import { formatAsList, wait } from "../utils.js";
+import { formatAsList, isTruthy, wait } from "../utils.js";
 import Deluge from "./Deluge.js";
 import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
@@ -165,17 +165,8 @@ export async function validateClientSavePaths(
 	}
 }
 
-export function organizeTrackers(trackers: Tracker[]): string[][] {
-	return trackers
-		.reduce<string[][]>((acc, tracker) => {
-			if (tracker.tier < 0) return acc;
-			const url = sanitizeTrackerUrl(tracker.url);
-			if (!url) return acc;
-			if (!acc[tracker.tier]) acc[tracker.tier] = [];
-			acc[tracker.tier].push(url);
-			return acc;
-		}, [])
-		.filter((tier) => tier.length); // Cleanup sparse array
+export function organizeTrackers(trackers: Tracker[]): string[] {
+	return trackers.map((t) => sanitizeTrackerUrl(t.url)).filter(isTruthy);
 }
 
 export async function waitForTorrentToComplete(

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -33,10 +33,8 @@ import {
 import {
 	extractCredentialsFromUrl,
 	humanReadableSize,
-	Mutex,
 	sanitizeInfoHash,
 	wait,
-	withMutex,
 } from "../utils.js";
 
 const XTransmissionSessionId = "X-Transmission-Session-Id";
@@ -274,106 +272,97 @@ export default class Transmission implements TorrentClient {
 		newSearcheesOnly?: boolean;
 		refresh?: string[];
 	}): Promise<ClientSearcheeResult> {
-		return withMutex(
-			Mutex.QUERY_CLIENT,
-			async () => {
-				const searchees: SearcheeClient[] = [];
-				const newSearchees: SearcheeClient[] = [];
-				const infoHashes = new Set<string>();
-				let torrents: TorrentGetResponseArgs["torrents"];
-				try {
-					torrents = (
-						await this.request<TorrentGetResponseArgs>(
-							"torrent-get",
-							{
-								fields: [
-									"hashString",
-									"name",
-									"files",
-									"totalSize",
-									"downloadDir",
-									"labels",
-									"trackers",
-								],
-							},
-						)
-					).torrents;
-				} catch (e) {
-					logger.error({
-						label: Label.TRANSMISSION,
-						message: "Failed to get torrents from client",
-					});
-					logger.debug(e);
-					return { searchees, newSearchees };
+		const searchees: SearcheeClient[] = [];
+		const newSearchees: SearcheeClient[] = [];
+		const infoHashes = new Set<string>();
+		let torrents: TorrentGetResponseArgs["torrents"];
+		try {
+			torrents = (
+				await this.request<TorrentGetResponseArgs>("torrent-get", {
+					fields: [
+						"hashString",
+						"name",
+						"files",
+						"totalSize",
+						"downloadDir",
+						"labels",
+						"trackers",
+					],
+				})
+			).torrents;
+		} catch (e) {
+			logger.error({
+				label: Label.TRANSMISSION,
+				message: "Failed to get torrents from client",
+			});
+			logger.debug(e);
+			return { searchees, newSearchees };
+		}
+		if (!torrents.length) {
+			logger.error({
+				label: Label.TRANSMISSION,
+				message: "No torrents found in client",
+			});
+			return { searchees, newSearchees };
+		}
+		for (const torrent of torrents) {
+			const infoHash = torrent.hashString.toLowerCase();
+			infoHashes.add(infoHash);
+			const dbTorrent = await memDB("torrent")
+				.where("info_hash", infoHash)
+				.first();
+			const refresh =
+				options?.refresh === undefined
+					? false
+					: options.refresh.length === 0
+						? true
+						: options.refresh.includes(infoHash);
+			if (dbTorrent && !refresh) {
+				if (!options?.newSearcheesOnly) {
+					searchees.push(createSearcheeFromDB(dbTorrent));
 				}
-				if (!torrents.length) {
-					logger.error({
-						label: Label.TRANSMISSION,
-						message: "No torrents found in client",
-					});
-					return { searchees, newSearchees };
-				}
-				for (const torrent of torrents) {
-					const infoHash = torrent.hashString.toLowerCase();
-					infoHashes.add(infoHash);
-					const dbTorrent = await memDB("torrent")
-						.where("info_hash", infoHash)
-						.first();
-					const refresh =
-						options?.refresh === undefined
-							? false
-							: options.refresh.length === 0
-								? true
-								: options.refresh.includes(infoHash);
-					if (dbTorrent && !refresh) {
-						if (!options?.newSearcheesOnly) {
-							searchees.push(createSearcheeFromDB(dbTorrent));
-						}
-						continue;
-					}
-					const files = torrent.files.map((file) => ({
-						name: basename(file.name),
-						path: file.name,
-						length: file.length,
-					}));
-					if (!files.length) {
-						logger.verbose({
-							label: Label.TRANSMISSION,
-							message: `No files found for ${torrent.name} [${sanitizeInfoHash(infoHash)}]: skipping`,
-						});
-						continue;
-					}
-					const trackers = organizeTrackers(
-						torrent.trackers.map((tracker) => ({
-							url: tracker.announce,
-							tier: tracker.tier,
-						})),
-					);
-					const { name } = torrent;
-					const title = parseTitle(name, files) ?? name;
-					const length = torrent.totalSize;
-					const savePath = torrent.downloadDir;
-					const category = "";
-					const tags = torrent.labels;
-					const searchee: SearcheeClient = {
-						infoHash,
-						name,
-						title,
-						files,
-						length,
-						savePath,
-						category,
-						tags,
-						trackers,
-					};
-					newSearchees.push(searchee);
-					searchees.push(searchee);
-				}
-				await updateSearcheeClientDB(newSearchees, infoHashes);
-				return { searchees, newSearchees };
-			},
-			{ useQueue: true },
-		);
+				continue;
+			}
+			const files = torrent.files.map((file) => ({
+				name: basename(file.name),
+				path: file.name,
+				length: file.length,
+			}));
+			if (!files.length) {
+				logger.verbose({
+					label: Label.TRANSMISSION,
+					message: `No files found for ${torrent.name} [${sanitizeInfoHash(infoHash)}]: skipping`,
+				});
+				continue;
+			}
+			const trackers = organizeTrackers(
+				torrent.trackers.map((tracker) => ({
+					url: tracker.announce,
+					tier: tracker.tier,
+				})),
+			);
+			const { name } = torrent;
+			const title = parseTitle(name, files) ?? name;
+			const length = torrent.totalSize;
+			const savePath = torrent.downloadDir;
+			const category = "";
+			const tags = torrent.labels;
+			const searchee: SearcheeClient = {
+				infoHash,
+				name,
+				title,
+				files,
+				length,
+				savePath,
+				category,
+				tags,
+				trackers,
+			};
+			newSearchees.push(searchee);
+			searchees.push(searchee);
+		}
+		await updateSearcheeClientDB(newSearchees, infoHashes);
+		return { searchees, newSearchees };
 	}
 
 	async recheckTorrent(infoHash: string): Promise<void> {

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -184,9 +184,9 @@ module.exports = {
 
 	/**
 	 * cross-seed will use links of this type to inject data-based matches into
-	 * your client. We recommend reading the following entry:
-	 * https://www.cross-seed.org/docs/tutorials/linking#hardlinks-vs-symlinks
-	 * Options: "symlink", "hardlink".
+	 * your client. We recommend reading the following page:
+	 * https://www.cross-seed.org/docs/tutorials/linking
+	 * Options: "symlink", "hardlink", "reflink".
 	 */
 	linkType: "hardlink",
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -438,10 +438,6 @@ export const VALIDATION_SCHEMA = z
 		return true;
 	}, "You cannot have both linkDir and linkDirs, use linkDirs only.")
 	.refine(
-		(config) => !config.useClientTorrents,
-		"useClientTorrents has not yet been implemented.",
-	)
-	.refine(
 		(config) => !config.torrentDir || !config.useClientTorrents,
 		ZodErrorMessages.torrentDirAndUseClientTorrents,
 	)

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -455,7 +455,7 @@ export const VALIDATION_SCHEMA = z
 	)
 	.refine(
 		(config) => !config.useClientTorrents || !config.delugeRpcUrl,
-		"Deluge is not supported for useClientTorrents.",
+		"Deluge does not currently support useClientTorrents, use torrentDir instead.",
 	)
 	.refine(
 		(config) =>

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -1,4 +1,11 @@
-import { existsSync, FSWatcher, readdirSync, statSync, watch } from "fs";
+import {
+	existsSync,
+	FSWatcher,
+	readdirSync,
+	readFileSync,
+	statSync,
+	watch,
+} from "fs";
 import Fuse from "fuse.js";
 import { basename, dirname, extname, join, resolve, sep } from "path";
 import { IGNORED_FOLDERS_SUBSTRINGS, VIDEO_EXTENSIONS } from "./constants.js";
@@ -48,7 +55,17 @@ export async function indexDataDirs(options: {
 				),
 			);
 		}
-		return await indexDataPaths(findSearcheesFromAllDataDirs());
+		const searcheePaths = findSearcheesFromAllDataDirs();
+		const maxUserWatchesPath = "/proc/sys/fs/inotify/max_user_watches";
+		if (existsSync(maxUserWatchesPath)) {
+			const limit = parseInt(readFileSync(maxUserWatchesPath, "utf8"));
+			if (limit < searcheePaths.length * 10) {
+				logger.error(
+					`max_user_watches too low for proper indexing of dataDirs. It is recommended to set fs.inotify.max_user_watches=1048576 in /etc/sysctl.conf (only on the host system if using docker) - current: ${limit}`,
+				);
+			}
+		}
+		return await indexDataPaths(searcheePaths);
 	}
 
 	await Promise.all(

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -51,9 +51,9 @@ export function updateMetafileMetadata(
 		metafile.tags = metadata["qBt-tags"].toString().split(",");
 	}
 	if (metadata.trackers) {
-		metafile.trackers = metadata.trackers.map((tier) =>
-			sanitizeTrackerUrls(tier),
-		);
+		metafile.trackers = metadata.trackers
+			.map((tier) => sanitizeTrackerUrls(tier))
+			.flat();
 	}
 }
 
@@ -99,7 +99,7 @@ export class Metafile {
 	isSingleFileTorrent: boolean;
 	category?: string;
 	tags?: string[];
-	trackers: string[][];
+	trackers: string[];
 	raw: Torrent;
 
 	constructor(raw: Torrent) {
@@ -162,9 +162,9 @@ export class Metafile {
 		const announceList = raw["announce-list"];
 		this.trackers =
 			Array.isArray(announceList) && announceList.length > 0
-				? announceList.map((tier) => sanitizeTrackerUrls(tier))
+				? announceList.map((tier) => sanitizeTrackerUrls(tier)).flat()
 				: raw.announce
-					? [sanitizeTrackerUrls([raw.announce])]
+					? sanitizeTrackerUrls([raw.announce])
 					: [];
 	}
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -39,7 +39,6 @@ import { isOk } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import {
 	createEnsembleSearchees,
-	createSearcheeFromMetafile,
 	createSearcheeFromPath,
 	createSearcheeFromTorrentFile,
 	File,
@@ -69,6 +68,7 @@ import {
 	getLogString,
 	humanReadableDate,
 	humanReadableSize,
+	inBatches,
 	isTruthy,
 	Mutex,
 	stripExtension,
@@ -258,11 +258,8 @@ export async function searchForLocalTorrentByCriteria(
 	const { delay, maxDataDepth, searchLimit } = getRuntimeConfig();
 
 	const rawSearchees: Searchee[] = [];
-	if (criteria.infoHash || !criteria.path) {
-		const res = createSearcheeFromMetafile(
-			await getTorrentByCriteria(criteria),
-		);
-		if (res.isOk()) rawSearchees.push(res.unwrap());
+	if (!criteria.path) {
+		rawSearchees.push(await getTorrentByCriteria(criteria));
 	} else {
 		const memoizedPaths = new Map<string, string[]>();
 		const memoizedLengths = new Map<string, number>();
@@ -338,23 +335,19 @@ async function getSearcheesForCandidate(
 	searcheeLabel: SearcheeLabel,
 ): Promise<{ searchees: SearcheeWithLabel[]; method: string } | null> {
 	const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
-	const { keys, metas, dataSearchees } = await getSimilarByName(
+	const { keys, clientSearchees, dataSearchees } = await getSimilarByName(
 		candidate.name,
 	);
 	const method = keys.length ? `[${keys}]` : "Fuse fallback";
-	if (!metas.length && !dataSearchees.length) {
+	if (!clientSearchees.length && !dataSearchees.length) {
 		logger.verbose({
 			label: searcheeLabel,
 			message: `Did not find an existing entry using ${method} for ${candidateLog}`,
 		});
 		return null;
 	}
-	const torrentSearchees = metas
-		.map(createSearcheeFromMetafile)
-		.filter(isOk)
-		.map((r) => r.unwrap());
 	const searchees = filterDupesFromSimilar(
-		[...torrentSearchees, ...dataSearchees]
+		[...clientSearchees, ...dataSearchees]
 			.map((searchee) => ({ ...searchee, label: searcheeLabel }))
 			.filter((searchee) => filterByContent(searchee)),
 	);
@@ -405,9 +398,10 @@ async function getEnsembleForCandidate(
 		acc.push({ length, name, path });
 		return acc;
 	}, []);
-	if (entriesToDelete.length) {
-		await memDB("ensemble").whereIn("path", entriesToDelete).del();
-	}
+	await inBatches(entriesToDelete, async (batch) => {
+		await memDB("data").whereIn("path", batch).del();
+		await memDB("ensemble").whereIn("path", batch).del();
+	});
 	if (files.length === 0) {
 		logger.verbose({
 			label: searcheeLabel,
@@ -530,10 +524,12 @@ export async function checkNewCandidateMatch(
 export async function findAllSearchees(
 	searcheeLabel: SearcheeLabel,
 ): Promise<SearcheeWithLabel[]> {
-	const { torrents, dataDirs, torrentDir } = getRuntimeConfig();
+	const { dataDirs, torrentDir, torrents, useClientTorrents } =
+		getRuntimeConfig();
+	const client = getClient();
 	const rawSearchees: Searchee[] = [];
 	if (Array.isArray(torrents)) {
-		const torrentInfos = (await getClient()?.getAllTorrents()) ?? [];
+		const torrentInfos = (await client?.getAllTorrents()) ?? [];
 		const searcheeResults = await Promise.all(
 			torrents.map((torrent) =>
 				createSearcheeFromTorrentFile(torrent, torrentInfos),
@@ -543,7 +539,12 @@ export async function findAllSearchees(
 			...searcheeResults.filter(isOk).map((r) => r.unwrap()),
 		);
 	} else {
-		if (torrentDir) {
+		if (useClientTorrents) {
+			const refresh = searcheeLabel === Label.SEARCH ? [] : undefined;
+			rawSearchees.push(
+				...(await client!.getClientSearchees({ refresh })).searchees,
+			);
+		} else if (torrentDir) {
 			rawSearchees.push(...(await loadTorrentDirLight(torrentDir)));
 		}
 		if (Array.isArray(dataDirs)) {
@@ -664,23 +665,23 @@ export async function main(): Promise<void> {
 }
 
 export async function scanRssFeeds() {
-	const { dataDirs, torrentDir, torznab } = getRuntimeConfig();
+	const { dataDirs, torrentDir, torznab, useClientTorrents } =
+		getRuntimeConfig();
 	await indexTorrentsAndDataDirs();
-	if (!torznab.length || (!torrentDir && !dataDirs?.length)) {
+	if (
+		!torznab.length ||
+		(!useClientTorrents && !torrentDir && !dataDirs?.length)
+	) {
 		logger.error({
 			label: Label.RSS,
 			message:
-				"RSS requires torznab and at least one of torrentDir (recommended) or dataDirs to be set",
+				"RSS requires torznab and at least one of useClientTorrents, torrentDir, or dataDirs to be set",
 		});
 		return;
 	}
 	const lastRun: number =
 		(await db("job_log").select("last_run").where({ name: "rss" }).first())
 			?.last_run ?? 0;
-	logger.verbose({
-		label: Label.RSS,
-		message: "Indexing new torrents...",
-	});
 	logger.verbose({
 		label: Label.RSS,
 		message: "Querying RSS feeds...",

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -172,9 +172,7 @@ export function findBlockedStringInReleaseMaybe(
 					? searchee.tags.includes(blocklistValue)
 					: !searchee.tags.length;
 			case BlocklistType.TRACKER:
-				return searchee.trackers?.some((tier) =>
-					tier.some((url) => url === blocklistValue),
-				);
+				return searchee.trackers?.some((url) => url === blocklistValue);
 			case BlocklistType.INFOHASH:
 				return blocklistValue === searchee.infoHash;
 			case BlocklistType.SIZE_BELOW:

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -73,7 +73,7 @@ export interface Searchee {
 	mtimeMs?: number;
 	category?: string;
 	tags?: string[];
-	trackers?: string[][];
+	trackers?: string[];
 	label?: SearcheeLabel;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,7 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 
 export enum Mutex {
+	QUERY_CLIENT = "QUERY_CLIENT",
 	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
 	CREATE_ALL_SEARCHEES = "CREATE_ALL_SEARCHEES",
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,6 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 
 export enum Mutex {
-	QUERY_CLIENT = "QUERY_CLIENT",
 	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
 	CREATE_ALL_SEARCHEES = "CREATE_ALL_SEARCHEES",
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,11 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 
-const mutexes = new Map<string, Promise<unknown>>();
+export enum Mutex {
+	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
+	CREATE_ALL_SEARCHEES = "CREATE_ALL_SEARCHEES",
+}
+const mutexes = new Map<Mutex, Promise<unknown>>();
 
 type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
 
@@ -479,13 +483,13 @@ export async function inBatches<T>(
  * @returns The result of the callback.
  */
 export async function withMutex<T>(
-	name: string,
+	name: Mutex,
 	cb: () => Promise<T>,
-	options?: { useQueue: boolean },
+	options: { useQueue: boolean },
 ): Promise<T> {
 	const existingMutex = mutexes.get(name) as Promise<T> | undefined;
 	if (existingMutex) {
-		if (options?.useQueue) {
+		if (options.useQueue) {
 			while (mutexes.has(name)) await mutexes.get(name);
 		} else {
 			return existingMutex;


### PR DESCRIPTION
Fixes: #365 

Added `useClientTorrents` which replaces `torrentDir`. They cannot both be enabled.

There is now a new type of Searchee, `SearcheeClient`. This is like `SearcheeWithInfoHash`, but has a new field `savePath` which makes linking much easier.

This change means that we now support renames in client or any modification a user can do. Right before linking, we refresh the searchee to catch any renames as the db only updates on added/deleted. All searchees are also refreshed at the start of each search cadence.

Indexing torrents and data now happens asynchronously. There is also now prevention of multiple concurrent indexes to not overload the client/disk. If an index is in progress, announce/rss/webhoook will simply wait on its completion without triggering a new one.

I think we should store the client and data indexes in the physical db to prevent any chance of memory issues. However I think that should be saved for the PR supporting multiple clients, as that implementation will affect the schema. Considering that this feature is opt-in for existing users, memDB should be fine until then. On a similar note, the indexing functions can be refactored but should be saved for then.