### PR TITLE
enhancement(inject): link files from multiple searchees

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -535,7 +535,18 @@ export async function performActionWithoutMutex(
 		if (shouldRecheck(searchee, decision) || !searchee.infoHash) {
 			await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
 		}
-	} else if (actionResult !== InjectionResult.ALREADY_EXISTS) {
+	} else if (actionResult === InjectionResult.ALREADY_EXISTS) {
+		if (linkedNewFiles) {
+			logger.info({
+				label: client.label,
+				message: `Rechecking ${getLogString(newMeta)} as new files were linked from ${getLogString(searchee)}`,
+			});
+			await client.recheckTorrent(newMeta.infoHash);
+			client.resumeInjection(newMeta.infoHash, decision, {
+				checkOnce: false,
+			});
+		}
+	} else {
 		await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
 		if (unlinkOk && destinationDir) {
 			unlinkMetafile(newMeta, destinationDir);


### PR DESCRIPTION
This was previously only supported from the inject job, it is now supported from `search`, `rss`, and `announce`. The main change was moving the check from the inject job to the action stage. If the torrent already existed and new files were linked, we will recheck and resume.

The main benefit is to prevent unnecessary downloads when another searchee has the file. For example, the user has two searchees, one with `.nfo` and another with `.srt` and the candidate needs both. It partly addresses this [FAQ](https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once).

Since the searchees from `search` are already grouped by similarity for caching, no change is needed in the process. However for `rss` and `announce`, we will now process all searches even if injection was successful if it was a partial match.

Searches from `webhook` doesn't apply since it's only a single searchee (or multiple which aren't cross seeds of each other). Since we also `ignoreCrossSeeds` by default, it means there can't be multiple searchees to use anyways.