### PR TITLE
fix(action): fallback to alt method if no stat.dev to determine linkDir

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -32,6 +32,8 @@ import {
 import { saveTorrentFile } from "./torrent.js";
 import { findAFileWithExt, getLogString, getMediaType } from "./utils.js";
 
+const linkTestName = "cross-seed.test";
+
 interface LinkResult {
 	contentPath: string;
 	alreadyExisted: boolean;
@@ -446,21 +448,47 @@ export async function performActions(
 	return results;
 }
 
-export function getLinkDir(path: string): string | null {
+export function getLinkDir(pathStr: string): string | null {
 	const { linkDirs, linkType } = getRuntimeConfig();
-	const pathDev = fs.statSync(path).dev;
-	for (const linkDir of linkDirs) {
-		if (fs.statSync(linkDir).dev === pathDev) return linkDir;
+	const pathStat = fs.statSync(pathStr);
+	const pathDev = pathStat.dev; // Windows always returns 0
+	if (pathDev) {
+		for (const linkDir of linkDirs) {
+			if (fs.statSync(linkDir).dev === pathDev) return linkDir;
+		}
+	}
+	const srcFile = pathStat.isFile()
+		? pathStr
+		: pathStat.isDirectory()
+			? findAFileWithExt(pathStr, ALL_EXTENSIONS)
+			: null;
+	if (srcFile) {
+		for (const linkDir of linkDirs) {
+			try {
+				const testPath = join(linkDir, linkTestName);
+				linkFile(
+					srcFile,
+					testPath,
+					linkType === LinkType.REFLINK
+						? linkType
+						: LinkType.HARDLINK,
+				);
+				fs.rmSync(testPath);
+				return linkDir;
+			} catch {
+				continue;
+			}
+		}
 	}
 	if (linkType !== LinkType.SYMLINK) {
 		logger.error(
-			`Cannot find any linkDir from linkDirs on the same drive to ${linkType} ${path}`,
+			`Cannot find any linkDir from linkDirs on the same drive to ${linkType} ${pathStr}`,
 		);
 		return null;
 	}
 	if (linkDirs.length > 1) {
 		logger.warn(
-			`Cannot find any linkDir from linkDirs on the same drive, using first linkDir for symlink: ${path}`,
+			`Cannot find any linkDir from linkDirs on the same drive, using first linkDir for symlink: ${pathStr}`,
 		);
 	}
 	return linkDirs[0];
@@ -472,7 +500,7 @@ export function getLinkDirVirtual(searchee: SearcheeVirtual): string | null {
 	for (let i = 1; i < searchee.files.length; i++) {
 		if (getLinkDir(searchee.files[i].path) !== linkDir) {
 			logger.error(
-				`Cannot hardlink files to multiple linkDirs for seasonFromEpisodes aggregation, source episodes are spread across multiple drives.`,
+				`Cannot link files to multiple linkDirs for seasonFromEpisodes aggregation, source episodes are spread across multiple drives.`,
 			);
 			return null;
 		}
@@ -480,8 +508,12 @@ export function getLinkDirVirtual(searchee: SearcheeVirtual): string | null {
 	return linkDir;
 }
 
-function linkFile(oldPath: string, newPath: string): boolean {
-	const { linkType } = getRuntimeConfig();
+function linkFile(
+	oldPath: string,
+	newPath: string,
+	linkType?: LinkType,
+): boolean {
+	if (!linkType) linkType = getRuntimeConfig().linkType;
 	try {
 		const ogFileResolvedPath = unwrapSymlinks(oldPath);
 
@@ -533,11 +565,11 @@ function unwrapSymlinks(path: string): string {
 export function testLinking(srcDir: string): void {
 	const { linkType } = getRuntimeConfig();
 	try {
-		const linkDir = getLinkDir(srcDir);
-		if (!linkDir) throw new Error(`No valid linkDir found for ${srcDir}`);
 		const srcFile = findAFileWithExt(srcDir, ALL_EXTENSIONS);
 		if (!srcFile) return;
-		const testPath = join(linkDir, "cross-seed.test");
+		const linkDir = getLinkDir(srcDir);
+		if (!linkDir) throw new Error(`No valid linkDir found for ${srcDir}`);
+		const testPath = join(linkDir, linkTestName);
 		linkFile(srcFile, testPath);
 		fs.rmSync(testPath);
 	} catch (e) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ import {
 	VIDEO_EXTENSIONS,
 	YEARS_REGEX,
 } from "./constants.js";
+import { logger } from "./logger.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { File, Searchee } from "./searchee.js";
@@ -462,16 +463,19 @@ export function countDirEntriesRec(
 }
 
 export function findAFileWithExt(dir: string, exts: string[]): string | null {
-	const entries = readdirSync(dir, { withFileTypes: true });
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-		if (entry.isFile() && exts.includes(path.extname(fullPath))) {
-			return fullPath;
+	try {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isFile() && exts.includes(path.extname(fullPath))) {
+				return fullPath;
+			}
+			if (entry.isDirectory()) {
+				const file = findAFileWithExt(fullPath, exts);
+				if (file) return file;
+			}
 		}
-		if (entry.isDirectory()) {
-			const file = findAFileWithExt(fullPath, exts);
-			if (file) return file;
-		}
+	} catch (e) {
+		logger.debug(e);
 	}
 	return null;
 }


### PR DESCRIPTION
If `stat.dev` is not available, `getLinkDir` will try linking to each `linkDir` and return the first successful one.