### PR TITLE
enhancement(qbit): support `Don't create subfolder`

### DIFF
--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -64,7 +64,13 @@ export interface TorrentClient {
 		meta: SearcheeWithInfoHash | Metafile,
 		options: { onlyCompleted: boolean },
 	) => Promise<
-		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
+		Result<
+			string,
+			| "NOT_FOUND"
+			| "TORRENT_NOT_COMPLETE"
+			| "INVALID_DATA"
+			| "UNKNOWN_ERROR"
+		>
 	>;
 	getAllDownloadDirs: (options: {
 		metas: SearcheeWithInfoHash[] | Metafile[];

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { stat, unlink } from "fs/promises";
 import ms from "ms";
 import { copyFileSync, existsSync } from "fs";
-import path, { basename, dirname } from "path";
+import path, { basename } from "path";
 import { linkAllFilesInMetafile, performAction } from "./action.js";
 import {
 	getClient,
@@ -273,7 +273,7 @@ async function injectFromStalledTorrent({
 		}
 		if (!inClient) {
 			if (linkedFilesRootResult.isOk()) {
-				const destinationDir = dirname(linkResult!.contentPath);
+				const destinationDir = linkResult!.destinationDir;
 				const result = await getClient()!.inject(
 					meta,
 					searchee,

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -27,13 +27,11 @@ import {
 	createSearcheeFromPath,
 	createSearcheeFromTorrentFile,
 	File,
-	getAbsoluteFilePath,
 	getAnimeKeys,
 	getEpisodeKey,
 	getLargestFile,
 	getMovieKey,
 	getSeasonKey,
-	getSourceRoot,
 	SearcheeLabel,
 	SearcheeWithInfoHash,
 	SearcheeWithoutInfoHash,
@@ -313,7 +311,7 @@ async function cacheEnsembleTorrentEntry(
 		});
 		if (downloadDirResult.isErr()) {
 			logger.error(
-				`Failed to get download dir for ${getLogString(searchee)}`,
+				`Failed to get download dir for ${getLogString(searchee)}: ${downloadDirResult.unwrapErr()}`,
 			);
 			return null;
 		}
@@ -325,11 +323,7 @@ async function cacheEnsembleTorrentEntry(
 	}
 
 	return {
-		path: getAbsoluteFilePath(
-			getSourceRoot(searchee, savePath),
-			largestFile.path,
-			searchee.files.length === 1,
-		),
+		path: join(savePath, largestFile.path),
 		info_hash: searchee.infoHash,
 		ensemble: key,
 		element,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -445,6 +445,24 @@ export async function* combineAsyncIterables<T>(
 	return;
 }
 
+export function getPathParts(
+	pathStr: string,
+	dirnameFunc = path.dirname,
+): string[] {
+	const parts: string[] = [];
+	let parent = pathStr;
+	while (parent !== ".") {
+		parts.unshift(path.basename(parent));
+		const newParent = dirnameFunc(parent);
+		if (newParent === parent) {
+			parts.shift();
+			break;
+		}
+		parent = newParent;
+	}
+	return parts;
+}
+
 export function countDirEntriesRec(
 	dirs: string[],
 	maxDataDepth: number,


### PR DESCRIPTION
This adds support for the `Don't create subfolder` option in qbit which means `cross-seed` can now handle all modifications that a user can do. This is only supported with `useClientTorrents`, doing this for `torrentDir` would require a large refactor of how we link which is why it hasn't be supported all this time. This option removes the root folder, so episodes are stored directly into the `savePath`, instead of `savePath/Show.S01`. 

This builds on #908 by now completely getting rid of `sourceRoot`, it was only used to test if the file exists which is still being performed. We now use `savePath/files[x].path` everywhere to get the absolute paths of torrents.

I also added two more validation checks that moves implicit runtime errors to startup:
- Require v4.3.1+ (released 11/25/2020) for qbit, this has been implicitly required since v6 pre-release. It would fail at startup or when trying to inject with an non-obvious error. Any users below this version cannot use `cross-seed` currently, this let's them know why.
- Fail validation if a user is using `torrentDir` with `Don't create subfolder` torrents. We have never supported this, and these users are running into errors with these after injection. We can just log an error for this though, it can now detect these and log it before inejction.