### PR TITLE
enhancement(decide): check release version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,8 +26,8 @@ export const RESOLUTION_REGEX = /\b(?<res>\d{3,4}[pix](?:\d{3,4}[pi]?)?)\b/i;
 export const RES_STRICT_REGEX = /(?<res>(?:2160|1080|720)[pi])/;
 export const YEARS_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/gi;
 export const REPACK_PROPER_REGEX =
-	/(?:\b(?<type>(?:REPACK|PROPER|\d\v\d)\d?))\b/i;
-export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|v\d)))\b/;
+	/(?:\b(?<type>(?:REPACK|PROPER|\dv\d)\d?))\b/i;
+export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|\dv\d)))\b/;
 export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{0,5}-)?(?<title>.*)/;
 export const ARR_DIR_REGEX =
 	/^(?<title>(?!.*(?:(\d{3,4}[ipx])|([xh.]+26[4-6])|(dvd)|(mpeg)|(xvid)|(?:(he)|a)vc))[\p{L}\s:\w'’!();.,&–+-]+(?:\(\d{4}\))?)(?<id>\s[{[](?:tm|tv|im)db(?:id)?-\w+?[}\]])?$/iu;

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -299,6 +299,18 @@ function sourceDoesMatch(searcheeTitle: string, candidateName: string) {
 	return searcheeSource === candidateSource;
 }
 
+function releaseVersionDoesMatch(searcheeName: string, candidateName: string) {
+	const searcheeVersionType = stripExtension(searcheeName)
+		.match(REPACK_PROPER_REGEX)
+		?.groups?.type?.trim()
+		?.toLowerCase();
+	const candidateVersionType = stripExtension(candidateName)
+		.match(REPACK_PROPER_REGEX)
+		?.groups?.type?.trim()
+		?.toLowerCase();
+	return searcheeVersionType === candidateVersionType;
+}
+
 export async function assessCandidate(
 	metaOrCandidate: Metafile | Candidate,
 	searchee: SearcheeWithLabel,
@@ -319,6 +331,9 @@ export async function assessCandidate(
 		}
 		if (!sourceDoesMatch(searchee.title, name)) {
 			return { decision: Decision.SOURCE_MISMATCH };
+		}
+		if (!releaseVersionDoesMatch(searchee.title, name)) {
+			return { decision: Decision.PROPER_REPACK_MISMATCH };
 		}
 		const size = metaOrCandidate.size;
 		if (size && !fuzzySizeDoesMatch(size, searchee)) {


### PR DESCRIPTION
I've readded the repack check which was removed in #707 due to decision cache. Since we are no longer caching decisions without snatches, this no longer applies.

Previously, this would only fail if the user was in safe mode, it can now fail in all modes. It's also no longer checking the `ARR_PROPER_REGEX` as this is a subset of the main regex. The searchee and candidate must now share the same version or both be missing.

This will increase the false negatives as some places don't correctly tag repack status, but a few repacks have been seen with the same size. Since repacks are rare, this should be a fine tradeoff for safety.