### PR TITLE
enhancement(decide): treat repack and proper the same

### DIFF
--- a/src/decide.ts
+++ b/src/decide.ts
@@ -301,15 +301,10 @@ function sourceDoesMatch(searcheeTitle: string, candidateName: string) {
 }
 
 function releaseVersionDoesMatch(searcheeName: string, candidateName: string) {
-	const searcheeVersionType = stripExtension(searcheeName)
-		.match(REPACK_PROPER_REGEX)
-		?.groups?.type?.trim()
-		?.toLowerCase();
-	const candidateVersionType = stripExtension(candidateName)
-		.match(REPACK_PROPER_REGEX)
-		?.groups?.type?.trim()
-		?.toLowerCase();
-	return searcheeVersionType === candidateVersionType;
+	return (
+		REPACK_PROPER_REGEX.test(searcheeName) ===
+		REPACK_PROPER_REGEX.test(candidateName)
+	);
 }
 
 export async function assessCandidate(


### PR DESCRIPTION
We can't rely on REPACK/PROPER consistency between trackers and with data. The check is reduced to if it's a re-release rather than a specific re-release.