### PR TITLE
enhancement(webhook): ability to override certain config options

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -29,7 +29,7 @@ import {
 	isSingleEpisode,
 } from "./preFilter.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
-import { getRuntimeConfig } from "./runtimeConfig.js";
+import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import {
 	File,
 	getReleaseGroup,
@@ -60,8 +60,9 @@ function logDecision(
 	decision: Decision,
 	metafile: Metafile | undefined,
 	tracker: string,
+	options?: { configOverride: Partial<RuntimeConfig> },
 ): void {
-	const { blockList, matchMode } = getRuntimeConfig();
+	const { blockList, matchMode } = getRuntimeConfig(options?.configOverride);
 
 	let reason: string;
 	switch (decision) {
@@ -315,8 +316,11 @@ export async function assessCandidate(
 	metaOrCandidate: Metafile | Candidate,
 	searchee: SearcheeWithLabel,
 	infoHashesToExclude: Set<string>,
+	options?: { configOverride: Partial<RuntimeConfig> },
 ): Promise<ResultAssessment> {
-	const { blockList, includeSingleEpisodes, matchMode } = getRuntimeConfig();
+	const { blockList, includeSingleEpisodes, matchMode } = getRuntimeConfig(
+		options?.configOverride,
+	);
 
 	// When metaOrCandidate is a Metafile, skip straight to the
 	// main matching algorithms as we don't need pre-download filtering.
@@ -506,11 +510,13 @@ async function assessAndSaveResults(
 	infoHashesToExclude: Set<string>,
 	firstSeen: number,
 	guidInfoHashMap: Map<string, string>,
+	options?: { configOverride: Partial<RuntimeConfig> },
 ) {
 	const assessment = await assessCandidate(
 		metaOrCandidate,
 		searchee,
 		infoHashesToExclude,
+		options,
 	);
 
 	if (assessment.metaCached && assessment.metafile) {
@@ -581,6 +587,7 @@ export async function assessCandidateCaching(
 	searchee: SearcheeWithLabel,
 	infoHashesToExclude: Set<string>,
 	guidInfoHashMap: Map<string, string>,
+	options?: { configOverride: Partial<RuntimeConfig> },
 ): Promise<ResultAssessment> {
 	const { name, guid, link, tracker } = candidate;
 
@@ -629,6 +636,7 @@ export async function assessCandidateCaching(
 			infoHashesToExclude,
 			cacheEntry?.firstSeen ?? Date.now(),
 			guidInfoHashMap,
+			options,
 		);
 	}
 
@@ -638,6 +646,7 @@ export async function assessCandidateCaching(
 		assessment.decision,
 		assessment.metafile,
 		tracker,
+		options,
 	);
 
 	return assessment;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -285,7 +285,7 @@ export async function searchForLocalTorrentByCriteria(
 		...searchee,
 		label: Label.WEBHOOK,
 	}));
-	const includeEpisodes = searchees.length === 1;
+	const allowSeasonPackEpisodes = searchees.length === 1;
 	const infoHashesToExclude = await getInfoHashesToExclude();
 	const indexerSearchCount = new Map<number, number>();
 	let totalFound = 0;
@@ -297,7 +297,7 @@ export async function searchForLocalTorrentByCriteria(
 			if (
 				!filterByContent(searchee, {
 					configOverride: options.configOverride,
-					includeEpisodes,
+					allowSeasonPackEpisodes,
 					ignoreCrossSeeds: options.ignoreCrossSeeds,
 				})
 			) {

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -85,7 +85,7 @@ export function filterByContent(
 	searchee: SearcheeWithLabel,
 	options?: {
 		configOverride: Partial<RuntimeConfig>;
-		includeEpisodes: boolean;
+		allowSeasonPackEpisodes: boolean;
 		ignoreCrossSeeds: boolean;
 	},
 ): boolean {
@@ -109,7 +109,7 @@ export function filterByContent(
 	}
 
 	if (
-		(!options?.includeEpisodes || !includeSingleEpisodes) &&
+		(!options?.allowSeasonPackEpisodes || !includeSingleEpisodes) &&
 		searchee.path &&
 		searchee.files.length === 1 &&
 		[Label.SEARCH, Label.WEBHOOK].includes(searchee.label) &&

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -10,11 +10,13 @@ import {
 	BlocklistType,
 	parseBlocklistEntry,
 	VIDEO_EXTENSIONS,
+	TORRENT_TAG,
+	TORRENT_CATEGORY_SUFFIX,
 } from "./constants.js";
 import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
-import { getRuntimeConfig } from "./runtimeConfig.js";
+import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import {
 	getSearcheeNewestFileAge,
 	Searchee,
@@ -39,10 +41,18 @@ function logReason(
 	searchee: Searchee,
 	mediaType: MediaType,
 ): void {
-	logger.verbose({
-		label: Label.PREFILTER,
-		message: `${getLogString(searchee)} | MediaType: ${mediaType.toUpperCase()} - was not selected for searching because ${reason}`,
-	});
+	const message = `${getLogString(searchee)} | MediaType: ${mediaType.toUpperCase()} - ${reason}`;
+	if (searchee.label === Label.WEBHOOK) {
+		logger.info({
+			label: Label.WEBHOOK,
+			message: `Did not search for ${message}`,
+		});
+	} else {
+		logger.verbose({
+			label: Label.PREFILTER,
+			message,
+		});
+	}
 }
 
 export function isSingleEpisode(
@@ -59,16 +69,32 @@ export function isSingleEpisode(
 	// To check arrs use: return parsedMedia?.episodes?.length === 1, uncomment above
 }
 
+function isCrossSeed(searchee: Searchee): boolean {
+	const { linkCategory } = getRuntimeConfig();
+	if (linkCategory?.length && searchee.category === linkCategory) return true; // qBit, Deluge
+	if (searchee.category === TORRENT_TAG) return true; // Deluge
+	if (searchee.category?.endsWith(TORRENT_CATEGORY_SUFFIX)) return true; // qBit, Deluge
+	if (searchee.tags?.includes(TORRENT_TAG)) return true; // qBit, rTorrent, Transmission
+	if (searchee.tags?.some((tag) => tag.endsWith(TORRENT_CATEGORY_SUFFIX))) {
+		return true; // qBit
+	}
+	return false;
+}
+
 export function filterByContent(
 	searchee: SearcheeWithLabel,
-	includeEpisodes?: boolean,
+	options?: {
+		configOverride: Partial<RuntimeConfig>;
+		includeEpisodes: boolean;
+		ignoreCrossSeeds: boolean;
+	},
 ): boolean {
 	const {
 		fuzzySizeThreshold,
 		includeNonVideos,
 		includeSingleEpisodes,
 		blockList,
-	} = getRuntimeConfig();
+	} = getRuntimeConfig(options?.configOverride);
 
 	const mediaType = getMediaType(searchee);
 
@@ -83,7 +109,7 @@ export function filterByContent(
 	}
 
 	if (
-		(!includeEpisodes || !includeSingleEpisodes) &&
+		(!options?.includeEpisodes || !includeSingleEpisodes) &&
 		searchee.path &&
 		searchee.files.length === 1 &&
 		[Label.SEARCH, Label.WEBHOOK].includes(searchee.label) &&
@@ -119,6 +145,11 @@ export function filterByContent(
 			searchee,
 			mediaType,
 		);
+		return false;
+	}
+
+	if (options?.ignoreCrossSeeds && isCrossSeed(searchee)) {
+		logReason("it is a cross seed", searchee, mediaType);
 		return false;
 	}
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -49,6 +49,13 @@ export function setRuntimeConfig(configObj: RuntimeConfig): void {
 	runtimeConfig = configObj;
 }
 
-export function getRuntimeConfig(): RuntimeConfig {
-	return runtimeConfig;
+export function getRuntimeConfig(
+	configOverride: Partial<RuntimeConfig> = {},
+): RuntimeConfig {
+	return {
+		...runtimeConfig,
+		...Object.fromEntries(
+			Object.entries(configOverride).filter(([, v]) => v !== undefined),
+		),
+	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,9 +259,11 @@ export const tap = (fn) => (value) => {
 	return value;
 };
 
-export async function filterAsync(arr, predicate) {
+export async function filterAsync<T>(
+	arr: T[],
+	predicate: (e: T) => Promise<boolean>,
+): Promise<T[]> {
 	const results = await Promise.all(arr.map(predicate));
-
 	return arr.filter((_, index) => results[index]);
 }
 


### PR DESCRIPTION
Fixes #869

This `getRuntimeConfig()` now takes `configOverride: Partial<RuntimeConfig> = {}` to override config values for that call. This is used by these webhook params.

The primary use for `webhook` is to immediately trigger a search on download completion. Any other automation should be handled by `searchCadence`. As such, we should default to config options but allow overwriting a few notable ones.

The docs should also be updated with overriding `includeSingleEpisodes` being a valid alternative for download completion as they are unlikely to have been trumped by a season pack.

`curl -XPOST <BASE_URL>/api/webhook?apikey=<API_KEY> -d "infoHash=%I" -d "includeSingleEpisodes=true"`

Additionally, I think `webhook` should ignore torrents with the `cross-seed` tag by default, in service of the primary use. Currently, lots of wasted searches are triggered from partial matches completing which we now have the opportunity to rectify.

Respecting excludes and ignoring the `cross-seed` tag is slightly breaking but doesn't affect the primary use. The main concern is any current automation being used as a replacement for `searchCadence` which of course is not recommended anyways. Users running the command manually in one off situations should receive instant feedback with the change.