### PR TITLE
logging(dataDirs): warn users with low max watches

### DIFF
--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -28,7 +28,7 @@ export async function indexDataDirs(options: {
 	startup: boolean;
 }): Promise<void> {
 	const { dataDirs, maxDataDepth } = getRuntimeConfig();
-	if (!dataDirs?.length) return;
+	if (!dataDirs.length) return;
 
 	if (options.startup) {
 		logger.info("Indexing dataDirs for reverse lookup...");
@@ -239,7 +239,7 @@ export function findPotentialNestedRoots(
 
 export function findSearcheesFromAllDataDirs(): string[] {
 	const { dataDirs, maxDataDepth } = getRuntimeConfig();
-	return dataDirs!.flatMap((dataDir) =>
+	return dataDirs.flatMap((dataDir) =>
 		readdirSync(dataDir)
 			.map((dirent) => join(dataDir, dirent))
 			.flatMap((path) => findPotentialNestedRoots(path, maxDataDepth)),

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -547,7 +547,7 @@ export async function findAllSearchees(
 		} else if (torrentDir) {
 			rawSearchees.push(...(await loadTorrentDirLight(torrentDir)));
 		}
-		if (Array.isArray(dataDirs)) {
+		if (dataDirs.length) {
 			const memoizedPaths = new Map<string, string[]>();
 			const memoizedLengths = new Map<string, number>();
 			const searcheeResults = await Promise.all(
@@ -670,7 +670,7 @@ export async function scanRssFeeds() {
 	await indexTorrentsAndDataDirs();
 	if (
 		!torznab.length ||
-		(!useClientTorrents && !torrentDir && !dataDirs?.length)
+		(!useClientTorrents && !torrentDir && !dataDirs.length)
 	) {
 		logger.error({
 			label: Label.RSS,

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -4,7 +4,7 @@ export interface RuntimeConfig {
 	delay: number;
 	torznab: string[];
 	useClientTorrents: boolean;
-	dataDirs?: string[];
+	dataDirs: string[];
 	matchMode: MatchMode;
 	skipRecheck: boolean;
 	autoResumeMaxDownload: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -264,7 +264,7 @@ async function announce(
 	const candidate = data as Candidate;
 	const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
 	try {
-		if (!useClientTorrents && !torrentDir && !dataDirs?.length) {
+		if (!useClientTorrents && !torrentDir && !dataDirs.length) {
 			throw new Error(
 				`Announce requires at least one of useClientTorrents, torrentDir, or dataDirs to be set`,
 			);

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -78,11 +78,9 @@ async function checkConfigPaths(): Promise<void> {
 			pathFailure++;
 		}
 	}
-	if (dataDirs) {
-		for (const dataDir of dataDirs) {
-			if (!(await verifyPath(dataDir, "dataDirs", READ_ONLY))) {
-				pathFailure++;
-			}
+	for (const dataDir of dataDirs) {
+		if (!(await verifyPath(dataDir, "dataDirs", READ_ONLY))) {
+			pathFailure++;
 		}
 	}
 	if (injectDir) {
@@ -94,7 +92,7 @@ async function checkConfigPaths(): Promise<void> {
 			pathFailure++;
 		}
 	}
-	if (linkDirs.length && dataDirs) {
+	if (linkDirs.length) {
 		for (const dataDir of dataDirs) {
 			try {
 				testLinking(dataDir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -451,6 +451,23 @@ export async function* combineAsyncIterables<T>(
 	return;
 }
 
+export function countDirEntriesRec(
+	dirs: string[],
+	maxDataDepth: number,
+): number {
+	if (maxDataDepth === 0) return 0;
+	let count = 0;
+	for (const dir of dirs) {
+		const newDirs: string[] = [];
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			count++;
+			if (entry.isDirectory()) newDirs.push(path.join(dir, entry.name));
+		}
+		count += countDirEntriesRec(newDirs, maxDataDepth - 1);
+	}
+	return count;
+}
+
 export function findAFileWithExt(dir: string, exts: string[]): string | null {
 	const entries = readdirSync(dir, { withFileTypes: true });
 	for (const entry of entries) {


### PR DESCRIPTION
`fs.watch` recursively creates watchers on linux. This limit can be reached depending on user configuration. For docker containers, it's simply read from the host system. This will warn users if their limit could be an issue with the amount of files in dataDirs to watch.

Also converting nullish dataDirs into an empty array to match other config options.