### PR TITLE
enhancement(reverselookup): handle AKA in titles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,7 @@ export const BAD_GROUP_PARSE_REGEX =
 	/^(?<badmatch>(?:dl|DDP?|aac|eac3|atmos|dts|ma|hd|[heav.c]{3.5}|[xh.]{1,2}[2456]|[0-9]+[ip]?|dxva|full|blu|ray|s(?:eason)?\W\d+|\W){3,})$/i;
 export const JSON_VALUES_REGEX = /".+?"\s*:\s*"(?<value>.+?)"\s*(?:,|})/g;
 export const ABS_WIN_PATH_REGEX = /^[a-z]:|^\\/i;
+export const AKA_REGEX = /(?:[_.\s-]+|\b)a[_.\s-]?k[_.\s-]?a(?:[_.\s-]+|\b)/i;
 
 // Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -140,12 +140,12 @@ async function indexDataPaths(paths: string[]): Promise<void> {
 		if (!title) continue;
 		dataRows.push({ title, path });
 		if (seasonFromEpisodes) {
-			const ensembleEntry = await indexEnsembleDataEntry(
+			const ensembleEntries = await indexEnsembleDataEntry(
 				title,
 				path,
 				files,
 			);
-			if (ensembleEntry) ensembleRows.push(ensembleEntry);
+			if (ensembleEntries) ensembleRows.push(...ensembleEntries);
 		}
 	}
 	await inBatches(dataRows, async (batch) => {
@@ -160,16 +160,15 @@ async function indexEnsembleDataEntry(
 	title: string,
 	path: string,
 	files: File[],
-): Promise<EnsembleEntry | null> {
+): Promise<EnsembleEntry[] | null> {
 	const ensemblePieces = await createEnsemblePieces(title, files);
-	if (!ensemblePieces) return null;
-	const { key, element, largestFile } = ensemblePieces;
-	return {
-		path: join(dirname(path), largestFile.path),
+	if (!ensemblePieces || !ensemblePieces.length) return null;
+	return ensemblePieces.map((ensemblePiece) => ({
+		path: join(dirname(path), ensemblePiece.largestFile.path),
 		info_hash: null,
-		ensemble: key,
-		element,
-	};
+		ensemble: ensemblePiece.key,
+		element: ensemblePiece.element,
+	}));
 }
 
 export async function getDataByFuzzyName(

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Sqlite from "better-sqlite3";
-import Knex from "knex";
+import knex from "knex";
 import { join } from "path";
 import { appDir } from "./configuration.js";
 import { migrations } from "./migrations/migrations.js";
@@ -10,14 +9,14 @@ const rawSqliteHandle = new Sqlite(filename);
 rawSqliteHandle.pragma("journal_mode = WAL");
 rawSqliteHandle.close();
 
-export const db = Knex.knex({
+export const db = knex({
 	client: "better-sqlite3",
 	connection: { filename },
 	migrations: { migrationSource: migrations },
 	useNullAsDefault: true,
 });
 
-export const memDB = Knex.knex({
+export const memDB = knex({
 	client: "better-sqlite3",
 	connection: ":memory:",
 	useNullAsDefault: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ import {
 import { logger } from "./logger.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
-import { File, Searchee } from "./searchee.js";
+import { File, getAllTitles, Searchee } from "./searchee.js";
 
 export enum Mutex {
 	INDEX_TORRENTS_AND_DATA_DIRS = "INDEX_TORRENTS_AND_DATA_DIRS",
@@ -119,25 +119,29 @@ export function areMediaTitlesSimilar(a: string, b: string): boolean {
 		b.match(SEASON_REGEX) ??
 		b.match(MOVIE_REGEX) ??
 		b.match(ANIME_REGEX);
-	const titlesA: string[] = (
+	const titlesA: string[] = getAllTitles(
 		matchA
 			? [matchA.groups?.title, matchA.groups?.altTitle].filter(isTruthy)
-			: [a]
+			: [a],
 	)
 		.map((title) => createKeyTitle(stripMetaFromName(title)))
 		.filter(isTruthy);
-	const titlesB: string[] = (
+	const titlesB: string[] = getAllTitles(
 		matchB
 			? [matchB.groups?.title, matchB.groups?.altTitle].filter(isTruthy)
-			: [b]
+			: [b],
 	)
 		.map((title) => createKeyTitle(stripMetaFromName(title)))
 		.filter(isTruthy);
 	const maxDistanceA = Math.floor(
-		Math.max(...titlesA.map((t) => t.length)) / LEVENSHTEIN_DIVISOR,
+		titlesA.reduce((sum, title) => sum + title.length, 0) /
+			titlesA.length /
+			LEVENSHTEIN_DIVISOR,
 	);
 	const maxDistanceB = Math.floor(
-		Math.max(...titlesB.map((t) => t.length)) / LEVENSHTEIN_DIVISOR,
+		titlesB.reduce((sum, title) => sum + title.length, 0) /
+			titlesB.length /
+			LEVENSHTEIN_DIVISOR,
 	);
 	const maxDistance = Math.max(maxDistanceA, maxDistanceB);
 	return titlesA.some((titleA) =>


### PR DESCRIPTION
Some trackers use a title of `TitleA AKA TitleB`, this splits by AKA and also performs the reverse lookup using all 3. This required supporting multiple keys for lookup for all media types, similar to anime.

I've also noticed some puts it after the title as "metadata", like `TitleA 2025 AKA TitleB`, these will not be supported.