### PR TITLE
feat(cmd): add cmd to update torrent_cache trackers

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,11 +1,7 @@
-import bencode from "bencode";
 import { readFile, rename } from "fs/promises";
 import path from "path";
 import { appDir, createAppDir } from "./configuration.js";
-import { Decision, TORRENT_CACHE_FOLDER } from "./constants.js";
-import { findAllTorrentFilesInDir } from "./torrent.js";
-import { writeFileSync } from "fs";
-import { Torrent } from "./parseTorrent.js";
+import { Decision } from "./constants.js";
 
 createAppDir();
 
@@ -46,56 +42,4 @@ export async function renameCacheFile(): Promise<void> {
 		path.join(appDir(), "cache.json"),
 		path.join(appDir(), "old-cache.bak.json"),
 	);
-}
-
-export async function updateTorrentCache(
-	oldUrl: string,
-	newUrl: string,
-): Promise<void> {
-	const torrentFilePaths = await findAllTorrentFilesInDir(
-		path.join(appDir(), TORRENT_CACHE_FOLDER),
-	);
-	console.log(
-		`Found ${torrentFilePaths.length} torrent files in cache, processing...`,
-	);
-	let count = 0;
-	for (const filePath of torrentFilePaths) {
-		try {
-			const torrent: Torrent = bencode.decode(await readFile(filePath));
-			const announce = torrent.announce?.toString();
-			const announceList = torrent["announce-list"]?.map((tier) =>
-				tier.map((url) => url.toString()),
-			);
-			if (
-				announce?.includes(oldUrl) ||
-				announceList?.some((t) => t.some((url) => url.includes(oldUrl)))
-			) {
-				count++;
-				console.log(`#${count}: ${filePath}`);
-				let updated = false;
-				if (announce) {
-					const newAnnounce = announce.replace(oldUrl, newUrl);
-					if (announce !== newAnnounce) {
-						updated = true;
-						console.log(`--- ${announce} -> ${newAnnounce}`);
-						torrent.announce = Buffer.from(newAnnounce);
-					}
-				}
-				if (announceList) {
-					torrent["announce-list"] = announceList.map((tier) =>
-						tier.map((url) => {
-							const newAnnounce = url.replace(oldUrl, newUrl);
-							if (url === newAnnounce) return Buffer.from(url);
-							updated = true;
-							console.log(`--- ${url} -> ${newAnnounce}`);
-							return Buffer.from(newAnnounce);
-						}),
-					);
-				}
-				if (updated) writeFileSync(filePath, bencode.encode(torrent));
-			}
-		} catch (e) {
-			console.error(`Error reading ${filePath}: ${e}`);
-		}
-	}
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,11 @@
+import bencode from "bencode";
 import { readFile, rename } from "fs/promises";
 import path from "path";
 import { appDir, createAppDir } from "./configuration.js";
-import { Decision } from "./constants.js";
+import { Decision, TORRENT_CACHE_FOLDER } from "./constants.js";
+import { findAllTorrentFilesInDir } from "./torrent.js";
+import { writeFileSync } from "fs";
+import { Torrent } from "./parseTorrent.js";
 
 createAppDir();
 
@@ -42,4 +46,56 @@ export async function renameCacheFile(): Promise<void> {
 		path.join(appDir(), "cache.json"),
 		path.join(appDir(), "old-cache.bak.json"),
 	);
+}
+
+export async function updateTorrentCache(
+	oldUrl: string,
+	newUrl: string,
+): Promise<void> {
+	const torrentFilePaths = await findAllTorrentFilesInDir(
+		path.join(appDir(), TORRENT_CACHE_FOLDER),
+	);
+	console.log(
+		`Found ${torrentFilePaths.length} torrent files in cache, processing...`,
+	);
+	let count = 0;
+	for (const filePath of torrentFilePaths) {
+		try {
+			const torrent: Torrent = bencode.decode(await readFile(filePath));
+			const announce = torrent.announce?.toString();
+			const announceList = torrent["announce-list"]?.map((tier) =>
+				tier.map((url) => url.toString()),
+			);
+			if (
+				announce?.includes(oldUrl) ||
+				announceList?.some((t) => t.some((url) => url.includes(oldUrl)))
+			) {
+				count++;
+				console.log(`#${count}: ${filePath}`);
+				let updated = false;
+				if (announce) {
+					const newAnnounce = announce.replace(oldUrl, newUrl);
+					if (announce !== newAnnounce) {
+						updated = true;
+						console.log(`--- ${announce} -> ${newAnnounce}`);
+						torrent.announce = Buffer.from(newAnnounce);
+					}
+				}
+				if (announceList) {
+					torrent["announce-list"] = announceList.map((tier) =>
+						tier.map((url) => {
+							const newAnnounce = url.replace(oldUrl, newUrl);
+							if (url === newAnnounce) return Buffer.from(url);
+							updated = true;
+							console.log(`--- ${url} -> ${newAnnounce}`);
+							return Buffer.from(newAnnounce);
+						}),
+					);
+				}
+				if (updated) writeFileSync(filePath, bencode.encode(torrent));
+			}
+		} catch (e) {
+			console.error(`Error reading ${filePath}: ${e}`);
+		}
+	}
 }

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { Option, program } from "commander";
 import { inspect } from "util";
 import { getApiKey, resetApiKey } from "./auth.js";
+import { updateTorrentCache } from "./cache.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
 import { FileConfig, generateConfig, getFileConfig } from "./configuration.js";
 import {
@@ -357,6 +358,24 @@ program
 		console.log("Clearing cache...");
 		await db("decision").whereNull("info_hash").del();
 		await db("timestamp").del();
+		await db.destroy();
+		await memDB.destroy();
+	});
+
+program
+	.command("update-torrent-cache-urls")
+	.description("Update announce urls in the torrent cache")
+	.usage("<old-announce-url> <new-announce-url>")
+	.argument(
+		"old-announce-url",
+		'A substring of the announce url to replace, e.g. update-torrent-cache-urls "old.example.com" "new.example.com"',
+	)
+	.argument(
+		"new-announce-url",
+		'A substring of the new announce url to replace the old one with, e.g. update-torrent-cache-urls "myoldpasskey" "mynewpasskey"',
+	)
+	.action(async (oldAnnounceUrl, newAnnounceUrl) => {
+		await updateTorrentCache(oldAnnounceUrl, newAnnounceUrl);
 		await db.destroy();
 		await memDB.destroy();
 	});

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { Option, program } from "commander";
 import { inspect } from "util";
 import { getApiKey, resetApiKey } from "./auth.js";
-import { updateTorrentCache } from "./cache.js";
+import { updateTorrentCache } from "./decide.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
 import { FileConfig, generateConfig, getFileConfig } from "./configuration.js";
 import {
@@ -363,19 +363,19 @@ program
 	});
 
 program
-	.command("update-torrent-cache-urls")
+	.command("update-torrent-cache-trackers")
 	.description("Update announce urls in the torrent cache")
 	.usage("<old-announce-url> <new-announce-url>")
 	.argument(
 		"old-announce-url",
-		'A substring of the announce url to replace, e.g. update-torrent-cache-urls "old.example.com" "new.example.com"',
+		'A substring of the announce url to replace, e.g. update-torrent-cache-trackers "old.example.com" "new.example.com"',
 	)
 	.argument(
 		"new-announce-url",
-		'A substring of the new announce url to replace the old one with, e.g. update-torrent-cache-urls "myoldpasskey" "mynewpasskey"',
+		'A substring of the new announce url to replace the old one with, e.g. update-torrent-cache-trackers "myoldpasskey" "mynewpasskey"',
 	)
-	.action(async (oldAnnounceUrl, newAnnounceUrl) => {
-		await updateTorrentCache(oldAnnounceUrl, newAnnounceUrl);
+	.action(async (oldStr, newStr) => {
+		await updateTorrentCache(oldStr, newStr);
 		await db.destroy();
 		await memDB.destroy();
 	});

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -10,7 +10,7 @@ interface TorrentDirent {
 	"path.utf-8"?: Buffer[];
 }
 
-interface Torrent {
+export interface Torrent {
 	info: {
 		"name.utf-8"?: Buffer;
 		name?: Buffer;


### PR DESCRIPTION
If a user changes their announce key or a tracker url changes, the `torrent_cache` needs to be updated. This can be done using tools like `sed`, but this is not cross-platform and a bit more complicated for users.