### PR TITLE
enhancement(job/inject): trigger inject job on webhook completion

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -151,6 +151,8 @@ async function search(
 	req: IncomingMessage,
 	res: ServerResponse,
 ): Promise<void> {
+	const injectJob = getJobs().find((job) => job.name === JobName.INJECT);
+	if (injectJob) injectJob.runAheadOfSchedule = true; // run on completion
 	await indexTorrentsAndDataDirs();
 	const dataStr = await getData(req);
 	let data;
@@ -394,6 +396,7 @@ async function runJob(
 	}
 
 	job.runAheadOfSchedule = true;
+	job.delayNextRun = true;
 	job.configOverride = {
 		excludeRecentSearch: data.ignoreExcludeRecentSearch ? 1 : undefined,
 		excludeOlder: data.ignoreExcludeOlder


### PR DESCRIPTION
This improves the inject job workflow as we often want to run after a download is completed in client:
1. The torrent that just completed had saved cross seeds due to `TORRENT_NOT_COMPLETE`. The inject job now triggers within the next minute to inject these earlier.
2. The torrent that just finished was a partial match. This could have downloaded new files for other partials matches, mainly for this [FAQ entry](https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once)

The next run time will be at its normal cadence unlike with the `/job` api.