### PR TITLE
enhancement(snatch): retry snatches

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -43,7 +43,6 @@ import {
 } from "./searchee.js";
 import {
 	cleanTitle,
-	combineAsyncIterables,
 	comparing,
 	extractInt,
 	formatAsList,
@@ -444,14 +443,12 @@ export async function* rssPager(
 	}
 }
 
-export async function* queryRssFeeds(
+export async function queryRssFeeds(
 	lastRun: number,
-): AsyncGenerator<Candidate> {
+): Promise<AsyncGenerator<Candidate>[]> {
 	const timeSinceLastRun = Date.now() - lastRun;
 	const indexers = await getEnabledIndexers();
-	yield* combineAsyncIterables(
-		indexers.map((indexer) => rssPager(indexer, timeSinceLastRun)),
-	);
+	return indexers.map((indexer) => rssPager(indexer, timeSinceLastRun));
 }
 
 export async function searchTorznab(


### PR DESCRIPTION
The core issue is that snatches can fail due to transient errors. This usually is from `announce` and `rss` due to the torrents being fresh, but it also happens with `search` and `webhook`. I find that `4` retries is a good number with a minute between each. Since snatches can now be much longer, I also updated `assessCandidates` to run async per indexer.

This comes one step short of addressing #375. Currently, `rss`, `search`, and `webhook` all respect `Retry-After` since they query the indexer first using `getEnabledIndexers()`. We can try also parsing `Retry-After` and updating the db from snatches, however the urls differ slightly from the db and would require some extra work. If we needed to rate limit an indexer, this would save at most 1 request but most of the time it will be 0.

`announce` does not support this since it comes directly from autobrr. The link is usually different as well since it's not proxied by prowlarr/jackett, but a direct link to the site. This means we likely won't have the `Retry-After` header and even if we did, it would be very difficult to match with the db. The current implementation respects it to end the retries early, but it's not saved anywhere for the next announce.

Should we the close the issue with this PR considering the above?