### PR TITLE
fix(cmd): use metafile directly for diff and tree

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -19,7 +19,6 @@ import { injectSavedTorrents, restoreFromTorrentCache } from "./inject.js";
 import { jobsLoop } from "./jobs.js";
 import { bulkSearch, scanRssFeeds } from "./pipeline.js";
 import { sendTestNotification } from "./pushNotifier.js";
-import { createSearcheeFromMetafile } from "./searchee.js";
 import { serve } from "./server.js";
 import { withFullRuntime, withMinimalRuntime } from "./startup.js";
 import {
@@ -316,14 +315,10 @@ program
 				console.log(
 					"Use `cross-seed diff` to compare two .torrent files",
 				);
-				const res = createSearcheeFromMetafile(
-					await parseTorrentFromFilename(torrentPath),
-				);
-				if (res.isErr()) return console.log(res.unwrapErr());
-				const searchee = res.unwrap();
-				delete searchee.category;
-				delete searchee.tags;
-				console.log(searchee);
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const { category, isSingleFileTorrent, raw, tags, ...meta } =
+					await parseTorrentFromFilename(torrentPath);
+				console.log(meta);
 			},
 			{ migrate: false },
 		),

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,5 +1,4 @@
 import { deepStrictEqual } from "assert";
-import { createSearcheeFromMetafile, Searchee } from "./searchee.js";
 import { parseTorrentFromFilename } from "./torrent.js";
 
 function diff(thing1, thing2) {
@@ -16,33 +15,13 @@ function diff(thing1, thing2) {
 }
 
 export async function diffCmd(first: string, second: string): Promise<void> {
-	const firstMeta = await parseTorrentFromFilename(first);
-	const secondMeta = await parseTorrentFromFilename(second);
-	const firstRes = createSearcheeFromMetafile(firstMeta);
-	if (firstRes.isErr()) {
-		console.log(firstRes.unwrapErr());
-		return;
-	}
-	const secondRes = createSearcheeFromMetafile(secondMeta);
-	if (secondRes.isErr()) {
-		console.log(secondRes.unwrapErr());
-		return;
-	}
-	const s1 = firstRes.unwrap();
-	const s2 = secondRes.unwrap();
+	const f1 = (await parseTorrentFromFilename(first)).files;
+	const f2 = (await parseTorrentFromFilename(second)).files;
 	const sortBy =
-		s1.files.length === 1
+		f1.length === 1
 			? (a, b) => b.length - a.length
-			: s2.files.length === 1
+			: f2.length === 1
 				? (a, b) => a.length - b.length
 				: (a, b) => a.path.localeCompare(b.path);
-
-	const stripForDiff = (searchee: Searchee) => {
-		for (const key of Object.keys(searchee)) {
-			if (key !== "files") delete searchee[key];
-		}
-		searchee.files.sort(sortBy);
-		return searchee;
-	};
-	return diff(stripForDiff(s1), stripForDiff(s2));
+	return diff(f1.sort(sortBy), f2.sort(sortBy));
 }


### PR DESCRIPTION
Creating searchees can fail if certain criteria aren't met.