### PR TITLE
fix(torrentClients): treat readonly searchees as data-based

### DIFF
--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -84,7 +84,7 @@ module.exports = {
 	 * torrentClients: ["deluge:http://:password@localhost:8112/json"]
 	 *
 	 * You can optionally add readonly: after the prefix to use a client as a
-	 * source for finding cross seeds, but not for injecting.
+	 * source for finding cross seeds but not for injecting.
 	 * e.g. "qbittorrent:readonly:http://username:password@localhost:8080"
 	 */
 	torrentClients: [],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,14 +275,14 @@ export function getLogString(
 	color: ChalkInstance = chalk.reset,
 ) {
 	if (searchee.title === searchee.name) {
-		return searchee.infoHash
-			? `${color(searchee.title)} ${chalk.dim(`[${sanitizeInfoHash(searchee.infoHash)}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]`)}`
+		return searchee.infoHash || searchee.clientHost
+			? `${color(searchee.title)} ${chalk.dim(`[${searchee.infoHash ? sanitizeInfoHash(searchee.infoHash) : ""}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]`)}`
 			: searchee.path
 				? color(searchee.path)
 				: color(searchee.title);
 	}
-	return searchee.infoHash
-		? `${color(searchee.title)} ${chalk.dim(`[${searchee.name} [${sanitizeInfoHash(searchee.infoHash)}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]]`)}`
+	return searchee.infoHash || searchee.clientHost
+		? `${color(searchee.title)} ${chalk.dim(`[${searchee.name} [${searchee.infoHash ? sanitizeInfoHash(searchee.infoHash) : ""}${searchee.clientHost ? `@${searchee.clientHost}` : ""}]]`)}`
 		: searchee.path
 			? `${color(searchee.title)} ${chalk.dim(`[${searchee.path}]`)}`
 			: `${color(searchee.title)} ${chalk.dim(`[${searchee.name}]`)}`;


### PR DESCRIPTION
If `infoHash` is present in the `inject()` function, the current logic expects it to be in client. By treating it as data-based, we only lose `duplicateCategories` functionality. But this is not a big deal since different clients uses `categories`, `tags`, and `labels` differently. Rewriting the `inject()` functions to preserve this is not worth it.