### PR TITLE
feat(clients): support multiple clients with dataDirs

### DIFF
--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -92,7 +92,7 @@ export interface TorrentClient {
 		newTorrent: Metafile,
 		searchee: Searchee,
 		decision: DecisionAnyMatch,
-		path?: string,
+		options: { onlyCompleted: boolean; destinationDir?: string },
 	) => Promise<InjectionResult>;
 	recheckTorrent: (infoHash: string) => Promise<void>;
 	validateConfig: () => Promise<void>;
@@ -139,25 +139,12 @@ export function getClients(): TorrentClient[] {
 	return activeClients;
 }
 
-export function getClient(searchee: Searchee): TorrentClient | undefined {
-	const clients = getClients();
-	if (clients.length === 1) return clients[0];
-	return clients.find((c) => c.clientHost === searchee.clientHost);
-}
-
-/**
- * Use byClientPriority if Searchee is available for a complete check
- */
 export function byClientHostPriority(clientHost: string | undefined): number {
 	const clients = getClients();
 	return (
 		clients.find((c) => c.clientHost === clientHost)?.clientPriority ??
 		clients.length
 	);
-}
-
-export function byClientPriority(searchee: Searchee): number {
-	return byClientHostPriority(getClient(searchee)?.clientHost);
 }
 
 export async function validateClientSavePaths(

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -57,8 +57,10 @@ const ZodErrorMessages = {
 		].map((l) => `${l}:`),
 		{ sort: false, style: "narrow", type: "unit" },
 	)}`,
-	multipleClients:
-		"You need to use useClientTorrents when using multiple clients (dataDirs and --torrents arg is not allowed).",
+	multipleClientsTorrentFile:
+		"torrentDir and --torrents arg does not support multiple clients, use useClientTorrents instead.",
+	multipleClientsNoLinking:
+		"dataDirs is not supported with multiple clients if not linking. To configure linking, please read: https://www.cross-seed.org/docs/tutorials/linking",
 	duplicateClients: "Duplicate torrent client URLs are not allowed.",
 	injectNeedsClients:
 		"You need to specify torrentClients when using 'inject'",
@@ -589,10 +591,15 @@ export const VALIDATION_SCHEMA = z
 	.refine(
 		(config) =>
 			config.torrentClients.length <= 1 ||
-			(config.useClientTorrents &&
-				!config.torrents?.length &&
-				!config.dataDirs.length),
-		ZodErrorMessages.multipleClients,
+			(!config.torrentDir && !config.torrents?.length),
+		ZodErrorMessages.multipleClientsTorrentFile,
+	)
+	.refine(
+		(config) =>
+			config.torrentClients.length <= 1 ||
+			config.linkDirs.length ||
+			!config.dataDirs.length,
+		ZodErrorMessages.multipleClientsNoLinking,
 	)
 	.refine(
 		(config) =>

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -4,11 +4,7 @@ import { zip } from "lodash-es";
 import ms from "ms";
 import { basename } from "path";
 import { performAction, performActions } from "./action.js";
-import {
-	byClientHostPriority,
-	byClientPriority,
-	getClients,
-} from "./clients/TorrentClient.js";
+import { byClientHostPriority, getClients } from "./clients/TorrentClient.js";
 import {
 	ActionResult,
 	Decision,
@@ -305,7 +301,7 @@ export async function searchForLocalTorrentByCriteria(
 	const searchees: SearcheeWithLabel[] = rawSearchees
 		.sort(
 			comparing(
-				(searchee) => byClientPriority(searchee),
+				(searchee) => byClientHostPriority(searchee.clientHost),
 				(searchee) => -searchee.files.length, // Assume searchees are complete
 				(searchee) => !searchee.infoHash,
 			),
@@ -536,7 +532,7 @@ export async function checkNewCandidateMatch(
 	let actionResult: ActionResult | null = null;
 	searchees.sort(
 		comparing(
-			(searchee) => byClientPriority(searchee),
+			(searchee) => byClientHostPriority(searchee.clientHost),
 			(searchee) => !searchee.infoHash, // Prefer packs over ensemble
 			(searchee) => -searchee.files.length,
 		),
@@ -714,7 +710,7 @@ async function findSearchableTorrents(options?: {
 		}
 		filteredSearchees.sort(
 			comparing(
-				(searchee) => byClientPriority(searchee),
+				(searchee) => byClientHostPriority(searchee.clientHost),
 				(searchee) => -searchee.files.length, // Assume searchees are complete
 				(searchee) => !searchee.infoHash,
 			),


### PR DESCRIPTION
Required a large refactoring of `action.ts` and which affected `inject.ts` and the clients. Mainly was just about moving lots of the work into their own separate functions to get more flexibility. Also took more advantage of union types to help specify what's possible in certain conditions.

All the new functionality is in `getClientAndDestinationDir()` with the integration in `performActionsWithoutMutex()`. The changes in `inject.ts` are simply due to the new function signatures in `action.ts`. The changes for the clients are to standardize the handling of `TORRENT_NOT_COMPLETE` and using `destinationDir` instead of `path` for the `client.inject()` argument.

As before, a single client has the same behavior. `dataDirs` and ensemble `dataDirs` choose a client by testing linking to the `savePaths` for each client. It chooses the first client with a successful link then finds a `linkDir`. Non-linking is not supported for dataDirs. In principle there is no reason why it can't, but it would require interacting with the filesystem which we should avoid for non-linking setups. Interacting with the filesystem won't be necessary with #934.

Users will likely desire some control over what goes where, but that's for #934 to address.