### PR TITLE
fix(testLinking): add more checks around creating temp file

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -733,9 +733,24 @@ export function testLinking(srcDir: string): void {
 	try {
 		let srcFile = findAFileWithExt(srcDir, ALL_EXTENSIONS);
 		if (!srcFile) {
+			try {
+				fs.accessSync(srcDir, fs.constants.W_OK);
+			} catch (e) {
+				logger.error(e);
+				logger.error(
+					`Failed to access ${srcDir}, cross-seed is unable to verify linking for this path.`,
+				);
+				return;
+			}
 			tempFile = join(srcDir, srcTestName);
 			try {
 				fs.writeFileSync(tempFile, "");
+				if (!fs.existsSync(tempFile)) {
+					logger.error(
+						`Failed to verify test file in ${tempFile}, cross-seed is unable to verify linking for this path.`,
+					);
+					return;
+				}
 				srcFile = tempFile;
 			} catch (e) {
 				logger.error(e);


### PR DESCRIPTION
Creating a temp file for testing linking is used if we can't find any valid file to link with (the extensions we support) and `stat.dev` isn't available. If we fail to create a tempfile, we log and error but do not fail validation.
1. Check if we have write access to create a temp file. This can happen if we are testing `dataDirs` as we only require read permissions for that.
2. Verify tempfile was created before trying to use it, the write can silently fail it seems.