### PR TITLE
framework for multiple client support

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -193,23 +193,29 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.choices(Object.values(Action)),
 		)
 		.option(
+			"--torrent-clients <clients...>",
+			"The the client prefix and urls of your torrent clients.",
+			// @ts-expect-error commander supports non-string defaults
+			fallback(fileConfig.torrentClients, []),
+		)
+		.option(
 			"--rtorrent-rpc-url <url>",
-			"The url of your rtorrent XMLRPC interface. Requires '-A inject'. See the docs for more information.",
+			"The url of your rtorrent XMLRPC interface.",
 			fileConfig.rtorrentRpcUrl,
 		)
 		.option(
 			"--qbittorrent-url <url>",
-			"The url of your qBittorrent webui. Requires '-A inject'. See the docs for more information.",
+			"The url of your qBittorrent webui.",
 			fileConfig.qbittorrentUrl,
 		)
 		.option(
 			"--transmission-rpc-url <url>",
-			"The url of your Transmission RPC interface. Requires '-A inject'. See the docs for more information.",
+			"The url of your Transmission RPC interface.",
 			fileConfig.transmissionRpcUrl,
 		)
 		.option(
 			"--deluge-rpc-url <url>",
-			"The url of your Deluge JSON-RPC interface. Requires '-A inject'. See the docs for more information.",
+			"The url of your Deluge JSON-RPC interface.",
 			fileConfig.delugeRpcUrl,
 		)
 		.option(
@@ -277,10 +283,6 @@ program.version(PROGRAM_VERSION, "-V, --version", "output the current version");
 program
 	.command("gen-config")
 	.description("Generate a config file")
-	.option(
-		"-d, --docker",
-		"Generate the docker config instead of the normal one",
-	)
 	.action(withMinimalRuntime(generateConfig));
 
 program

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -62,47 +62,28 @@ module.exports = {
 	port: 2468,
 
 	/**
-	 * cross-seed will send POST requests to these urls with a JSON payload of
-	 * { title, body, extra }. Conforms to the caronc/apprise REST API.
+	 * cross-seed will send caronc/apprise POST requests to these urls
+	 * with a JSON payload of:
+	 * https://www.cross-seed.org/docs/basics/options#notificationwebhookurls
 	 */
 	notificationWebhookUrls: [],
 
 	/**
-	 * The url of your rtorrent XMLRPC interface.
-	 * Only relevant with action: "inject".
-	 * Could be something like "http://username:password@localhost:1234/RPC2
-	 */
-	rtorrentRpcUrl: undefined,
-
-	/**
-	 * The url of your qBittorrent webui.
-	 * Only relevant with action: "inject".
+	 * The urls of your torrent clients' web interfaces prefixed by their type.
+	 * You may need to urlencode your username and password if they contain special characters:
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#can-i-use-special-characters-in-my-urls
 	 *
+	 * torrentClients: ["qbittorrent:http://username:password@localhost:8080"]
 	 * If using Automatic Torrent Management, please read:
 	 * https://www.cross-seed.org/docs/v6-migration#new-folder-structure-for-links
 	 *
-	 * Supply your username and password inside the url like so:
-	 * "http://username:password@localhost:8080"
+	 * torrentClients: ["rtorrent:http://username:password@localhost:1234/RPC2"]
+	 *
+	 * torrentClients: ["transmission:http://username:password@localhost:9091/transmission/rpc"]
+	 *
+	 * torrentClients: ["deluge:http://:password@localhost:8112/json"]
 	 */
-	qbittorrentUrl: undefined,
-
-	/**
-	 * The url of your Transmission RPC interface.
-	 * Usually ends with "/transmission/rpc".
-	 * Only relevant with action: "inject".
-	 * Supply your username and password inside the url like so:
-	 * "http://username:password@localhost:9091/transmission/rpc"
-	 */
-	transmissionRpcUrl: undefined,
-
-	/**
-	 * The url of your Deluge JSON-RPC interface.
-	 * Usually ends with "/json".
-	 * Only relevant with action: "inject".
-	 * Supply your WebUI password as well like so:
-	 * "http://:password@localhost:8112/json"
-	 */
-	delugeRpcUrl: undefined,
+	torrentClients: [],
 
 	/**
 	 * END OF POTENTIALLY SENSITIVE CONFIGURATION OPTIONS

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,7 +15,6 @@ export interface FileConfig {
 	delay?: number;
 	includeSingleEpisodes?: boolean;
 	outputDir?: string;
-	rtorrentRpcUrl?: string;
 	includeNonVideos?: boolean;
 	seasonFromEpisodes?: number;
 	fuzzySizeThreshold?: number;
@@ -34,7 +33,9 @@ export interface FileConfig {
 	linkCategory?: string;
 	torrentDir?: string;
 	torznab?: string[];
+	torrentClients?: string[];
 	qbittorrentUrl?: string;
+	rtorrentRpcUrl?: string;
 	transmissionRpcUrl?: string;
 	delugeRpcUrl?: string;
 	duplicateCategories?: boolean;

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -152,7 +152,10 @@ async function indexDataPaths(paths: string[]): Promise<void> {
 		await memDB("data").insert(batch).onConflict("path").merge();
 	});
 	await inBatches(ensembleRows, async (batch) => {
-		await memDB("ensemble").insert(batch).onConflict("path").merge();
+		await memDB("ensemble")
+			.insert(batch)
+			.onConflict(["client_host", "path"])
+			.merge();
 	});
 }
 
@@ -164,6 +167,7 @@ async function indexEnsembleDataEntry(
 	const ensemblePieces = await createEnsemblePieces(title, files);
 	if (!ensemblePieces || !ensemblePieces.length) return null;
 	return ensemblePieces.map((ensemblePiece) => ({
+		client_host: null,
 		path: join(dirname(path), ensemblePiece.largestFile.path),
 		info_hash: null,
 		ensemble: ensemblePiece.key,

--- a/src/db.ts
+++ b/src/db.ts
@@ -22,7 +22,9 @@ export const memDB = knex({
 	useNullAsDefault: true,
 });
 await memDB.schema.createTable("torrent", (table) => {
-	table.string("info_hash").primary();
+	table.string("client_host");
+	table.string("info_hash").index();
+	table.primary(["client_host", "info_hash"]);
 	table.string("name");
 	table.string("title");
 	table.json("files");
@@ -37,8 +39,10 @@ await memDB.schema.createTable("data", (table) => {
 	table.string("title");
 });
 await memDB.schema.createTable("ensemble", (table) => {
-	table.string("path").primary();
-	table.string("info_hash").unique();
+	table.string("client_host");
+	table.string("path").index();
+	table.primary(["client_host", "path"]);
+	table.string("info_hash").index();
 	table.string("ensemble");
 	table.string("element");
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 import stripAnsi from "strip-ansi";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
+import { parseClientEntry } from "./clients/TorrentClient.js";
 import { appDir, createAppDirHierarchy } from "./configuration.js";
 
 export enum Label {
@@ -73,9 +74,17 @@ function redactMessage(
 		/\/notification\/crossSeed\/[a-zA-Z-0-9_-]+/g,
 		`/notification/crossSeed/${redactionMsg}`,
 	);
-	for (const [key, urlStr] of Object.entries(options)) {
-		if (key.endsWith("Url") && typeof urlStr === "string") {
-			ret = redactUrlPassword(ret, urlStr);
+	for (const [key, value] of Object.entries(options)) {
+		if (key.endsWith("Url") && typeof value === "string") {
+			ret = redactUrlPassword(ret, value);
+		}
+		if (key === "torrentClients" && Array.isArray(value)) {
+			for (const clientEntry of value) {
+				ret = redactUrlPassword(
+					ret,
+					parseClientEntry(clientEntry)!.url,
+				);
+			}
 		}
 	}
 	return ret;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -239,43 +239,6 @@ export function findBlockedStringInReleaseMaybe(
 }
 
 /**
- * Filters duplicates from searchees that should be for different candidates,
- * e.g. all searchees created by cross-seed.
- * @param searchees - An array of searchees to filter duplicates from.
- * @returns An array of searchees with duplicates removed, preferring infoHash.
- */
-export function filterDupesByName<T extends Searchee>(searchees: T[]): T[] {
-	const duplicateMap = searchees.reduce((acc, cur) => {
-		const entry = acc.get(cur.title);
-		if (entry === undefined) {
-			acc.set(cur.title, cur);
-			return acc;
-		}
-		if (cur.files.length > entry.files.length) {
-			acc.set(cur.title, cur);
-			return acc;
-		}
-		if (cur.files.length < entry.files.length) {
-			return acc;
-		}
-		if (cur.infoHash && !entry.infoHash) {
-			acc.set(cur.title, cur);
-		}
-		return acc;
-	}, new Map());
-
-	const filtered = Array.from(duplicateMap.values());
-	const numDupes = searchees.length - filtered.length;
-	if (numDupes > 0) {
-		logger.verbose({
-			label: Label.PREFILTER,
-			message: `${numDupes} duplicates not selected for searching`,
-		});
-	}
-	return filtered;
-}
-
-/**
  * Filters duplicates from searchees that are for the same candidates,
  * e.g. searchees for the same media but different resolutions.
  * @param searchees - An array of searchees for a specific media.
@@ -290,6 +253,7 @@ export function filterDupesFromSimilar<T extends Searchee>(
 			if (searchee.title !== s.title) return false;
 			if (searchee.length !== s.length) return false;
 			if (searchee.files.length !== s.files.length) return false;
+			if (searchee.clientHost !== s.clientHost) return false;
 			const potentialFiles = s.files.map((f) => f.length);
 			return searchee.files.every((file) => {
 				const index = potentialFiles.indexOf(file.length);

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -83,6 +83,7 @@ export function sendResultsNotification(
 	const searcheeTrackers = searchee.trackers ?? null;
 	const searcheeLength = searchee.length;
 	const searcheeInfoHash = searchee.infoHash ?? null;
+	const searcheeClientHost = searchee.clientHost ?? null;
 	const searcheePath = searchee.path ?? null;
 	const searcheeSource = getSearcheeSource(searchee);
 
@@ -129,6 +130,7 @@ export function sendResultsNotification(
 					tags: searcheeTags,
 					trackers: searcheeTrackers,
 					length: searcheeLength,
+					clientHost: searcheeClientHost,
 					infoHash: searcheeInfoHash,
 					path: searcheePath,
 					source: searcheeSource,
@@ -164,6 +166,7 @@ export function sendResultsNotification(
 					tags: searcheeTags,
 					trackers: searcheeTrackers,
 					length: searcheeLength,
+					clientHost: searcheeClientHost,
 					infoHash: searcheeInfoHash,
 					path: searcheePath,
 					source: searcheeSource,

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -24,10 +24,7 @@ export interface RuntimeConfig {
 	excludeOlder?: number;
 	excludeRecentSearch?: number;
 	action: Action;
-	rtorrentRpcUrl?: string;
-	qbittorrentUrl?: string;
-	transmissionRpcUrl?: string;
-	delugeRpcUrl?: string;
+	torrentClients: string[];
 	duplicateCategories: boolean;
 	notificationWebhookUrls: string[];
 	torrents: string[];

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -5,7 +5,10 @@ import { sep } from "path";
 import { inspect } from "util";
 import { testLinking } from "./action.js";
 import { validateUArrLs } from "./arr.js";
-import { getClient } from "./clients/TorrentClient.js";
+import {
+	getClient,
+	instantiateDownloadClients,
+} from "./clients/TorrentClient.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
 import { NEWLINE_INDENT, PROGRAM_NAME, PROGRAM_VERSION } from "./constants.js";
 import { db, memDB } from "./db.js";
@@ -162,6 +165,7 @@ async function retry<T>(
 
 export async function doStartupValidation(): Promise<void> {
 	await checkConfigPaths(); // ensure paths are valid first
+	instantiateDownloadClients();
 	const validateClientConfig = async () => getClient()?.validateConfig(); // preserve `this` class pointer
 	const errors = (
 		await Promise.allSettled([

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,13 +275,13 @@ export function getLogString(
 ) {
 	if (searchee.title === searchee.name) {
 		return searchee.infoHash
-			? `${color(searchee.title)} ${chalk.dim(`[${sanitizeInfoHash(searchee.infoHash)}]`)}`
+			? `${color(searchee.title)} ${chalk.dim(`[${sanitizeInfoHash(searchee.infoHash)}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]`)}`
 			: searchee.path
 				? color(searchee.path)
 				: color(searchee.title);
 	}
 	return searchee.infoHash
-		? `${color(searchee.title)} ${chalk.dim(`[${searchee.name} [${sanitizeInfoHash(searchee.infoHash)}]]`)}`
+		? `${color(searchee.title)} ${chalk.dim(`[${searchee.name} [${sanitizeInfoHash(searchee.infoHash)}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]]`)}`
 		: searchee.path
 			? `${color(searchee.title)} ${chalk.dim(`[${searchee.path}]`)}`
 			: `${color(searchee.title)} ${chalk.dim(`[${searchee.name}]`)}`;


### PR DESCRIPTION
Only a single client is supported on this branch.

The goal for this feature is to source searchees from multiple clients and cross seed them to their respective clients. cross seeding from one client to another is not supported. Injections will only happen in a single client, the already exists checks looks at all clients.

The client config options have all been deprecated and `torrentClients: []` is used instead. Each url must be prefixed by it's client type similar to blockList. This allows the user to define a `clientPriority` which affects which client is chosen when source torrents are duplicated/ambiguous.

The `URL(url).host` is used to distinguish between clients, duplicates are not allowed. This is added to `SearcheeClient`. Logging for the clients now includes this to distinguish themselves.