### PR TITLE
feat(clients): support multiple clients with useClientTorrents

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -665,7 +665,6 @@ export default class Deluge implements TorrentClient {
 		return Object.entries(torrents).map(([hash, torrent]) => ({
 			infoHash: hash,
 			category: torrent.label ?? "",
-			tags: [],
 		}));
 	}
 
@@ -739,7 +738,6 @@ export default class Deluge implements TorrentClient {
 			const length = torrent.total_size!;
 			const savePath = torrent.save_path!;
 			const category = torrent.label ?? "";
-			const tags = [];
 			const searchee: SearcheeClient = {
 				infoHash,
 				name,
@@ -749,7 +747,6 @@ export default class Deluge implements TorrentClient {
 				clientHost: this.clientHost,
 				savePath,
 				category,
-				tags,
 				trackers,
 			};
 			newSearchees.push(searchee);

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -526,7 +526,6 @@ export default class RTorrent implements TorrentClient {
 			// response: [ [tag1], [tag2], ... ], assuming infoHash order is preserved
 			return hashes.map((hash, index) => ({
 				infoHash: hash.toLowerCase(),
-				category: "",
 				tags:
 					(results[index] as string[]).length !== 1
 						? results[index]
@@ -681,7 +680,6 @@ export default class RTorrent implements TorrentClient {
 			);
 			const title = parseTitle(name, files) ?? name;
 			const savePath = isMultiFile ? dirname(directory) : directory;
-			const category = "";
 			const tags = labels.length
 				? decodeURIComponent(labels)
 						.split(",")
@@ -695,7 +693,6 @@ export default class RTorrent implements TorrentClient {
 				length,
 				clientHost: this.clientHost,
 				savePath,
-				category,
 				tags,
 				trackers,
 			};

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -302,7 +302,6 @@ export default class Transmission implements TorrentClient {
 		});
 		return res.torrents.map((torrent) => ({
 			infoHash: torrent.hashString,
-			category: "",
 			tags: torrent.labels,
 		}));
 	}
@@ -385,7 +384,6 @@ export default class Transmission implements TorrentClient {
 			const title = parseTitle(name, files) ?? name;
 			const length = torrent.totalSize;
 			const savePath = torrent.downloadDir;
-			const category = "";
 			const tags = torrent.labels;
 			const searchee: SearcheeClient = {
 				infoHash,
@@ -395,7 +393,6 @@ export default class Transmission implements TorrentClient {
 				length,
 				clientHost: this.clientHost,
 				savePath,
-				category,
 				tags,
 				trackers,
 			};

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -6,7 +6,7 @@ import { inspect } from "util";
 import { testLinking } from "./action.js";
 import { validateUArrLs } from "./arr.js";
 import {
-	getClient,
+	getClients,
 	instantiateDownloadClients,
 } from "./clients/TorrentClient.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
@@ -166,7 +166,8 @@ async function retry<T>(
 export async function doStartupValidation(): Promise<void> {
 	await checkConfigPaths(); // ensure paths are valid first
 	instantiateDownloadClients();
-	const validateClientConfig = async () => getClient()?.validateConfig(); // preserve `this` class pointer
+	const validateClientConfig = async () =>
+		Promise.all(getClients().map((client) => client.validateConfig()));
 	const errors = (
 		await Promise.allSettled([
 			retry(validateTorznabUrls, 5, ms("1 minute")),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@ import { File, getAllTitles, Searchee } from "./searchee.js";
 export enum Mutex {
 	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
 	CREATE_ALL_SEARCHEES = "CREATE_ALL_SEARCHEES",
+	CLIENT_INJECTION = "CLIENT_INJECTION",
 }
 const mutexes = new Map<Mutex, Promise<unknown>>();
 


### PR DESCRIPTION
fixes #223 

This adds support for `useClientTorrents: true`, `dataDirs` requires a different process and will be added later. Supporting `torrentDir` will add a great deal of complexity and may not be needed. We should avoid doing this unless necessary.

Most areas of the application now uses `getClients()` and performs the operation across all clients. `getClient(searchee)` is only used during linking to determine which client to inject to. If there is only a single client, it's always returned to preserve existing functionality.

Searchees are always sourced from all clients then later sorted `byClientPriority` to ensure consistent injection preferences. Though if the injection fails for one client, it could be injected into another. Webhook infoHash lookup returns torrents from all clients.

Ensembles use the most common `clientHost` then by `clientPriority` to choose which client to inject into.