### PR TITLE
update(zod/maxdatadepth): classify greater than 3 depth as warning

### DIFF
--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -378,7 +378,7 @@ export const VALIDATION_SCHEMA = z
 			.gte(1)
 			.refine((maxDataDepth) => {
 				if (maxDataDepth > 3) {
-					logger.error(
+					logger.warn(
 						`Your maxDataDepth is most likely incorrect, please read: https://www.cross-seed.org/docs/tutorials/data-based-matching#setting-up-data-based-matching`,
 					);
 				}


### PR DESCRIPTION
Using a `maxDataDepth` of more than 3 cross-seed will issue an error. This is misleading, as there are certain rare edge-case folder structures that can be valid and necessitate a depth greater than 3.

This reduces the error to a warning.