### PR TITLE
update(search): `EPISODE` `SEASON` `MOVIE` if tracker support XXX

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -338,9 +338,9 @@ export function indexerDoesSupportMediaType(
 	switch (mediaType) {
 		case MediaType.EPISODE:
 		case MediaType.SEASON:
-			return caps.tv;
+			return caps.tv || caps.anime || caps.xxx;
 		case MediaType.MOVIE:
-			return caps.movie;
+			return caps.movie || caps.anime || caps.xxx;
 		case MediaType.ANIME:
 		case MediaType.VIDEO:
 			return caps.movie || caps.tv || caps.anime || caps.xxx;


### PR DESCRIPTION
Some XXX tiles uses standard formatting. If the tracker only has XXX categories for its caps, these wouldn't have been searched. The same logic applies for anime.