### PR TITLE
fix(seasonFromEpisodes/zod): fix no-season-from-episodes triggering zod due to typecheck

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -416,7 +416,15 @@ export const VALIDATION_SCHEMA = z
 			.number()
 			.positive()
 			.lte(1, ZodErrorMessages.numberMustBeRatio)
-			.nullish(),
+			.nullish()
+			.or(
+				z
+					.boolean()
+					.refine((value) => value !== true, {
+						message: "Expected string, received boolean (true)",
+					})
+					.transform(() => null),
+			),
 		excludeOlder: z
 			.string()
 			.min(1, ZodErrorMessages.emptyString)


### PR DESCRIPTION
fixes #928 

Just like with he exclude options, when using `--no` command returns a false (boolean) - which does not conform to Zod. We have to transform this to null in order for it to meet 'nullish' and operate properly in cross-seed