### PR TITLE
fix(action/linking): trim tracker to match qbit behavior

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -25,10 +25,16 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 
 const ANNOUNCE_SCHEMA = z
 	.object({
-		name: z.string().refine((name) => name.trim().length > 0),
+		name: z
+			.string()
+			.transform((name) => name.trim())
+			.refine((name) => name.length > 0),
 		guid: z.string().url(),
 		link: z.string().url(),
-		tracker: z.string().refine((tracker) => tracker.trim().length > 0),
+		tracker: z
+			.string()
+			.transform((tracker) => tracker.trim())
+			.refine((tracker) => tracker.length > 0),
 	})
 	.strict()
 	.required()

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -131,11 +131,12 @@ function parseTorznabResults(xml: TorznabResults): Candidate[] {
 	return items.map((item) => ({
 		guid: item.guid[0],
 		name: item.title[0],
-		tracker:
+		tracker: (
 			item?.prowlarrindexer?.[0]?._ ??
 			item?.jackettindexer?.[0]?._ ??
 			item?.indexer?.[0]?._ ??
-			UNKNOWN_TRACKER,
+			UNKNOWN_TRACKER
+		).trim(),
 		link: item.link[0],
 		size: Number(item.size[0]),
 		pubDate: new Date(item.pubDate[0]).getTime(),


### PR DESCRIPTION
If a user has trailing white space in the Prowlarr indexer names, `flatLinking: false` will preserve this when linking but qBittorrent trims the savePath when being injected.