### PR TITLE
update(snatch): 5 minute retry for announces

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -571,6 +571,7 @@ export const VALIDATION_SCHEMA = z
 	)
 	.refine(
 		(config) =>
+			process.env.DEV ||
 			!config.useClientTorrents ||
 			!config.torrentClients.some((c) => c.startsWith(Label.DELUGE)),
 		"Deluge does not currently support useClientTorrents, use torrentDir instead.",

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -358,7 +358,10 @@ export async function assessCandidate(
 	if (isCandidate) {
 		const res = await snatch(metaOrCandidate, searchee.label, {
 			retries: 4,
-			delayMs: ms("60 seconds"),
+			delayMs:
+				searchee.label === Label.ANNOUNCE
+					? ms("5 minutes")
+					: ms("1 minute"),
 		});
 		if (res.isErr()) {
 			const err = res.unwrapErr();


### PR DESCRIPTION
Due to the way autobrr retries announces, it could send another one even before the 202 code is reported by `cross-seed`. Bumping this to `5 minutes` for announce should help.

`search`, `webhook`, and `rss` cannot have concurrent snatch attempts themselves. Two different jobs can have concurrent snatches for the same tracker, but that's extremely unlikely to happen at any scale unlike announce. Also, these assessments are not completely isolated as each announce is. The `search` job might perform 10,000+ assessments over the course of it's entire run.

Also added the ability to override the deluge restrict with the `DEV` env variable like other options.