### PR TITLE
update(matchMode): use "strict" and "flexible" instead of "safe" and "risky"

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -72,9 +72,9 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		.addOption(
 			new Option(
 				"--match-mode <mode>",
-				"Safe will only download torrents with perfect matches. Risky will allow for renames and more matches, but might cause false positives. Partial is like risky but it ignores small files like .nfo/.srt if missing.",
+				`"strict" will require all file names to match exactly. "flexible" allows for file renames. "partial" is like "flexible" but it ignores small files like .nfo/.srt if missing.`,
 			)
-				.default(fallback(fileConfig.matchMode, MatchMode.SAFE))
+				.default(fallback(fileConfig.matchMode, MatchMode.STRICT))
 				.choices(Object.values(MatchMode))
 				.makeOptionMandatory(),
 		)

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -301,7 +301,7 @@ module.exports = {
 	 * 1 - must have all episodes (values below 1 requires matchMode: "partial")
 	 * 0.8 - must have at least 80% of the episodes
 	 */
-	seasonFromEpisodes: 0.8,
+	seasonFromEpisodes: 1,
 
 	/**
 	 * You should NOT modify this unless you have good reason.

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -42,8 +42,10 @@ module.exports = {
 	 *
 	 *      sonarr: ["http://sonarr:8989/?apikey=12345",
 	 *               "http://sonarr4k:8989/?apikey=12345"],
+	 *
+	 * For benefits, please read: https://www.cross-seed.org/docs/tutorials/id-searching
 	 */
-	sonarr: undefined,
+	sonarr: [],
 
 	/**
 	 * URL(s) to your Radarr instance(s), included in the same way as torznab
@@ -58,11 +60,13 @@ module.exports = {
 	 *
 	 *       radarr: ["http://radarr:7878/?apikey=12345",
 	 *                "http://radarr4k:7878/?apikey=12345"],
+	 *
+	 * For benefits, please read: https://www.cross-seed.org/docs/tutorials/id-searching
 	 */
-	radarr: undefined,
+	radarr: [],
 
 	/**
-	 * Bind to a specific host address.
+	 * Bind to a specific host address. If you are using docker, keep this as undefined
 	 * Example: "127.0.0.1"
 	 * Default is "0.0.0.0"
 	 */
@@ -165,20 +169,20 @@ module.exports = {
 	 * DATADIRS. THIS PATH MUST ALSO BE ACCESSIBLE VIA YOUR TORRENT CLIENT
 	 * USING THE SAME PATH.
 	 *
-	 * https://www.cross-seed.org/docs/basics/options#linkdirs
+	 * Instructions: https://www.cross-seed.org/docs/tutorials/linking
 	 */
 	linkDirs: [],
 
 	/**
-	 * cross-seed will use links of this type to inject data-based matches into
-	 * your client. We recommend reading the following page:
-	 * https://www.cross-seed.org/docs/tutorials/linking
+	 * cross-seed will use links of this type to inject matches into your client.
 	 * Options: "symlink", "hardlink", "reflink".
+	 *
+	 * https://www.cross-seed.org/docs/tutorials/linking#hardlinks-vs-symlinks-vs-reflinks
 	 */
 	linkType: "hardlink",
 
 	/**
-	 * Enabling this will link files using v5's flat folder style.
+	 * Enabling this will link files using v5's flat folder style, not recommended.
 	 *
 	 * Each individual Torznab tracker's cross-seeds, otherwise, will have its
 	 * own folder with the tracker's name and it's links within it.
@@ -191,23 +195,22 @@ module.exports = {
 	flatLinking: false,
 
 	/**
-	 * Determines flexibility of naming during matching, all options will have
-	 * no false positives. Using partial can double the amount of cross seeds found.
-	 * Options: "safe", "risky", "partial".
+	 * Determines flexibility of the matching algorithm, all options are equally safe.
+	 * Using "partial" is recommended as it will match all possible cross seeds.
+	 * Options: "strict", "flexible", "partial".
 	 *
-	 * "safe" will allow only perfect name/size matches using the standard
-	 * matching algorithm.
+	 * "strict" requires all file names to match exactly (required if not linking).
 	 *
-	 * "risky" uses filesize as its only comparison point.
+	 * "flexible" allows for file renames or inconsistencies.
 	 *
-	 * "partial" is like risky but allows matches if they are missing small
+	 * "partial" is like "flexible" but allows matches even if they are missing small
 	 * files like .nfo/.srt.
 	 *
 	 * We recommend reading the following entries:
 	 * https://www.cross-seed.org/docs/basics/options#matchmode
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
-	matchMode: "safe",
+	matchMode: "partial",
 
 	/**
 	 * Skip rechecking on injection if unnecessary. Certain matches, such as partial,
@@ -243,7 +246,11 @@ module.exports = {
 	torrentDir: null,
 
 	/**
-	 * Where to save the torrent files that cross-seed finds for you.
+	 * Where to save the .torrent files that cross-seed finds for you.
+	 * This is NOT where the torrent data (.e.g .mkv, .mp4) will be saved.
+	 * This directory will be used for retrying injections.
+	 *
+	 * DO NOT USE THIS DIRECTORY AS A WATCH FOLDER FOR YOUR TORRENT CLIENT!!!
 	 *
 	 * If you are a Windows user you need to put double '\' (e.g. "C:\\output")
 	 */
@@ -290,11 +297,11 @@ module.exports = {
 	 * Match season packs from the individual episodes you already have.
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 *
-	 * null - disabled
-	 * 1 - must have all episodes
+	 * null - disabled (required if not linking)
+	 * 1 - must have all episodes (values below 1 requires matchMode: "partial")
 	 * 0.8 - must have at least 80% of the episodes
 	 */
-	seasonFromEpisodes: 1,
+	seasonFromEpisodes: 0.8,
 
 	/**
 	 * You should NOT modify this unless you have good reason.

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -66,11 +66,11 @@ module.exports = {
 	radarr: [],
 
 	/**
-	 * Bind to a specific host address. If you are using docker, keep this as undefined
+	 * Bind to a specific host address. Do not change without a good reason.
 	 * Example: "127.0.0.1"
 	 * Default is "0.0.0.0"
 	 */
-	host: undefined,
+	host: "0.0.0.0",
 
 	/**
 	 * The port you wish to listen on for daemon mode.

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -210,7 +210,7 @@ module.exports = {
 	 * https://www.cross-seed.org/docs/basics/options#matchmode
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
-	matchMode: "partial",
+	matchMode: "flexible",
 
 	/**
 	 * Skip rechecking on injection if unnecessary. Certain matches, such as partial,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -200,8 +200,8 @@ export function isStaticDecision(decision: Decision): boolean {
 }
 
 export enum MatchMode {
-	SAFE = "safe",
-	RISKY = "risky",
+	STRICT = "strict",
+	FLEXIBLE = "flexible",
 	PARTIAL = "partial",
 }
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -107,7 +107,7 @@ function logDecision(
 			reason = "the info hash matches a torrent you already have";
 			break;
 		case Decision.FILE_TREE_MISMATCH:
-			reason = `it has a different file tree${matchMode === MatchMode.SAFE ? " (will match in risky or partial match mode)" : ""}`;
+			reason = `it has a different file tree${matchMode === MatchMode.STRICT ? " (will match in flexible or partial matchMode)" : ""}`;
 			break;
 		case Decision.RELEASE_GROUP_MISMATCH:
 			reason = `it has a different release group: ${getReleaseGroup(
@@ -414,7 +414,7 @@ export async function assessCandidate(
 	}
 
 	const sizeMatch = compareFileTreesIgnoringNames(metafile, searchee);
-	if (sizeMatch && matchMode !== MatchMode.SAFE) {
+	if (sizeMatch && matchMode !== MatchMode.STRICT) {
 		return { decision: Decision.MATCH_SIZE_ONLY, metafile, metaCached };
 	}
 

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -359,7 +359,7 @@ async function injectionAlreadyExists({
 	const existsDecision =
 		matchMode === MatchMode.PARTIAL
 			? Decision.MATCH_PARTIAL
-			: matchMode === MatchMode.RISKY
+			: matchMode === MatchMode.FLEXIBLE
 				? Decision.MATCH_SIZE_ONLY
 				: Decision.MATCH;
 	const result = await getClient()!.isTorrentComplete(meta.infoHash);


### PR DESCRIPTION
This updates the names for `matchMode` to be less misleading. The new ones are `strict` `flexible` `partial`. This better conveys that these options are equally safe as many users took `safe` and `risky` too literally.

I also think we should update the config template to `matchMode: "partial"` and `seasonFromEpisodes: 0.8`. Users have long asked for `optimal` settings and this should be close to it for most. If we are assuming that users will be setting up linking, similar to how the current options assume a client will be configured, we should start with these options. If a user cannot use linking or they do not want to, the options become opt-out for new users.

I think we have enough evidence that these options bring the user more matches with no real increases in risk. Though I understand if we still want to be conservative with this.