### PR TITLE
fix(searchee): use `file.path` instead of `searchee.name` for sourceRoot

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -21,7 +21,9 @@ import { getRuntimeConfig } from "./runtimeConfig.js";
 import {
 	createSearcheeFromPath,
 	getAbsoluteFilePath,
+	getRootFolder,
 	getSearcheeSource,
+	getSourceRoot,
 	Searchee,
 	SearcheeVirtual,
 	SearcheeWithInfoHash,
@@ -205,14 +207,7 @@ function linkVirtualSearchee(
 }
 
 function unlinkMetafile(meta: Metafile, destinationDir: string) {
-	const file = meta.files[0];
-	let rootFolder = file.path;
-	let parent = dirname(rootFolder);
-	while (parent !== ".") {
-		rootFolder = parent;
-		parent = dirname(rootFolder);
-	}
-	const fullPath = join(destinationDir, rootFolder);
+	const fullPath = join(destinationDir, getRootFolder(meta.files[0]));
 	if (!fs.existsSync(fullPath)) return;
 	if (!fullPath.startsWith(destinationDir)) return; // assert: fullPath is within destinationDir
 	if (fs.statSync(fullPath).ino === fs.statSync(destinationDir).ino) return; // assert: fullPath is not destinationDir
@@ -274,12 +269,7 @@ export async function linkAllFilesInMetafile(
 			}
 			savePath = downloadDirResult.unwrap();
 		}
-		sourceRoot = join(
-			savePath,
-			searchee.files.length === 1
-				? searchee.files[0].path
-				: searchee.name,
-		);
+		sourceRoot = getSourceRoot(searchee, savePath);
 		if (!fs.existsSync(sourceRoot)) {
 			logger.error({
 				label: searchee.label,

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -33,6 +33,7 @@ import {
 	getLargestFile,
 	getMovieKey,
 	getSeasonKey,
+	getSourceRoot,
 	SearcheeLabel,
 	SearcheeWithInfoHash,
 	SearcheeWithoutInfoHash,
@@ -323,15 +324,9 @@ async function cacheEnsembleTorrentEntry(
 		return null;
 	}
 
-	// Don't want to statSync(sourceRoot).isFile() now as it might be downloading.
-	// The path will get checked when rss/announce has a potential match.
-	const sourceRoot = join(
-		savePath,
-		searchee.files.length === 1 ? searchee.files[0].path : searchee.name,
-	);
 	return {
 		path: getAbsoluteFilePath(
-			sourceRoot,
+			getSourceRoot(searchee, savePath),
 			largestFile.path,
 			searchee.files.length === 1,
 		),


### PR DESCRIPTION
This is to better support renames in client for `useClientTorrents`. For .torrent and data based searchees, they are equivalent by definition. This is likely why `searchee.name` was being used to calculate `sourceRoot` all this time.

In qBittorrent, you can rename the torrent itself or its files. Renaming the files is currently handled by `useClientTorrents`, but renaming the torrent is not.

This is fixed by using the root folder from `files[0].path` instead of `searchee.name` for `sourceRoot` to cover the cases where it differs for API based searchees. This is what we use when linking so it's also conceptually more correct.