### PR TITLE
feat(inject/ignoreFiles): ignore certain non-relevant files for resume behavior with partial matches

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -544,7 +544,7 @@ export async function performActionWithoutMutex(
 				message: `Rechecking ${getLogString(newMeta)} as new files were linked from ${getLogString(searchee)}`,
 			});
 			await client.recheckTorrent(newMeta.infoHash);
-			client.resumeInjection(newMeta.infoHash, decision, {
+			client.resumeInjection(newMeta, decision, {
 				checkOnce: false,
 			});
 		}

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -30,7 +30,7 @@ import {
 	wait,
 } from "../utils.js";
 import {
-	calculateSizeForAutoResume,
+	shouldResumeFromNonRelevantFiles,
 	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
@@ -336,9 +336,8 @@ export default class Deluge implements TorrentClient {
 				}
 				if (torrentInfo.total_remaining! > maxRemainingBytes) {
 					if (
-						!calculateSizeForAutoResume(
-							meta.files,
-							torrentInfo.total_size!,
+						!shouldResumeFromNonRelevantFiles(
+							meta,
 							torrentInfo.total_remaining!,
 							torrentLog,
 							this.label,

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -344,7 +344,7 @@ export default class Deluge implements TorrentClient {
 					) {
 						logger.warn({
 							label: this.label,
-							message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.total_remaining!, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+							message: `autoResumeMaxDownload will not resume ${torrentLog}: remainingSize ${humanReadableSize(torrentInfo.total_remaining!, { binary: true })} > ${humanReadableSize(maxRemainingBytes, { binary: true })} limit`,
 						});
 						return;
 					}

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -339,8 +339,7 @@ export default class Deluge implements TorrentClient {
 						!shouldResumeFromNonRelevantFiles(
 							meta,
 							torrentInfo.total_remaining!,
-							torrentLog,
-							this.label,
+							{ torrentLog, label: this.label },
 						)
 					) {
 						logger.warn({

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -34,7 +34,7 @@ import {
 	wait,
 } from "../utils.js";
 import {
-	calculateSizeForAutoResume,
+	shouldResumeFromNonRelevantFiles,
 	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
@@ -842,9 +842,8 @@ export default class QBittorrent implements TorrentClient {
 			}
 			if (torrentInfo.amount_left! > maxRemainingBytes) {
 				if (
-					!calculateSizeForAutoResume(
-						meta.files,
-						torrentInfo.total_size!,
+					!shouldResumeFromNonRelevantFiles(
+						meta,
 						torrentInfo.amount_left!,
 						torrentLog,
 						this.label,

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -850,7 +850,7 @@ export default class QBittorrent implements TorrentClient {
 				) {
 					logger.warn({
 						label: this.label,
-						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.amount_left, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+						message: `autoResumeMaxDownload will not resume ${torrentLog}: remainingSize ${humanReadableSize(torrentInfo.amount_left, { binary: true })} > ${humanReadableSize(maxRemainingBytes, { binary: true })} limit`,
 					});
 					return;
 				}

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -840,18 +840,17 @@ export default class QBittorrent implements TorrentClient {
 				});
 				return;
 			}
-			if (torrentInfo.amount_left! > maxRemainingBytes) {
+			if (torrentInfo.amount_left > maxRemainingBytes) {
 				if (
 					!shouldResumeFromNonRelevantFiles(
 						meta,
-						torrentInfo.amount_left!,
-						torrentLog,
-						this.label,
+						torrentInfo.amount_left,
+						{ torrentLog, label: this.label },
 					)
 				) {
 					logger.warn({
 						label: this.label,
-						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.amount_left!, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.amount_left, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
 					});
 					return;
 				}

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -754,18 +754,17 @@ export default class RTorrent implements TorrentClient {
 				});
 				return;
 			}
-			if (torrentInfo.bytesLeft! > maxRemainingBytes) {
+			if (torrentInfo.bytesLeft > maxRemainingBytes) {
 				if (
 					!shouldResumeFromNonRelevantFiles(
 						meta,
-						torrentInfo.bytesLeft!,
-						torrentLog,
-						this.label,
+						torrentInfo.bytesLeft,
+						{ torrentLog, label: this.label },
 					)
 				) {
 					logger.warn({
 						label: this.label,
-						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.bytesLeft!, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.bytesLeft, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
 					});
 					return;
 				}

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -764,7 +764,7 @@ export default class RTorrent implements TorrentClient {
 				) {
 					logger.warn({
 						label: this.label,
-						message: `Will not resume ${torrentLog}: ${humanReadableSize(torrentInfo.bytesLeft, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+						message: `autoResumeMaxDownload will not resume ${torrentLog}: remainingSize ${humanReadableSize(torrentInfo.bytesLeft, { binary: true })} > ${humanReadableSize(maxRemainingBytes, { binary: true })} limit`,
 					});
 					return;
 				}

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -32,7 +32,7 @@ import {
 	wait,
 } from "../utils.js";
 import {
-	calculateSizeForAutoResume,
+	shouldResumeFromNonRelevantFiles,
 	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
@@ -756,9 +756,8 @@ export default class RTorrent implements TorrentClient {
 			}
 			if (torrentInfo.bytesLeft! > maxRemainingBytes) {
 				if (
-					!calculateSizeForAutoResume(
-						meta.files,
-						meta.length!,
+					!shouldResumeFromNonRelevantFiles(
+						meta,
 						torrentInfo.bytesLeft!,
 						torrentLog,
 						this.label,

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -457,12 +457,10 @@ export default class Transmission implements TorrentClient {
 			}
 			if (leftUntilDone > maxRemainingBytes) {
 				if (
-					!shouldResumeFromNonRelevantFiles(
-						meta,
-						leftUntilDone,
+					!shouldResumeFromNonRelevantFiles(meta, leftUntilDone, {
 						torrentLog,
-						this.label,
-					)
+						label: this.label,
+					})
 				) {
 					logger.warn({
 						label: this.label,

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -464,7 +464,7 @@ export default class Transmission implements TorrentClient {
 				) {
 					logger.warn({
 						label: this.label,
-						message: `Will not resume ${torrentLog}: ${humanReadableSize(leftUntilDone, { binary: true })} remaining > ${humanReadableSize(maxRemainingBytes, { binary: true })}`,
+						message: `autoResumeMaxDownload will not resume ${torrentLog}: remainingSize ${humanReadableSize(leftUntilDone, { binary: true })} > ${humanReadableSize(maxRemainingBytes, { binary: true })} limit`,
 					});
 					return;
 				}

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -28,7 +28,7 @@ import {
 	wait,
 } from "../utils.js";
 import {
-	calculateSizeForAutoResume,
+	shouldResumeFromNonRelevantFiles,
 	ClientSearcheeResult,
 	getMaxRemainingBytes,
 	getResumeStopTime,
@@ -457,9 +457,8 @@ export default class Transmission implements TorrentClient {
 			}
 			if (leftUntilDone > maxRemainingBytes) {
 				if (
-					!calculateSizeForAutoResume(
-						meta.files,
-						meta.length,
+					!shouldResumeFromNonRelevantFiles(
+						meta,
 						leftUntilDone,
 						torrentLog,
 						this.label,

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -63,6 +63,15 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			"Don't use torrents from your client for matching",
 		)
 		.option(
+			"--ignore-non-relevant-files-to-resume",
+			"Ignore certain known irrelevant files when calculating resume size",
+			fallback(fileConfig.ignoreNonRelevantFilesToResume, false),
+		)
+		.option(
+			"--no-ignore-non-relevant-files-to-resume",
+			"Don't ignore certain known irrelevant files when calculating resume size",
+		)
+		.option(
 			"--data-dirs <dirs...>",
 			"Directories to use if searching by data instead of torrents (separated by spaces)",
 			// @ts-expect-error commander supports non-string defaults

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -188,12 +188,13 @@ module.exports = {
 	autoResumeMaxDownload: 52428800,
 
 	/**
-	 *  Whether or not to ignore certain known-irrelevant files such as nfo,
-	 *  sample, txt, subs, proofs, and bonus/commentary files in the auto resume
-	 *  check. This functionality will only work if after exclusion the size is within
-	 *  fuzzySizeThreshold for remaining files size difference.
+	 * If the amount remaining is above autoResumeMaxDownload, resume if the
+	 * only files missing are known-irrelevant files such as nfo, sample, txt,
+	 * subs, proofs, and bonus/commentary files.
+	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
 	ignoreNonRelevantFilesToResume: false,
+
 	/**
 	 * Determines how deep into the specified dataDirs to go to generate new
 	 * searchees.

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -188,6 +188,13 @@ module.exports = {
 	autoResumeMaxDownload: 52428800,
 
 	/**
+	 *  Whether or not to ignore certain known-irrelevant files such as nfo,
+	 *  sample, txt, subs, proofs, and bonus/commentary files in the auto resume
+	 *  check. This functionality will only work if after exclusion the size is within
+	 *  fuzzySizeThreshold for remaining files size difference.
+	 */
+	ignoreNonRelevantFilesToResume: false,
+	/**
 	 * Determines how deep into the specified dataDirs to go to generate new
 	 * searchees.
 	 *

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -188,9 +188,10 @@ module.exports = {
 	autoResumeMaxDownload: 52428800,
 
 	/**
-	 * If the amount remaining is above autoResumeMaxDownload, resume if the
-	 * only files missing are known-irrelevant files such as nfo, sample, txt,
-	 * subs, proofs, and bonus/commentary files.
+	 * If set to `true` and the amount remaining is above autoResumeMaxDownload,
+	 * resume if accumulated size of the missing files is less than the
+	 * accumulated size of the known-irrelevant files such as nfo, sample, txt,
+	 * subs, proofs, and bonus/commentary files present in the torrent.
 	 * https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once
 	 */
 	ignoreNonRelevantFilesToResume: false,

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -370,6 +370,10 @@ export const VALIDATION_SCHEMA = z
 			.int()
 			.gte(0, ZodErrorMessages.autoResumeMaxDownloadUnsupported)
 			.lte(52428800, ZodErrorMessages.autoResumeMaxDownloadUnsupported),
+		ignoreNonRelevantFilesToResume: z
+			.boolean()
+			.nullish()
+			.transform((v) => (typeof v === "boolean" ? v : false)),
 		linkCategory: z.string().nullish(),
 		linkDir: z.string().nullish(),
 		linkDirs: z.array(z.string()).optional().default([]),

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,6 +25,7 @@ export interface FileConfig {
 	matchMode?: MatchMode;
 	skipRecheck?: boolean;
 	autoResumeMaxDownload?: number;
+	ignoreNonRelevantFilesToResume?: boolean;
 	linkDir?: string;
 	linkDirs?: string[];
 	linkType?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -257,8 +257,9 @@ export const RESUME_EXCLUDED_KEYWORDS: string[] = [
 	"extras",
 	"bonus",
 ];
-export const RESUME_EXCLUDED_FILETYPES: string[] = [
+export const RESUME_EXCLUDED_EXTS: string[] = [
 	".nfo",
+	".srr",
 	".srt",
 	".txt",
 	".ass",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -251,3 +251,15 @@ export const IGNORED_FOLDERS_SUBSTRINGS = [
 	"certificate",
 	"video_ts",
 ];
+export const RESUME_EXCLUDED_KEYWORDS: string[] = [
+	"sample",
+	"trailer",
+	"extras",
+	"bonus",
+];
+export const RESUME_EXCLUDED_FILETYPES: string[] = [
+	".nfo",
+	".srt",
+	".txt",
+	".ass",
+];

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -312,7 +312,7 @@ async function injectFromStalledTorrent({
 			message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
 		});
 		await client!.recheckTorrent(meta.infoHash);
-		client!.resumeInjection(meta.infoHash, stalledDecision, {
+		client!.resumeInjection(meta, stalledDecision, {
 			checkOnce: false,
 		});
 	} else {
@@ -378,7 +378,7 @@ async function injectionAlreadyExists({
 			label: Label.INJECT,
 			message: `${progress} ${filePathLog} is being checked by client - ${chalk.green(injectionResult)}`,
 		});
-		client!.resumeInjection(meta.infoHash, decision, {
+		client!.resumeInjection(meta, decision, {
 			checkOnce: false,
 		});
 	} else if (!isComplete && decision !== Decision.MATCH_PARTIAL) {
@@ -389,7 +389,7 @@ async function injectionAlreadyExists({
 			message: `${progress} Rechecking ${filePathLog} as it's not complete but has all files (final check at ${humanReadableDate(finalCheckTime)}) - ${chalk.yellow(injectionResult)}`,
 		});
 		await client!.recheckTorrent(meta.infoHash);
-		client!.resumeInjection(meta.infoHash, decision, {
+		client!.resumeInjection(meta, decision, {
 			checkOnce: false,
 		});
 		if (Date.now() >= finalCheckTime) {
@@ -406,7 +406,7 @@ async function injectionAlreadyExists({
 				label: Label.INJECT,
 				message: `${progress} ${filePathLog} - ${chalk.yellow(injectionResult)} (incomplete)`,
 			});
-			client!.resumeInjection(meta.infoHash, decision, {
+			client!.resumeInjection(meta, decision, {
 				checkOnce: true,
 			});
 		}

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -8,6 +8,7 @@ export interface RuntimeConfig {
 	matchMode: MatchMode;
 	skipRecheck: boolean;
 	autoResumeMaxDownload: number;
+	ignoreNonRelevantFilesToResume: boolean;
 	linkDirs: string[];
 	linkType: LinkType;
 	flatLinking: boolean;


### PR DESCRIPTION
The behavior idea I had in mind involves excluding known non-relevant files as a second measure to check if resuming is desired. This should cover most instances where any sample or miscellaneous file commonly included in some trackers prevents resuming and provides a larger buffer to resume with.

The option to enable this behavior is `ignoreNonRelevantFilesToResume`. Defaults, if not included in the config (onboarding), to false. The previous behavior stays intact with the 50MB limit, but I'm not sure that increasing it as @ShanaryS suggests in #939 is necessary given this option's functionality, and I would contend that that is not the best or proper "total" solution for the job.
