### PR TITLE
feat(torrentClients): support clients as readonly

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -263,7 +263,7 @@ async function getClientAndDestinationDir(
 			return null;
 		}
 		let error: Error | undefined;
-		for (const testClient of getClients()) {
+		for (const testClient of getClients().filter((c) => !c.readonly)) {
 			const torrentSavePaths = new Set(
 				(
 					await testClient.getAllDownloadDirs({
@@ -424,7 +424,9 @@ export async function performActionWithoutMutex(
 	let client =
 		clients.length === 1
 			? clients[0]
-			: clients.find((c) => c.clientHost === searchee.clientHost);
+			: clients.find(
+					(c) => c.clientHost === searchee.clientHost && !c.readonly,
+				);
 	if (linkDirs.length) {
 		const savePathRes = await getSavePath(client, searchee, options);
 		if (savePathRes.isErr()) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -85,6 +85,7 @@ export default class Deluge implements TorrentClient {
 	readonly clientHost: string;
 	readonly clientPriority: number;
 	readonly clientType = Label.DELUGE;
+	readonly readonly: boolean;
 	readonly label: string;
 	private delugeCookie: string | null = null;
 	private delugeLabel = TORRENT_TAG;
@@ -92,10 +93,11 @@ export default class Deluge implements TorrentClient {
 	private isLabelEnabled: boolean;
 	private delugeRequestId: number = 0;
 
-	constructor(url: string, priority: number) {
+	constructor(url: string, priority: number, readonly: boolean) {
 		this.url = url;
 		this.clientHost = new URL(url).host;
 		this.clientPriority = priority;
+		this.readonly = readonly;
 		this.label = `${this.clientType}@${this.clientHost}`;
 	}
 
@@ -108,7 +110,7 @@ export default class Deluge implements TorrentClient {
 		this.isLabelEnabled = await this.labelEnabled();
 		logger.info({
 			label: this.label,
-			message: `Logged in successfully`,
+			message: `Logged in successfully${this.readonly ? " (readonly)" : ""}`,
 		});
 
 		if (!torrentDir) return;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -122,11 +122,13 @@ export default class QBittorrent implements TorrentClient {
 	readonly clientHost: string;
 	readonly clientPriority: number;
 	readonly clientType = Label.QBITTORRENT;
+	readonly readonly: boolean;
 	readonly label: string;
 
-	constructor(url: string, priority: number) {
+	constructor(url: string, priority: number, readonly: boolean) {
 		this.clientHost = new URL(url).host;
 		this.clientPriority = priority;
+		this.readonly = readonly;
 		this.label = `${this.clientType}@${this.clientHost}`;
 		this.url = extractCredentialsFromUrl(url, "/api/v2").unwrapOrThrow(
 			new CrossSeedError(
@@ -187,7 +189,7 @@ export default class QBittorrent implements TorrentClient {
 		}
 		logger.info({
 			label: this.label,
-			message: `Logged in to ${this.version} successfully`,
+			message: `Logged in to ${this.version} successfully${this.readonly ? " (readonly)" : ""}`,
 		});
 	}
 

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -106,12 +106,14 @@ export default class RTorrent implements TorrentClient {
 	readonly clientHost: string;
 	readonly clientPriority: number;
 	readonly clientType = Label.RTORRENT;
+	readonly readonly: boolean;
 	readonly label: string;
 	readonly batchSize = 500;
 
-	constructor(url: string, priority: number) {
+	constructor(url: string, priority: number, readonly: boolean) {
 		this.clientHost = new URL(url).host;
 		this.clientPriority = priority;
+		this.readonly = readonly;
 		this.label = `${this.clientType}@${this.clientHost}`;
 		const { href, username, password } = extractCredentialsFromUrl(
 			url,
@@ -320,7 +322,7 @@ export default class RTorrent implements TorrentClient {
 		}
 		logger.info({
 			label: this.label,
-			message: `Logged in successfully`,
+			message: `Logged in successfully${this.readonly ? " (readonly)" : ""}`,
 		});
 
 		if (!torrentDir) return;

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -90,12 +90,14 @@ export default class Transmission implements TorrentClient {
 	readonly clientHost: string;
 	readonly clientPriority: number;
 	readonly clientType = Label.TRANSMISSION;
+	readonly readonly: boolean;
 	readonly label: string;
 
-	constructor(url: string, priority: number) {
+	constructor(url: string, priority: number, readonly: boolean) {
 		this.url = url;
 		this.clientHost = new URL(url).host;
 		this.clientPriority = priority;
+		this.readonly = readonly;
 		this.label = `${this.clientType}@${this.clientHost}`;
 	}
 
@@ -185,7 +187,7 @@ export default class Transmission implements TorrentClient {
 		}
 		logger.info({
 			label: this.label,
-			message: `Logged in successfully`,
+			message: `Logged in successfully${this.readonly ? " (readonly)" : ""}`,
 		});
 
 		if (!torrentDir) return;

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -193,7 +193,7 @@ function createCommandWithSharedOptions(name: string, description: string) {
 		)
 		.option(
 			"--torrent-clients <clients...>",
-			"The the client prefix and urls of your torrent clients.",
+			"The the client prefix, readonly status, and urls of your torrent clients.",
 			// @ts-expect-error commander supports non-string defaults
 			fallback(fileConfig.torrentClients, []),
 		)

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -82,6 +82,10 @@ module.exports = {
 	 * torrentClients: ["transmission:http://username:password@localhost:9091/transmission/rpc"]
 	 *
 	 * torrentClients: ["deluge:http://:password@localhost:8112/json"]
+	 *
+	 * You can optionally add readonly: after the prefix to use a client as a
+	 * source for finding cross seeds, but not for injecting.
+	 * e.g. "qbittorrent:readonly:http://username:password@localhost:8080"
 	 */
 	torrentClients: [],
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -56,7 +56,8 @@ const ZodErrorMessages = {
 			Label.DELUGE,
 		].map((l) => `${l}:`),
 		{ sort: false, style: "narrow", type: "unit" },
-	)}`,
+	)} and optionally followed by readonly: (e.g torrentClients: ["qbittorrent:http://username:password@localhost:8080", "rtorrent:readonly:http://username:password@localhost:1234/RPC2"])`,
+	clientTypeReadOnly: `You must have at least one non-readonly torrent client when using action: "inject"`,
 	multipleClientsTorrentFile:
 		"torrentDir and --torrents arg does not support multiple clients, use useClientTorrents instead.",
 	multipleClientsNoLinking:
@@ -587,6 +588,12 @@ export const VALIDATION_SCHEMA = z
 			!config.useClientTorrents ||
 			!config.torrentClients.some((c) => c.startsWith(Label.DELUGE)),
 		"Deluge does not currently support useClientTorrents, use torrentDir instead.",
+	)
+	.refine(
+		(config) =>
+			config.action !== Action.INJECT ||
+			config.torrentClients.some((c) => !c.includes(":readonly:")),
+		ZodErrorMessages.clientTypeReadOnly,
 	)
 	.refine(
 		(config) =>


### PR DESCRIPTION
fixes #926

This allows a user to define clients to use only to source cross seeds from, but not to inject into. This better alternative to the [3rd use case](https://www.cross-seed.org/docs/tutorials/data-based-matching#general-usage-for-datadirs) for dataDirs. If the user is using `action: "inject"`, at least one client must be `non-readonly`.

Users will denote `readonly` status by:
`torrentClients: ["deluge:http://:password@localhost:8112/json", "qbittorrent:readonly:http://username:password@localhost:8080"]`
where all cross seeds would be injected into deluge but can also match from qbit.

The only change required is during the action stage. We simply filter out any clients that are `readonly` from being selected, while still keeping them for checking existing.