### PR TITLE
fix(decide/cache): don't update db if snatch already exists

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -50,6 +50,7 @@ import {
 export interface ResultAssessment {
 	decision: Decision;
 	metafile?: Metafile;
+	metaCached?: boolean;
 }
 
 function logDecision(
@@ -327,10 +328,13 @@ export async function assessCandidate(
 		}
 	}
 
+	let metaCached = !isCandidate;
+
 	if (findBlockedStringInReleaseMaybe(searchee, blockList)) {
 		return {
 			decision: Decision.BLOCKED_RELEASE,
 			metafile: !isCandidate ? metaOrCandidate : undefined,
+			metaCached,
 		};
 	}
 
@@ -356,22 +360,26 @@ export async function assessCandidate(
 			}
 		}
 		metafile = res.unwrap();
-		cacheTorrentFile(metafile);
+		metaCached = cacheTorrentFile(metafile);
 		metaOrCandidate.size = metafile.length; // Trackers can be wrong
 	} else {
 		metafile = metaOrCandidate;
 	}
 
 	if (searchee.infoHash === metafile.infoHash) {
-		return { decision: Decision.SAME_INFO_HASH, metafile };
+		return { decision: Decision.SAME_INFO_HASH, metafile, metaCached };
 	}
 
 	if (infoHashesToExclude.has(metafile.infoHash)) {
-		return { decision: Decision.INFO_HASH_ALREADY_EXISTS, metafile };
+		return {
+			decision: Decision.INFO_HASH_ALREADY_EXISTS,
+			metafile,
+			metaCached,
+		};
 	}
 
 	if (findBlockedStringInReleaseMaybe(metafile, blockList)) {
-		return { decision: Decision.BLOCKED_RELEASE, metafile };
+		return { decision: Decision.BLOCKED_RELEASE, metafile, metaCached };
 	}
 
 	// Prevent candidate episodes from matching searchee season packs
@@ -380,17 +388,17 @@ export async function assessCandidate(
 		SEASON_REGEX.test(searchee.title) &&
 		isSingleEpisode(metafile, getMediaType(metafile))
 	) {
-		return { decision: Decision.FILE_TREE_MISMATCH, metafile };
+		return { decision: Decision.FILE_TREE_MISMATCH, metafile, metaCached };
 	}
 
 	const perfectMatch = compareFileTrees(metafile, searchee);
 	if (perfectMatch) {
-		return { decision: Decision.MATCH, metafile };
+		return { decision: Decision.MATCH, metafile, metaCached };
 	}
 
 	const sizeMatch = compareFileTreesIgnoringNames(metafile, searchee);
 	if (sizeMatch && matchMode !== MatchMode.SAFE) {
-		return { decision: Decision.MATCH_SIZE_ONLY, metafile };
+		return { decision: Decision.MATCH_SIZE_ONLY, metafile, metaCached };
 	}
 
 	if (matchMode === MatchMode.PARTIAL) {
@@ -398,17 +406,21 @@ export async function assessCandidate(
 			getPartialSizeRatio(metafile, searchee) >=
 			getMinSizeRatio(searchee);
 		if (!partialSizeMatch) {
-			return { decision: Decision.PARTIAL_SIZE_MISMATCH, metafile };
+			return {
+				decision: Decision.PARTIAL_SIZE_MISMATCH,
+				metafile,
+				metaCached,
+			};
 		}
 		const partialMatch = compareFileTreesPartial(metafile, searchee);
 		if (partialMatch) {
-			return { decision: Decision.MATCH_PARTIAL, metafile };
+			return { decision: Decision.MATCH_PARTIAL, metafile, metaCached };
 		}
 	} else if (!sizeMatch) {
-		return { decision: Decision.SIZE_MISMATCH, metafile };
+		return { decision: Decision.SIZE_MISMATCH, metafile, metaCached };
 	}
 
-	return { decision: Decision.FILE_TREE_MISMATCH, metafile };
+	return { decision: Decision.FILE_TREE_MISMATCH, metafile, metaCached };
 }
 
 function existsInTorrentCache(infoHash: string): boolean {
@@ -446,14 +458,15 @@ async function getCachedTorrentFile(
 	}
 }
 
-function cacheTorrentFile(meta: Metafile): void {
+function cacheTorrentFile(meta: Metafile): boolean {
 	const torrentPath = path.join(
 		appDir(),
 		TORRENT_CACHE_FOLDER,
 		`${meta.infoHash}.cached.torrent`,
 	);
-	if (existsInTorrentCache(meta.infoHash)) return;
+	if (existsInTorrentCache(meta.infoHash)) return false;
 	writeFileSync(torrentPath, meta.encode());
+	return true;
 }
 
 async function assessAndSaveResults(
@@ -470,7 +483,7 @@ async function assessAndSaveResults(
 		infoHashesToExclude,
 	);
 
-	if (assessment.metafile) {
+	if (assessment.metaCached && assessment.metafile) {
 		guidInfoHashMap.set(guid, assessment.metafile.infoHash);
 		await db.transaction(async (trx) => {
 			const { id } = await trx("searchee")

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -7,6 +7,7 @@ import { Label, logger } from "./logger.js";
 import { main, scanRssFeeds } from "./pipeline.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { updateCaps } from "./torznab.js";
+import { cleanupTorrentCache } from "./decide.js";
 
 class Job {
 	name: string;
@@ -50,6 +51,7 @@ function getJobs(): Job[] {
 	if (action === Action.INJECT) {
 		jobs.push(new Job("inject", ms("1 hour"), injectSavedTorrents));
 	}
+	jobs.push(new Job("cleanup", ms("1 day"), cleanupTorrentCache));
 	return jobs;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -458,3 +458,13 @@ export function findAFileWithExt(dir: string, exts: string[]): string | null {
 	}
 	return null;
 }
+
+export async function inBatches<T>(
+	items: T[],
+	cb: (batch: T[]) => Promise<void>,
+	batchSize = 100,
+): Promise<void> {
+	for (let i = 0; i < items.length; i += batchSize) {
+		await cb(items.slice(i, i + batchSize));
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -458,13 +458,3 @@ export function findAFileWithExt(dir: string, exts: string[]): string | null {
 	}
 	return null;
 }
-
-export async function inBatches<T>(
-	items: T[],
-	cb: (batch: T[]) => Promise<void>,
-	batchSize = 100,
-): Promise<void> {
-	for (let i = 0; i < items.length; i += batchSize) {
-		await cb(items.slice(i, i + batchSize));
-	}
-}


### PR DESCRIPTION
The goal is to prevent matching guid to a cached torrent from another tracker if the infoHash is the same. This can cause a torrent to be injected with the wrong save path with `flatLinking: false` and incorrect tracker logging. The torrents from these two trackers would not be able to coexist in client regardless so first come first served is fine.

This prevents caching the guid in the db if we try to snatch but the infoHash already exists in the cache. It already won't overwrite the existing file and only update the last access time. Now it also won't cache this result in the database. This should only happen in these scenarios:
- This bug
- If the user has deleted the config.db without deleting the torrent_cache
- Any more trackers that benefit from fuzzy lookups that we haven't covered

This does not affect the guid (or fuzzy guid) lookups that we already cover. It's only when that check fails and we try to snatch the candidate.

The 2nd commit is to clean up old cached entries after a year past the last access time which was previously rejected when the caching was implemented. However it would now benefit the first two use cases above aside from just cleaning up space. It also serves to correct this issue for current users over time.

Since the access time is updated each time we check if it exists (so using the cache or trying to snatch), the timing of cleanup is a year after the torrent is unregistered or a year after `excludeOlder`, whichever comes first. It's currently being done before caching a torrent file as timing could matter.

We could also include the guid along with the infoHash when saving. But it doesn't really seem worth changing it since only one can exist in client and having to deal with existing user migrations.