### PR TITLE
logging(errors): display e.message

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -129,11 +129,13 @@ async function makeArrApiCall<ResponseType>(
 	}
 
 	let response: Response;
+	let clonedResponse: Response;
 	try {
 		response = await fetch(url, {
 			signal: AbortSignal.timeout(ms("30 seconds")),
 			headers: { "X-Api-Key": apikey },
 		});
+		clonedResponse = response.clone();
 	} catch (networkError) {
 		if (
 			networkError.name === "AbortError" ||
@@ -153,10 +155,10 @@ async function makeArrApiCall<ResponseType>(
 		);
 	}
 	try {
-		const responseBody = await response.clone().json();
+		const responseBody = await response.json();
 		return resultOf(responseBody as ResponseType);
 	} catch (e) {
-		const responseText = await response.text();
+		const responseText = await clonedResponse.text();
 		return resultOfErr(
 			new Error(
 				`Arr response was non-JSON. ${getBodySampleMessage(responseText)}`,

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -381,7 +381,7 @@ export default class Deluge implements TorrentClient {
 			logger.debug(e);
 			logger.warn({
 				label: Label.DELUGE,
-				message: `Failed to label ${getLogString(newTorrent)} as ${label}`,
+				message: `Failed to label ${getLogString(newTorrent)} as ${label}: ${e.message}`,
 			});
 		}
 	}
@@ -761,7 +761,7 @@ export default class Deluge implements TorrentClient {
 		} catch (e) {
 			logger.error({
 				label: Label.DELUGE,
-				message: `Failed to fetch torrent data: ${infoHash}`,
+				message: `Failed to fetch torrent data: ${infoHash}: ${e.message}`,
 			});
 			logger.debug(e);
 			throw new Error("web.update_ui: failed to fetch data from client", {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -508,9 +508,10 @@ export default class QBittorrent implements TorrentClient {
 	 */
 	async getTorrentInfo(
 		hash: string | undefined,
-		retries = 0,
+		numRetries = 0,
 	): Promise<TorrentInfo | undefined> {
 		if (!hash) return undefined;
+		const retries = Math.max(numRetries, 0);
 		for (let i = 0; i <= retries; i++) {
 			const responseText = await this.request(
 				"/torrents/info",

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -320,7 +320,7 @@ export default class RTorrent implements TorrentClient {
 		} catch (e) {
 			logger.debug(e);
 			throw new CrossSeedError(
-				`Failed to reach rTorrent at ${rtorrentRpcUrl}`,
+				`Failed to reach rTorrent at ${rtorrentRpcUrl}: ${e.message}`,
 			);
 		}
 
@@ -439,7 +439,7 @@ export default class RTorrent implements TorrentClient {
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,
-				message: "Error parsing response for all torrents",
+				message: `Error parsing response for all torrents: ${e.message}`,
 			});
 			logger.debug(e);
 			return new Map();
@@ -529,7 +529,7 @@ export default class RTorrent implements TorrentClient {
 		} catch (e) {
 			logger.error({
 				Label: Label.RTORRENT,
-				message: "Error parsing response for all torrents",
+				message: `Error parsing response for all torrents: ${e.message}`,
 			});
 			logger.debug(e);
 			return [];
@@ -814,7 +814,7 @@ export default class RTorrent implements TorrentClient {
 			} catch (e) {
 				logger.verbose({
 					label: Label.RTORRENT,
-					message: `Failed to inject torrent ${meta.name} on attempt ${i + 1}/${retries}`,
+					message: `Failed to inject torrent ${meta.name} on attempt ${i + 1}/${retries}: ${e.message}`,
 				});
 				logger.debug(e);
 				await wait(1000 * Math.pow(2, i));

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -152,7 +152,7 @@ export async function validateClientSavePaths(
 	for (const savePath of uniqueSavePaths) {
 		if (ABS_WIN_PATH_REGEX.test(savePath) === (path.sep === "/")) {
 			throw new CrossSeedError(
-				`Cannot use linkDir with cross platform cross-seed and torrent client, please run cross-seed in docker or natively to match your torrent client (https://www.cross-seed.org/docs/basics/managing-the-daemon): ${savePath}`,
+				`Cannot use linkDirs with cross platform cross-seed and torrent client, please run cross-seed in docker or natively to match your torrent client (https://www.cross-seed.org/docs/basics/managing-the-daemon): ${savePath}`,
 			);
 		}
 		try {
@@ -160,7 +160,7 @@ export async function validateClientSavePaths(
 		} catch (e) {
 			logger.error(e);
 			throw new CrossSeedError(
-				"Failed to link from torrent client save paths to a linkDir. If you have a temp/cache drive, you will need to add extra linkDirs or blocklist the category, tag, or trackers that correspond to it.",
+				"Failed to link from torrent client save paths to a linkDir. If you have a temp/cache drive, you will need to add extra linkDirs or blocklist the category, tag, or trackers that correspond to it (https://www.cross-seed.org/docs/tutorials/linking#setting-up-linking)",
 			);
 		}
 	}
@@ -174,11 +174,12 @@ export async function waitForTorrentToComplete(
 	infoHash: string,
 	options = { retries: 6 },
 ): Promise<boolean> {
-	for (let i = 0; i <= options.retries; i++) {
+	const retries = Math.max(options.retries, 0);
+	for (let i = 0; i <= retries; i++) {
 		if ((await getClient()!.isTorrentComplete(infoHash)).orElse(false)) {
 			return true;
 		}
-		if (i < options.retries) {
+		if (i < retries) {
 			await wait(ms("1 second") * 2 ** i);
 		}
 	}

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -127,7 +127,7 @@ export default class Transmission implements TorrentClient {
 			return this.request(method, args, retries - 1);
 		}
 		try {
-			const responseBody = (await response.json()) as Response<T>;
+			const responseBody = (await response.clone().json()) as Response<T>;
 			if (
 				responseBody.result === "success" ||
 				responseBody.result === "duplicate torrent" // slight hack but best solution for now
@@ -146,12 +146,12 @@ export default class Transmission implements TorrentClient {
 				});
 				logger.debug({
 					label: Label.TRANSMISSION,
-					message: response,
+					message: response.clone().text(),
 				});
 			} else {
 				logger.error({
 					label: Label.TRANSMISSION,
-					message: `Transmission responded with an error`,
+					message: `Transmission responded with an error: ${e.message}`,
 				});
 				logger.debug(e);
 			}
@@ -166,7 +166,7 @@ export default class Transmission implements TorrentClient {
 		} catch (e) {
 			const { transmissionRpcUrl } = getRuntimeConfig();
 			throw new CrossSeedError(
-				`Failed to reach Transmission at ${transmissionRpcUrl}`,
+				`Failed to reach Transmission at ${transmissionRpcUrl}: ${e.message}`,
 			);
 		}
 
@@ -297,7 +297,7 @@ export default class Transmission implements TorrentClient {
 		} catch (e) {
 			logger.error({
 				label: Label.TRANSMISSION,
-				message: "Failed to get torrents from client",
+				message: `Failed to get torrents from client: ${e.message}`,
 			});
 			logger.debug(e);
 			return { searchees, newSearchees };

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -248,7 +248,7 @@ export function findPotentialNestedRoots(
 			return [root];
 		}
 	} catch (e) {
-		logger.verbose(`Failed to process path: ${root}`);
+		logger.verbose(`Failed to process path ${root}: ${e.message}`);
 		logger.debug(e);
 		return [];
 	}

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -465,7 +465,7 @@ async function getCachedTorrentFile(
 	} catch (e) {
 		logger.error({
 			label: Label.DECIDE,
-			message: `Failed to parse cached torrent ${sanitizeInfoHash(infoHash)}${options.deleteOnFail ? " - deleting" : ""}`,
+			message: `Failed to parse cached torrent ${sanitizeInfoHash(infoHash)}${options.deleteOnFail ? " - deleting" : ""}: ${e.message}`,
 		});
 		logger.debug(e);
 		if (options.deleteOnFail) {

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -106,7 +106,7 @@ async function deleteTorrentFileIfSafe(torrentFilePath: string): Promise<void> {
 		if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
 			logger.error({
 				label: Label.INJECT,
-				message: `Failed to delete ${filePathLog}`,
+				message: `Failed to delete ${filePathLog}: ${e.message}`,
 			});
 			logger.debug(e);
 		}
@@ -460,7 +460,7 @@ async function loadMetafile(
 	} catch (e) {
 		logger.error({
 			label: Label.INJECT,
-			message: `${progress} Failed to parse ${filePathLog}`,
+			message: `${progress} Failed to parse ${filePathLog}: ${e.message}`,
 		});
 		logger.debug(e);
 		return resultOfErr("FAILED_TO_PARSE");

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -252,7 +252,7 @@ async function findMatchesBatch(
 			const searcheeLog = getLogString(searchee, chalk.bold.white);
 			logger.error({
 				label: searchee.label,
-				message: `${progress}Error searching for ${searcheeLog}`,
+				message: `${progress}Error searching for ${searcheeLog}: ${e.message}`,
 			});
 			logger.debug(e);
 		}
@@ -340,7 +340,7 @@ export async function searchForLocalTorrentByCriteria(
 			const searcheeLog = getLogString(searchee, chalk.bold.white);
 			logger.error({
 				label: searchee.label,
-				message: `${progress}Error searching for ${searcheeLog}`,
+				message: `${progress}Error searching for ${searcheeLog}: ${e.message}`,
 			});
 			logger.debug(e);
 		}

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -61,9 +61,11 @@ export class PushNotifier {
 							}"`,
 						);
 					}
-				} catch (error) {
-					logger.error(`${url} failed to send push notification`);
-					logger.debug(error);
+				} catch (e) {
+					logger.error(
+						`${url} failed to send push notification: ${e.message}`,
+					);
+					logger.debug(e);
 				}
 			}),
 		);

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -396,7 +396,7 @@ export async function createSearcheeFromTorrentFile(
 		const meta = await parseTorrentWithMetadata(filepath, torrentInfos);
 		return createSearcheeFromMetafile(meta);
 	} catch (e) {
-		logger.error(`Failed to parse ${basename(filepath)}`);
+		logger.error(`Failed to parse ${basename(filepath)}: ${e.message}`);
 		logger.debug(e);
 		return resultOfErr(e);
 	}

--- a/src/server.ts
+++ b/src/server.ts
@@ -312,10 +312,12 @@ async function announce(
 		}
 
 		const { status, state } = determineResponse(result);
-		logger.info({
-			label: Label.ANNOUNCE,
-			message: `${state} ${candidateLog} (status: ${status})`,
-		});
+		if (result.actionResult !== InjectionResult.SUCCESS) {
+			logger.info({
+				label: Label.ANNOUNCE,
+				message: `${state} ${candidateLog} (status: ${status})`,
+			});
+		}
 		res.writeHead(status);
 		res.end();
 	} catch (e) {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -137,16 +137,17 @@ async function checkConfigPaths(): Promise<void> {
 
 async function retry<T>(
 	cb: () => Promise<T>,
-	retries: number,
+	numRetries: number,
 	delayMs: number,
 ): Promise<T> {
+	const retries = Math.max(numRetries, 0);
 	let lastError = new Error("Retry failed");
 	for (let i = 0; i <= retries; i++) {
 		try {
 			return await cb();
 		} catch (e) {
 			const retryMsg =
-				i < retries ? `, retrying in ${delayMs / 1000} seconds` : "";
+				i < retries ? `, retrying in ${delayMs / 1000}s` : "";
 			logger.error(
 				`Attempt ${i + 1}/${retries + 1} failed${retryMsg}: ${e.message}`,
 			);

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -389,7 +389,7 @@ export async function* rssPager(
 		} catch (e) {
 			logger.error({
 				label: Label.TORZNAB,
-				message: `Paging indexer ${indexer.url} stopped at page ${i + 1}: request failed`,
+				message: `Paging indexer ${indexer.url} stopped at page ${i + 1}: request failed - ${e.message}`,
 			});
 			logger.debug(e);
 			break;
@@ -606,7 +606,7 @@ async function fetchCaps(indexer: {
 		);
 	} catch (e) {
 		const error = new Error(
-			`Indexer ${indexer.url} failed to respond, check verbose logs`,
+			`Indexer ${indexer.url} failed to respond, check verbose logs: ${e.message}`,
 		);
 		logger.error(error.message);
 		logger.debug(e);


### PR DESCRIPTION
This improves the logs a bit by consistently using `e.message` in the error logs for a quick summary.

I noticed some issues with consuming response bodies in arr.ts. So I added some clones to which seems to have solved the issue.

Also checking if parent path exists before linking to avoid any unnecessary errors.