### PR TITLE
enhancement(preFIlter): exclude episode/season from arr directory detection

### DIFF
--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -26,6 +26,7 @@ import {
 import { indexerDoesSupportMediaType } from "./torznab.js";
 import {
 	comparing,
+	extractInt,
 	filesWithExt,
 	getLogString,
 	getMediaType,
@@ -158,6 +159,7 @@ export function filterByContent(
 		statSync(searchee.path).isDirectory() &&
 		ARR_DIR_REGEX.test(basename(searchee.path)) &&
 		nonVideoSizeRatio < 0.02 &&
+		![MediaType.EPISODE, MediaType.SEASON].includes(mediaType) &&
 		!(
 			searchee.files.length > 1 &&
 			SONARR_SUBFOLDERS_REGEX.test(basename(searchee.path))
@@ -170,6 +172,16 @@ export function filterByContent(
 		);
 		return false;
 	}
+
+	if (
+		searchee.path &&
+		mediaType === MediaType.SEASON &&
+		extractInt(searchee.title.match(SEASON_REGEX)!.groups!.season) === 0
+	) {
+		logReason("it is a Specials folder", searchee, mediaType);
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,34 +85,25 @@ export function hasExt(files: File[], exts: string[]): boolean {
 	return files.some((f) => exts.includes(path.extname(f.name.toLowerCase())));
 }
 
-export function getMediaType(searchee: Searchee): MediaType {
-	function unsupportedMediaType(searchee: Searchee): MediaType {
-		if (hasExt(searchee.files, AUDIO_EXTENSIONS)) {
-			return MediaType.AUDIO;
-		} else if (hasExt(searchee.files, BOOK_EXTENSIONS)) {
-			return MediaType.BOOK;
-		} else {
-			return MediaType.OTHER;
-		}
-	}
-
-	/* eslint-disable no-fallthrough */
-	switch (true) {
-		case EP_REGEX.test(searchee.title):
+export function getMediaType({ title, files }: Searchee): MediaType {
+	switch (true /* eslint-disable no-fallthrough */) {
+		case EP_REGEX.test(title):
 			return MediaType.EPISODE;
-		case SEASON_REGEX.test(searchee.title):
+		case SEASON_REGEX.test(title):
 			return MediaType.SEASON;
-		case hasExt(searchee.files, VIDEO_EXTENSIONS):
-			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
-			if (ANIME_REGEX.test(searchee.title)) return MediaType.ANIME;
+		case hasExt(files, VIDEO_EXTENSIONS):
+			if (MOVIE_REGEX.test(title)) return MediaType.MOVIE;
+			if (ANIME_REGEX.test(title)) return MediaType.ANIME;
 			return MediaType.VIDEO;
-		case hasExt(searchee.files, VIDEO_DISC_EXTENSIONS):
-			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
+		case hasExt(files, VIDEO_DISC_EXTENSIONS):
+			if (MOVIE_REGEX.test(title)) return MediaType.MOVIE;
 			return MediaType.VIDEO;
-		case hasExt(searchee.files, [".rar"]):
-			if (MOVIE_REGEX.test(searchee.title)) return MediaType.MOVIE;
-		default:
-			return unsupportedMediaType(searchee);
+		case hasExt(files, [".rar"]):
+			if (MOVIE_REGEX.test(title)) return MediaType.MOVIE;
+		default: // Minimally supported media types
+			if (hasExt(files, AUDIO_EXTENSIONS)) return MediaType.AUDIO;
+			if (hasExt(files, BOOK_EXTENSIONS)) return MediaType.BOOK;
+			return MediaType.OTHER;
 	}
 }
 


### PR DESCRIPTION
These can never be the arr dirs that we are trying to filter against. This will only happen if the user has non-standard naming for their arrs.

The other time this can happen is if it's trying to search `Specials`, so now I added an explicit check for this. `Specials` will usually get parsed into `Show S0` due to the episode files in the folder.