### PR TITLE
extract boilerplate for useClientTorrents

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -12,7 +12,6 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { loadTorrentDirLight } from "../torrent.js";
 import {
 	extractCredentialsFromUrl,
 	getLogString,
@@ -28,7 +27,6 @@ import {
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
-	validateSavePaths,
 } from "./TorrentClient.js";
 
 interface TorrentInfo {
@@ -89,11 +87,6 @@ export default class Deluge implements TorrentClient {
 				"Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir",
 			);
 		}
-		const searcheesRes = loadTorrentDirLight(torrentDir);
-		const infoHashPathMap = await this.getAllDownloadDirs({
-			onlyCompleted: false,
-		});
-		await validateSavePaths(infoHashPathMap, await searcheesRes);
 	}
 
 	/**

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -479,7 +479,7 @@ export default class QBittorrent implements TorrentClient {
 			infoHash: torrent.hash,
 			category: torrent.category,
 			tags: torrent.tags.length ? torrent.tags.split(",") : [],
-			trackers: torrent.tracker.length ? [[torrent.tracker]] : undefined,
+			trackers: torrent.tracker.length ? [torrent.tracker] : undefined,
 		}));
 	}
 

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -15,7 +15,6 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { loadTorrentDirLight } from "../torrent.js";
 import {
 	TorrentMetadataInClient,
 	getMaxRemainingBytes,
@@ -24,7 +23,6 @@ import {
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
-	validateSavePaths,
 } from "./TorrentClient.js";
 import {
 	extractCredentialsFromUrl,
@@ -168,13 +166,6 @@ export default class QBittorrent implements TorrentClient {
 				"Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir",
 			);
 		}
-		const searcheesRes = loadTorrentDirLight(torrentDir);
-		const infoHashPathMap = await this.getAllDownloadDirs({
-			metas: [], // Don't need to account for subfolder layout
-			onlyCompleted: false,
-			v1HashOnly: true,
-		});
-		await validateSavePaths(infoHashPathMap, await searcheesRes);
 	}
 
 	private async request(

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -29,9 +29,7 @@ import {
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
-	validateSavePaths,
 } from "./TorrentClient.js";
-import { loadTorrentDirLight } from "../torrent.js";
 
 const COULD_NOT_FIND_INFO_HASH = "Could not find info-hash.";
 
@@ -315,13 +313,6 @@ export default class RTorrent implements TorrentClient {
 				"Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir",
 			);
 		}
-		const searcheesRes = loadTorrentDirLight(torrentDir);
-		const allTorrents = await this.getAllTorrents();
-		const infoHashPathMap = await this.getAllDownloadDirs({
-			metas: allTorrents.map((torrent) => torrent.infoHash),
-			onlyCompleted: false,
-		});
-		await validateSavePaths(infoHashPathMap, await searcheesRes);
 	}
 
 	async getDownloadDir(

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -35,7 +35,7 @@ export interface TorrentMetadataInClient {
 	infoHash: string;
 	category: string;
 	tags: string[];
-	trackers?: string[][];
+	trackers?: string[];
 }
 
 export interface TorrentClient {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -53,6 +53,7 @@ export interface TorrentClient {
 	getAllDownloadDirs: (options: {
 		metas: SearcheeWithInfoHash[] | Metafile[];
 		onlyCompleted: boolean;
+		v1HashOnly?: boolean;
 	}) => Promise<Map<string, string>>;
 	resumeInjection: (
 		infoHash: string,
@@ -90,9 +91,9 @@ export function getClient(): TorrentClient | null {
 	return activeClient;
 }
 
-export async function validateSavePaths(
-	infoHashPathMap: Map<string, string>,
+export async function validateClientSavePaths(
 	searchees: SearcheeWithInfoHash[],
+	infoHashPathMap: Map<string, string>,
 ): Promise<void> {
 	const { linkDirs } = getRuntimeConfig();
 	logger.info(`Validating all existing torrent save paths...`);

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -10,7 +10,6 @@ import { Metafile } from "../parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "../Result.js";
 import { getRuntimeConfig } from "../runtimeConfig.js";
 import { Searchee, SearcheeWithInfoHash } from "../searchee.js";
-import { loadTorrentDirLight } from "../torrent.js";
 import {
 	TorrentMetadataInClient,
 	getMaxRemainingBytes,
@@ -19,7 +18,6 @@ import {
 	resumeSleepTime,
 	shouldRecheck,
 	TorrentClient,
-	validateSavePaths,
 } from "./TorrentClient.js";
 import {
 	extractCredentialsFromUrl,
@@ -160,11 +158,6 @@ export default class Transmission implements TorrentClient {
 				"Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir",
 			);
 		}
-		const searcheesRes = loadTorrentDirLight(torrentDir);
-		const infoHashPathMap = await this.getAllDownloadDirs({
-			onlyCompleted: false,
-		});
-		await validateSavePaths(infoHashPathMap, await searcheesRes);
 	}
 
 	async checkOriginalTorrent(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -31,7 +31,7 @@ import { serve } from "./server.js";
 import "./signalHandlers.js";
 import { doStartupValidation } from "./startup.js";
 import {
-	// indexTorrentsAndDataDirs,
+	indexTorrentsAndDataDirs,
 	parseTorrentFromFilename,
 } from "./torrent.js";
 import { fallback } from "./utils.js";
@@ -459,7 +459,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 			await validateAndSetRuntimeConfig(options);
 			await db.migrate.latest();
 			await doStartupValidation();
-			// await indexTorrentsAndDataDirs({ startup: true });
+			await indexTorrentsAndDataDirs({ startup: true });
 			serve(options.port, options.host);
 			jobsLoop();
 		} catch (e) {
@@ -475,7 +475,7 @@ createCommandWithSharedOptions("rss", "Run an rss scan").action(
 			await validateAndSetRuntimeConfig(options);
 			await db.migrate.latest();
 			await doStartupValidation();
-			// await indexTorrentsAndDataDirs({ startup: true });
+			await indexTorrentsAndDataDirs({ startup: true });
 			await scanRssFeeds();
 			await db.destroy();
 			await memDB.destroy();

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -30,9 +30,11 @@ import { createSearcheeFromMetafile } from "./searchee.js";
 import { serve } from "./server.js";
 import "./signalHandlers.js";
 import { doStartupValidation } from "./startup.js";
-import { indexEnsemble, parseTorrentFromFilename } from "./torrent.js";
+import {
+	// indexTorrentsAndDataDirs,
+	parseTorrentFromFilename,
+} from "./torrent.js";
 import { fallback } from "./utils.js";
-import { initializeDataDirs } from "./dataFiles.js";
 
 let fileConfig: FileConfig;
 try {
@@ -108,6 +110,15 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"Torznab urls with apikey included (separated by spaces)",
 			// @ts-expect-error commander supports non-string defaults
 			fallback(fileConfig.torznab),
+		)
+		.option(
+			"--use-client-torrents",
+			"Use torrents from your client for matching",
+			fallback(fileConfig.useClientTorrents, false),
+		)
+		.option(
+			"--no-use-client-torrents",
+			"Don't use torrents from your client for matching",
 		)
 		.option(
 			"--data-dirs <dirs...>",
@@ -448,8 +459,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 			await validateAndSetRuntimeConfig(options);
 			await db.migrate.latest();
 			await doStartupValidation();
-			await indexEnsemble();
-			await initializeDataDirs();
+			// await indexTorrentsAndDataDirs({ startup: true });
 			serve(options.port, options.host);
 			jobsLoop();
 		} catch (e) {
@@ -465,8 +475,7 @@ createCommandWithSharedOptions("rss", "Run an rss scan").action(
 			await validateAndSetRuntimeConfig(options);
 			await db.migrate.latest();
 			await doStartupValidation();
-			await indexEnsemble();
-			await initializeDataDirs();
+			// await indexTorrentsAndDataDirs({ startup: true });
 			await scanRssFeeds();
 			await db.destroy();
 			await memDB.destroy();

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -121,6 +121,13 @@ module.exports = {
 	 */
 
 	/**
+	 * Use the torrents already in your torrent client to find matches.
+	 * This is the preferred method of cross-seeding, only set to false
+	 * if you want to EXCLUSIVELY use dataDirs.
+	 */
+	useClientTorrents: true,
+
+	/**
 	 * Pause at least this many seconds in between each search. Higher is safer
 	 * for you and friendlier for trackers.
 	 * Minimum value of 30.
@@ -237,7 +244,7 @@ module.exports = {
 	maxDataDepth: 3,
 
 	/**
-	 * Directory containing .torrent files.
+	 * Directory containing .torrent files. This is unnecessary with useClientTorrents.
 	 * For qBittorrent, this is BT_Backup.
 	 * For rtorrent, this is your session directory as configured in your
 	 * .rtorrent.rc file.
@@ -246,7 +253,7 @@ module.exports = {
 	 *
 	 * If you are a Windows user you need to put double '\' (e.g. "C:\\torrents")
 	 */
-	torrentDir: "/path/to/torrent/file/dir",
+	torrentDir: null,
 
 	/**
 	 * Where to save the torrent files that cross-seed finds for you.

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -24,7 +24,7 @@ const ZodErrorMessages = {
 	blocklistTracker: `Blocklist tracker is not a valid URL host. If URL is https://user:pass@tracker.example.com:8080/announce/key, you must use "tracker:tracker.example.com:8080"`,
 	blocklistHash: `Blocklist hash must be 40 characters and alphanumeric`,
 	blocklistSize: `Blocklist size must be an integer for the number of bytes. You can only have one sizeBelow, one sizeAbove, and sizeBelow <= sizeAbove.`,
-	blocklistNeedsClient: `Blocklist ${BlocklistType.CATEGORY}:, ${BlocklistType.TAG}:, and ${BlocklistType.TRACKER}: requires torrentDir and a torrent client to connect to.`,
+	blocklistNeedsClient: `Blocklist ${BlocklistType.CATEGORY}:, ${BlocklistType.TAG}:, and ${BlocklistType.TRACKER}: requires torrentDir or useClientTorrents.`,
 	blocklistNeedsDataDirs: `Blocklist ${BlocklistType.FOLDER}: and ${BlocklistType.FOLDER_REGEX}: only applies to searchees from dataDirs.`,
 	vercel: "format does not follow vercel's `ms` style ( https://github.com/vercel/ms#examples )",
 	emptyString:
@@ -54,12 +54,15 @@ const ZodErrorMessages = {
 		"includeSingleEpisodes is not recommended when using announce, please read: https://www.cross-seed.org/docs/v6-migration#updated-includesingleepisodes-behavior",
 	invalidOutputDir:
 		"outputDir should only contain .torrent files, cross-seed will populate and manage (https://www.cross-seed.org/docs/basics/options#outputdir)",
-	needsInputDir:
-		"You need to set at least one of torrentDir (recommended) or dataDirs for search/rss/announce matching to work.",
+	torrentDirAndUseClientTorrents:
+		"You cannot have both torrentDir and useClientTorrents.",
+	needsClient: "You need to have a client configured for useClientTorrents.",
+	needSearchees:
+		"You need to have torrentDir, useClientTorrents or dataDirs for search/rss/announce matching to work.",
 	matchModeNeedsLinkDirs:
 		"When using action 'inject', you need to set linkDirs (and have your data accessible) for risky and partial matchMode.",
 	ensembleNeedsClient:
-		"seasonFromEpisodes requires a torrent client to connect to when using torrentDir.",
+		"seasonFromEpisodes requires a torrent client to connect to when using torrentDir or useClientTorrents.",
 	ensembleNeedsLinkDirs:
 		"When using action 'inject', you need to set linkDirs (and have your data accessible) for seasonFromEpisodes. Set seasonFromEpisodes to null to disable.",
 	ensembleNeedsPartial:
@@ -300,6 +303,7 @@ export const VALIDATION_SCHEMA = z
 			.gte(process.env.DEV ? 0 : 30, ZodErrorMessages.delayUnsupported)
 			.lte(3600, ZodErrorMessages.delayUnsupported),
 		torznab: z.array(z.string().url()),
+		useClientTorrents: z.boolean().optional().default(false),
 		dataDirs: z.array(z.string()).nullish(),
 		matchMode: z.nativeEnum(MatchMode),
 		skipRecheck: z.boolean().optional().default(true),
@@ -434,6 +438,19 @@ export const VALIDATION_SCHEMA = z
 		return true;
 	}, "You cannot have both linkDir and linkDirs, use linkDirs only.")
 	.refine(
+		(config) => !config.torrentDir || !config.useClientTorrents,
+		ZodErrorMessages.torrentDirAndUseClientTorrents,
+	)
+	.refine(
+		(config) =>
+			!config.useClientTorrents ||
+			config.qbittorrentUrl ||
+			config.delugeRpcUrl ||
+			config.transmissionRpcUrl ||
+			config.rtorrentRpcUrl,
+		ZodErrorMessages.needsClient,
+	)
+	.refine(
 		(config) =>
 			!config.searchCadence ||
 			!config.excludeRecentSearch ||
@@ -535,7 +552,7 @@ export const VALIDATION_SCHEMA = z
 		}
 		if (
 			!(
-				config.torrentDir &&
+				(config.useClientTorrents || config.torrentDir) &&
 				(config.qbittorrentUrl ||
 					config.delugeRpcUrl ||
 					config.transmissionRpcUrl ||
@@ -563,10 +580,11 @@ export const VALIDATION_SCHEMA = z
 	}, ZodErrorMessages.blocklistNeedsDataDirs)
 	.refine(
 		(config) =>
+			config.useClientTorrents ||
 			config.torrentDir ||
 			config.dataDirs?.length ||
 			(!config.rssCadence && !config.searchCadence),
-		ZodErrorMessages.needsInputDir,
+		ZodErrorMessages.needSearchees,
 	)
 	.refine(
 		(config) =>
@@ -578,7 +596,7 @@ export const VALIDATION_SCHEMA = z
 	.refine(
 		(config) =>
 			!config.seasonFromEpisodes ||
-			!config.torrentDir ||
+			(!config.torrentDir && !config.useClientTorrents) ||
 			config.qbittorrentUrl ||
 			config.delugeRpcUrl ||
 			config.transmissionRpcUrl ||

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -438,6 +438,10 @@ export const VALIDATION_SCHEMA = z
 		return true;
 	}, "You cannot have both linkDir and linkDirs, use linkDirs only.")
 	.refine(
+		(config) => !config.useClientTorrents,
+		"useClientTorrents has not yet been implemented.",
+	)
+	.refine(
 		(config) => !config.torrentDir || !config.useClientTorrents,
 		ZodErrorMessages.torrentDirAndUseClientTorrents,
 	)
@@ -449,6 +453,10 @@ export const VALIDATION_SCHEMA = z
 			config.transmissionRpcUrl ||
 			config.rtorrentRpcUrl,
 		ZodErrorMessages.needsClient,
+	)
+	.refine(
+		(config) => !config.useClientTorrents || !config.delugeRpcUrl,
+		"Deluge is not supported for useClientTorrents.",
 	)
 	.refine(
 		(config) =>

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -21,6 +21,7 @@ export interface FileConfig {
 	fuzzySizeThreshold?: number;
 	excludeOlder?: string;
 	excludeRecentSearch?: string;
+	useClientTorrents?: boolean;
 	dataDirs?: string[];
 	matchMode?: MatchMode;
 	skipRecheck?: boolean;

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -150,7 +150,7 @@ async function indexEnsembleDataEntry(
 	const { key, element, largestFile } = ensemblePieces;
 	return {
 		path: join(dirname(path), largestFile.path),
-		// info_hash: null,
+		info_hash: null,
 		ensemble: key,
 		element,
 	};

--- a/src/db.ts
+++ b/src/db.ts
@@ -22,12 +22,24 @@ export const memDB = Knex.knex({
 	connection: ":memory:",
 	useNullAsDefault: true,
 });
+await memDB.schema.createTable("torrent", (table) => {
+	table.string("info_hash").primary();
+	table.string("name");
+	table.string("title");
+	table.json("files");
+	table.integer("length");
+	table.string("save_path");
+	table.string("category");
+	table.json("tags");
+	table.json("trackers");
+});
 await memDB.schema.createTable("data", (table) => {
 	table.string("path").primary();
 	table.string("title");
 });
 await memDB.schema.createTable("ensemble", (table) => {
 	table.string("path").primary();
+	table.string("info_hash").unique();
 	table.string("ensemble");
 	table.string("element");
 });

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -51,9 +51,9 @@ export function updateMetafileMetadata(
 		metafile.tags = metadata["qBt-tags"].toString().split(",");
 	}
 	if (metadata.trackers) {
-		metafile.trackers = metadata.trackers.map((tier) =>
-			sanitizeTrackerUrls(tier),
-		);
+		metafile.trackers = metadata.trackers
+			.map((tier) => sanitizeTrackerUrls(tier))
+			.flat();
 	}
 }
 
@@ -99,7 +99,7 @@ export class Metafile {
 	isSingleFileTorrent: boolean;
 	category?: string;
 	tags?: string[];
-	trackers: string[][];
+	trackers: string[];
 	raw: Torrent;
 
 	constructor(raw: Torrent) {
@@ -162,9 +162,9 @@ export class Metafile {
 		const announceList = raw["announce-list"];
 		this.trackers =
 			Array.isArray(announceList) && announceList.length > 0
-				? announceList.map((tier) => sanitizeTrackerUrls(tier))
+				? announceList.map((tier) => sanitizeTrackerUrls(tier)).flat()
 				: raw.announce
-					? [sanitizeTrackerUrls([raw.announce])]
+					? sanitizeTrackerUrls([raw.announce])
 					: [];
 	}
 

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -40,19 +40,6 @@ interface TorrentMetadata {
 	"qBt-tags"?: Buffer;
 }
 
-function sanitizeTrackerUrls(urls: Buffer[]): string[] {
-	const sanitizeTrackerUrl = (url: string) => {
-		try {
-			return new URL(url).host;
-		} catch {
-			return null;
-		}
-	};
-	return urls
-		.map((url) => sanitizeTrackerUrl(url.toString()))
-		.filter(isTruthy);
-}
-
 export function updateMetafileMetadata(
 	metafile: Metafile,
 	metadata: TorrentMetadata,
@@ -68,6 +55,20 @@ export function updateMetafileMetadata(
 			sanitizeTrackerUrls(tier),
 		);
 	}
+}
+
+export function sanitizeTrackerUrl(url: string): string | null {
+	try {
+		return new URL(url).host;
+	} catch {
+		return null;
+	}
+}
+
+function sanitizeTrackerUrls(urls: Buffer[]): string[] {
+	return urls
+		.map((url) => sanitizeTrackerUrl(url.toString()))
+		.filter(isTruthy);
 }
 
 function sumLength(sum: number, file: { length: number }): number {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -653,6 +653,7 @@ export async function main(): Promise<void> {
 
 export async function scanRssFeeds() {
 	const { dataDirs, torrentDir, torznab } = getRuntimeConfig();
+	await indexTorrentsAndDataDirs();
 	if (!torznab.length || (!torrentDir && !dataDirs?.length)) {
 		logger.error({
 			label: Label.RSS,
@@ -668,7 +669,6 @@ export async function scanRssFeeds() {
 		label: Label.RSS,
 		message: "Indexing new torrents...",
 	});
-	await indexTorrentsAndDataDirs();
 	logger.verbose({
 		label: Label.RSS,
 		message: "Querying RSS feeds...",

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -172,9 +172,7 @@ export function findBlockedStringInReleaseMaybe(
 					? searchee.tags.includes(blocklistValue)
 					: !searchee.tags.length;
 			case BlocklistType.TRACKER:
-				return searchee.trackers?.some((tier) =>
-					tier.some((url) => url === blocklistValue),
-				);
+				return searchee.trackers?.some((url) => url === blocklistValue);
 			case BlocklistType.INFOHASH:
 				return blocklistValue === searchee.infoHash;
 			case BlocklistType.SIZE_BELOW:

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -3,6 +3,7 @@ import { Action, LinkType, MatchMode } from "./constants.js";
 export interface RuntimeConfig {
 	delay: number;
 	torznab: string[];
+	useClientTorrents: boolean;
 	dataDirs?: string[];
 	matchMode: MatchMode;
 	skipRecheck: boolean;

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -73,7 +73,7 @@ export interface Searchee {
 	mtimeMs?: number;
 	category?: string;
 	tags?: string[];
-	trackers?: string[][];
+	trackers?: string[];
 	label?: SearcheeLabel;
 }
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -115,12 +115,11 @@ async function checkConfigPaths(): Promise<void> {
 }
 
 export async function doStartupValidation(): Promise<void> {
-	const downloadClient = getClient();
 	await Promise.all<void>([
 		checkConfigPaths(),
 		validateTorznabUrls(),
 		validateUArrLs(),
-		downloadClient?.validateConfig(),
+		getClient()?.validateConfig(),
 	]);
 	logger.verbose({
 		label: Label.CONFIGDUMP,

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -35,7 +35,7 @@ import {
 import { createKeyTitle, getLogString, stripExtension } from "./utils.js";
 import {
 	getDataByFuzzyName,
-	indexDataDirs,
+	// indexDataDirs,
 	shouldIgnorePathHeuristically,
 } from "./dataFiles.js";
 
@@ -432,7 +432,7 @@ export async function indexEnsemble(): Promise<void> {
 
 export async function indexTorrentsAndDataDirs(): Promise<void> {
 	await indexNewTorrents();
-	await indexDataDirs();
+	// await indexDataDirs();
 }
 
 export async function getInfoHashesToExclude(): Promise<Set<string>> {

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -5,7 +5,11 @@ import { readdir, readFile, writeFile } from "fs/promises";
 import Fuse from "fuse.js";
 import { extname, join, resolve } from "path";
 import { inspect } from "util";
-import { getClient, TorrentMetadataInClient } from "./clients/TorrentClient.js";
+import {
+	getClient,
+	TorrentMetadataInClient,
+	validateClientSavePaths,
+} from "./clients/TorrentClient.js";
 import {
 	LEVENSHTEIN_DIVISOR,
 	MediaType,
@@ -32,10 +36,17 @@ import {
 	SearcheeWithInfoHash,
 	SearcheeWithoutInfoHash,
 } from "./searchee.js";
-import { createKeyTitle, getLogString, stripExtension } from "./utils.js";
+import {
+	createKeyTitle,
+	getLogString,
+	inBatches,
+	isTruthy,
+	stripExtension,
+	withMutex,
+} from "./utils.js";
 import {
 	getDataByFuzzyName,
-	// indexDataDirs,
+	indexDataDirs,
 	shouldIgnorePathHeuristically,
 } from "./dataFiles.js";
 
@@ -60,6 +71,7 @@ export enum SnatchError {
 
 export interface EnsembleEntry {
 	path: string;
+	info_hash: string | null;
 	ensemble: string;
 	element: string | number;
 }
@@ -278,30 +290,33 @@ export async function createEnsemblePieces(
 }
 
 async function cacheEnsembleTorrentEntry(
-	meta: Metafile,
+	searchee: SearcheeWithInfoHash,
 	torrentSavePaths?: Map<string, string>,
 ): Promise<EnsembleEntry | null> {
-	const ensemblePieces = await createEnsemblePieces(meta.title, meta.files);
+	const ensemblePieces = await createEnsemblePieces(
+		searchee.title,
+		searchee.files,
+	);
 	if (!ensemblePieces) return null;
 	const { key, element, largestFile } = ensemblePieces;
 
 	let savePath: string | undefined;
-	if (!torrentSavePaths) {
-		const downloadDirResult = await getClient()!.getDownloadDir(meta, {
+	if (torrentSavePaths) {
+		savePath = torrentSavePaths.get(searchee.infoHash);
+	} else {
+		const downloadDirResult = await getClient()!.getDownloadDir(searchee, {
 			onlyCompleted: false,
 		});
 		if (downloadDirResult.isErr()) {
 			logger.error(
-				`Failed to get download dir for ${getLogString(meta)}`,
+				`Failed to get download dir for ${getLogString(searchee)}`,
 			);
 			return null;
 		}
 		savePath = downloadDirResult.unwrap();
-	} else {
-		savePath = torrentSavePaths.get(meta.infoHash);
 	}
 	if (!savePath) {
-		logger.error(`Failed to get save path for ${getLogString(meta)}`);
+		logger.error(`Failed to get save path for ${getLogString(searchee)}`);
 		return null;
 	}
 
@@ -309,27 +324,59 @@ async function cacheEnsembleTorrentEntry(
 	// The path will get checked when rss/announce has a potential match.
 	const sourceRoot = join(
 		savePath,
-		meta.files.length === 1 ? meta.files[0].path : meta.name,
+		searchee.files.length === 1 ? searchee.files[0].path : searchee.name,
 	);
 	return {
 		path: getAbsoluteFilePath(
 			sourceRoot,
 			largestFile.path,
-			meta.files.length === 1,
+			searchee.files.length === 1,
 		),
+		info_hash: searchee.infoHash,
 		ensemble: key,
 		element,
 	};
 }
 
-async function indexNewTorrents(): Promise<void> {
-	const { seasonFromEpisodes, torrentDir } = getRuntimeConfig();
-	if (!torrentDir) return;
+async function indexTorrents(options: { startup: boolean }): Promise<void> {
+	const { seasonFromEpisodes, torrentDir, useClientTorrents } =
+		getRuntimeConfig();
+	if (!useClientTorrents && !torrentDir) return;
+	let searchees: SearcheeWithInfoHash[];
+	let infoHashPathMap: Map<string, string> | undefined;
 
-	const dirContents = new Set(await findAllTorrentFilesInDir(torrentDir));
+	if (options.startup) {
+		logger.info("Indexing torrentDir for reverse lookup...");
+		searchees = await loadTorrentDirLight(torrentDir!);
+		infoHashPathMap = await getClient()!.getAllDownloadDirs({
+			metas: searchees,
+			onlyCompleted: false,
+			v1HashOnly: true,
+		});
+		await validateClientSavePaths(searchees, { ...infoHashPathMap });
+	} else {
+		searchees = await indexTorrentDir(torrentDir!);
+	}
+	if (!seasonFromEpisodes) return;
+
+	const ensembleRows = (
+		await Promise.all(
+			searchees.map((searchee) =>
+				cacheEnsembleTorrentEntry(searchee, infoHashPathMap),
+			),
+		)
+	).filter(isTruthy);
+	await inBatches(ensembleRows, async (batch) => {
+		await memDB("ensemble").insert(batch).onConflict("path").merge();
+	});
+}
+
+async function indexTorrentDir(dir: string): Promise<SearcheeWithInfoHash[]> {
+	const dirContents = new Set(await findAllTorrentFilesInDir(dir));
 
 	// Index new torrents in the torrentDir
 	let firstNewTorrent = true;
+	const newSearchees: SearcheeWithInfoHash[] = [];
 	for (const filepath of dirContents) {
 		const doesAlreadyExist = await db("torrent")
 			.select("id")
@@ -337,10 +384,7 @@ async function indexNewTorrents(): Promise<void> {
 			.first();
 
 		if (!doesAlreadyExist) {
-			if (firstNewTorrent) {
-				logger.verbose("Indexing torrentDir due to recent changes...");
-				firstNewTorrent = false;
-			}
+			if (firstNewTorrent) firstNewTorrent = false;
 			let meta: Metafile;
 			try {
 				meta = await parseTorrentFromFilename(filepath);
@@ -359,80 +403,47 @@ async function indexNewTorrents(): Promise<void> {
 				})
 				.onConflict("file_path")
 				.ignore();
-			if (seasonFromEpisodes) {
-				const ensembleEntry = await cacheEnsembleTorrentEntry(meta);
-				if (ensembleEntry) {
-					await memDB("ensemble")
-						.insert(ensembleEntry)
-						.onConflict("path")
-						.ignore();
-				}
-			}
+			const res = await createSearcheeFromTorrentFile(filepath, []);
+			if (res.isOk()) newSearchees.push(res.unwrap());
 		}
 	}
 
 	const dbFiles = await db("torrent").select({ filePath: "file_path" });
 	const dbFilePaths: string[] = dbFiles.map((row) => row.filePath);
-
 	const filesToDelete = dbFilePaths.filter(
 		(filePath) => !dirContents.has(filePath),
 	);
-
-	const batchSize = 100;
-	for (let i = 0; i < filesToDelete.length; i += batchSize) {
-		const batch = filesToDelete.slice(i, i + batchSize);
-		if (!batch.length) break;
+	await inBatches(filesToDelete, async (batch) => {
 		await db("torrent").whereIn("file_path", batch).del();
-	}
-}
-
-export async function indexEnsemble(): Promise<void> {
-	const { seasonFromEpisodes, torrentDir } = getRuntimeConfig();
-	if (!seasonFromEpisodes || !torrentDir) return;
-
-	logger.info("Indexing ensemble for reverse lookup...");
-	const dirContents = await findAllTorrentFilesInDir(torrentDir);
-	const metas: Metafile[] = [];
-	for (const filepath of dirContents) {
-		let meta: Metafile;
-		try {
-			meta = await parseTorrentFromFilename(filepath);
-		} catch (e) {
-			logOnce(`Failed to parse ${filepath}`, () => {
-				logger.error(`Failed to parse ${filepath}`);
-				logger.debug(e);
-			});
-			continue;
-		}
-		metas.push(meta);
-	}
-	const torrentSavePaths = await getClient()!.getAllDownloadDirs({
-		metas,
-		onlyCompleted: false,
 	});
-	const ensembleRows = (
-		await Promise.allSettled(
-			metas.map((meta) =>
-				cacheEnsembleTorrentEntry(meta, torrentSavePaths),
-			),
-		)
-	).reduce<EnsembleEntry[]>((acc, result) => {
-		if (result.status === "fulfilled" && result.value) {
-			acc.push(result.value);
-		}
-		return acc;
-	}, []);
-	const batchSize = 100;
-	for (let i = 0; i < ensembleRows.length; i += batchSize) {
-		const batch = ensembleRows.slice(i, i + batchSize);
-		if (!batch.length) break;
-		await memDB("ensemble").insert(batch).onConflict("path").ignore();
-	}
+
+	return newSearchees;
 }
 
-export async function indexTorrentsAndDataDirs(): Promise<void> {
-	await indexNewTorrents();
-	// await indexDataDirs();
+export async function indexTorrentsAndDataDirs(
+	options = { startup: false },
+): Promise<void> {
+	return withMutex("indexTorrentsAndDataDirs", async () => {
+		const maxRetries = 3;
+		for (let attempt = 1; attempt <= maxRetries; attempt++) {
+			try {
+				await Promise.all([
+					indexTorrents(options),
+					indexDataDirs(options),
+				]);
+				break;
+			} catch (e) {
+				const msg = `Indexing failed (${maxRetries - attempt}): ${e.message}`;
+				if (attempt < maxRetries) {
+					logger.verbose(msg);
+				} else {
+					logger.error(msg);
+					if (options.startup) throw e;
+				}
+				logger.debug(e);
+			}
+		}
+	});
 }
 
 export async function getInfoHashesToExclude(): Promise<Set<string>> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,11 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
 
-const mutexes = new Map<string, Promise<unknown>>();
+export enum Mutex {
+	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
+	CREATE_ALL_SEARCHEES = "CREATE_ALL_SEARCHEES",
+}
+const mutexes = new Map<Mutex, Promise<unknown>>();
 
 type Truthy<T> = T extends false | "" | 0 | null | undefined ? never : T; // from lodash
 
@@ -479,13 +483,13 @@ export async function inBatches<T>(
  * @returns The result of the callback.
  */
 export async function withMutex<T>(
-	name: string,
+	name: Mutex,
 	cb: () => Promise<T>,
-	options?: { useQueue: boolean },
+	options: { useQueue: boolean },
 ): Promise<T> {
 	const existingMutex = mutexes.get(name) as Promise<T> | undefined;
 	if (existingMutex) {
-		if (options?.useQueue) {
+		if (options.useQueue) {
 			while (mutexes.has(name)) await mutexes.get(name);
 		} else {
 			return existingMutex;


### PR DESCRIPTION
One thing of note is moving the indexing to as early as possible for rss/webhook/announce. This is to better take advantage of preventing simultaneous indexing.