### PR TITLE
enhancement(inject): increase maximum auto resume to 100 MiB

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -91,7 +91,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"--auto-resume-max-download <number>",
 			"The maximum size in bytes remaining for a torrent to be resumed",
 			parseInt,
-			fallback(fileConfig.autoResumeMaxDownload, 52428800),
+			fallback(fileConfig.autoResumeMaxDownload, 104857600),
 		)
 		.option(
 			"--link-category <cat>",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -178,10 +178,10 @@ module.exports = {
 
 	/**
 	 * The maximum size in bytes remaining for a torrent to be resumed.
-	 * Must be in the range of 0 to 52428800 (50 MiB).
+	 * Must be in the range of 0 to 104857600 (100 MiB).
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
-	autoResumeMaxDownload: 52428800,
+	autoResumeMaxDownload: 104857600,
 
 	/**
 	 * Determines how deep into the specified dataDirs to go to generate new

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -41,7 +41,7 @@ const ZodErrorMessages = {
 		"excludeOlder and excludeRecentSearch must be defined for searching. excludeOlder must be 2-5x excludeRecentSearch.",
 	injectNeedsInjectMode: "`cross-seed inject` requires the 'inject' action.",
 	autoResumeMaxDownloadUnsupported:
-		"autoResumeMaxDownload must be an integer of bytes between between 0 and 52428800 (50 MiB).",
+		"autoResumeMaxDownload must be an integer of bytes between between 0 and 104857600 (100 MiB).",
 	numberMustBeRatio:
 		"fuzzySizeThreshold and seasonFromEpisodes must be between 0 and 1.",
 	fuzzySizeThresholdMax:
@@ -364,7 +364,7 @@ export const VALIDATION_SCHEMA = z
 			.number()
 			.int()
 			.gte(0, ZodErrorMessages.autoResumeMaxDownloadUnsupported)
-			.lte(52428800, ZodErrorMessages.autoResumeMaxDownloadUnsupported),
+			.lte(104857600, ZodErrorMessages.autoResumeMaxDownloadUnsupported),
 		linkCategory: z.string().nullish(),
 		linkDir: z.string().nullish(),
 		linkDirs: z.array(z.string()).optional().default([]),


### PR DESCRIPTION
A lot of users have asked for an increase to `100 MiB` since a lot of samples top out in the `50-100  MiB` range. I changed the default to this new max since most users would probably want it, though the partial matching tutorial mentions this option anyways.

The main downside is a higher chance of `cross-seed` resuming a partial season pack that's missing an episode, but it's extremely rare for an episode to be less than `100 MiB`.

I think this should be the absolute limit for this setting. @zakkarry mentioned alternative methods for resuming, but I think that would need to be saved for v7.

I would like to reiterate here that these matches still need to respect `fuzzySizeThreshold`. So the minimum torrent size that could use a `100 MiB` auto resume is `1 GiB` or `5 GiB` with the default fuzzy.