### PR TITLE
fix(db/startup): prevent invalid pathing returns on new install referencing the db/appDir

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -62,6 +62,13 @@ Make sure that
   - every entry has a comma after it, including inside arrays
 `.trim();
 
+/**
+ * Returns the appDir relevant to the OS/Environment. Due to initialization of
+ * the SQLiteDB during read of db.ts - will need to create appDir in this function if
+ * it does not exist (ENOENT)
+ *
+ * @return a string representing the absolute path to cross-seed config directory
+ */
 export function appDir(): string {
 	const appDir =
 		process.env.CONFIG_DIR ||
@@ -72,6 +79,7 @@ export function appDir(): string {
 		accessSync(appDir, constants.R_OK | constants.W_OK);
 	} catch (e) {
 		if (e.code === "ENOENT") {
+			mkdirSync(appDir, { recursive: true });
 			return appDir;
 		}
 		const dockerMessage =
@@ -85,13 +93,14 @@ export function appDir(): string {
 	return appDir;
 }
 
-export function createAppDir(): void {
-	mkdirSync(path.join(appDir(), "torrent_cache"), { recursive: true });
-	mkdirSync(path.join(appDir(), "logs"), { recursive: true });
+export function createAppDirHierarchy(): void {
+	const appDirPath = appDir();
+	mkdirSync(path.join(appDirPath, "torrent_cache"), { recursive: true });
+	mkdirSync(path.join(appDirPath, "logs"), { recursive: true });
 }
 
 export function generateConfig(): void {
-	createAppDir();
+	createAppDirHierarchy();
 	const dest = path.join(appDir(), "config.js");
 	const templatePath = path.join("./config.template.cjs");
 	if (existsSync(dest)) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import { join } from "path";
 import stripAnsi from "strip-ansi";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
-import { appDir, createAppDir } from "./configuration.js";
+import { appDir, createAppDirHierarchy } from "./configuration.js";
 
 export enum Label {
 	QBITTORRENT = "qbittorrent",
@@ -104,7 +104,7 @@ export function logOnce(cacheKey: string, cb: () => void, ttl?: number) {
 }
 
 export function initializeLogger(options: Record<string, unknown>): void {
-	createAppDir();
+	createAppDirHierarchy();
 	logger = winston.createLogger({
 		level: "info",
 		format: winston.format.combine(


### PR DESCRIPTION
due to db.ts being read and the following line referencing appDir during gen-config runs

https://github.com/cross-seed/cross-seed/blob/master/src/db.ts#L8-L9

the path may be referenced before it exists...causing better-sqlite to freak out and fail.

when receiving an ENOENT during startup and appDir() execution, simply create the path, as we will undoubtedly need it anyway.

rename the createAppDir() function appropriately as well, and document this behavior in jsdocs.

probably a better way to handle startup long term, but wanted to get a solution available that prevents new users from facing failures on step 1.
- consolidated discord thread: [Discord](https://discord.com/channels/880949701845872672/1335949251645280306/1335949251645280306)