### PR TITLE
fix(regex): cover edgecases in scene title parsing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export const YEARS_REGEX = /(?<year>(?:19|20)\d{2})(?![pix])/gi;
 export const REPACK_PROPER_REGEX =
 	/(?:\b(?<type>(?:REPACK|PROPER|\dv\d)\d?))\b/i;
 export const ARR_PROPER_REGEX = /(?:\b(?<arrtype>(?:Proper|\dv\d)))\b/;
-export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{0,5}-)?(?<title>.*)/;
+export const SCENE_TITLE_REGEX = /^(?:[a-z0-9]{3,5}-)?(?<title>.*)/;
 export const ARR_DIR_REGEX =
 	/^(?<title>(?!.*(?:(\d{3,4}[ipx])|([xh.]+26[4-6])|(dvd)|(mpeg)|(xvid)|(?:(he)|a)vc))[\p{L}\s:\w'’!();.,&–+-]+(?:\(\d{4}\))?)(?<id>\s[{[](?:tm|tv|im)db(?:id)?-\w+?[}\]])?$/iu;
 export const SONARR_SUBFOLDERS_REGEX =


### PR DESCRIPTION
Covers parsing titles should as `'9-1-1.S01` into `1-1`.