### PR TITLE
enhancement(linkType): support reflink

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -208,6 +208,7 @@ export enum MatchMode {
 export enum LinkType {
 	SYMLINK = "symlink",
 	HARDLINK = "hardlink",
+	REFLINK = "reflink",
 }
 
 export enum BlocklistType {


### PR DESCRIPTION
Fixes: #421

`reflink`does nothing for partial matches which the original issue seemed to misunderstand. The only benefit to cross-seed (aside from user preference), is better handling the rare corrupted cross seeds. The main downside of reflink is the delayed performance impact to when writes are requested rather than on creation, which is irrelevant in the context of seeding.

With the testing at startup and checking for the same `stat.dev` (#835, #861), we can add `reflink` without any unintented side effects while checking if the user system supports it. There could be an argument made to not require the same `stat.dev` but then this opens up `cross-seed` to straight up copying the data. I think we should wait until a valid use case is presented then add it as a new `LinkType` that uses `COPYFILE_FICLONE` which will fallback to copying. We could also fallback to hardlink/symlink but I'm not sure a user base for that exists either.