### PR TITLE
fix(torrentDir): support torrentDir without client if action save

### DIFF
--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -109,10 +109,11 @@ export function getClient(): TorrentClient | null {
 
 export async function validateClientSavePaths(
 	searchees: SearcheeWithInfoHash[],
-	infoHashPathMap: Map<string, string>,
+	infoHashPathMapOrig: Map<string, string>,
 ): Promise<void> {
 	const { linkDirs } = getRuntimeConfig();
 	logger.info(`Validating all existing torrent save paths...`);
+	const infoHashPathMap = new Map(infoHashPathMapOrig);
 
 	const entryDir = searchees.find((s) => !infoHashPathMap.has(s.infoHash));
 	if (entryDir) {

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -502,6 +502,14 @@ export const VALIDATION_SCHEMA = z
 		ZodErrorMessages.seasonFromEpisodesMin,
 	)
 	.refine((config) => {
+		if (config.action === Action.SAVE && config.linkDirs.length) {
+			logger.error(
+				`You cannot use action 'save' with linkDirs, use 'inject' for cross-seed to perform linking.`,
+			);
+		}
+		return true;
+	})
+	.refine((config) => {
 		if (
 			config.action === Action.INJECT &&
 			config.qbittorrentUrl &&


### PR DESCRIPTION
Fixes #890

The refactoring of how torrents are indexed broke this use case since it wasn't explicitly defined. I verified this configuration and there should be no issues.

I also added an extra config check for `action: save` with linkDirs defined.