### PR TITLE
update(db): remove memDB

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -204,9 +204,7 @@ async function getSavePath(
 			})
 		).newSearchees.find((s) => s.infoHash === searchee.infoHash);
 		if (!refreshedSearchee) return resultOfErr("TORRENT_NOT_FOUND");
-		for (const [key, value] of Object.entries(refreshedSearchee)) {
-			searchee[key] = value;
-		}
+		Object.assign(searchee, refreshedSearchee);
 		if (
 			!(await client.isTorrentComplete(searchee.infoHash)).orElse(false)
 		) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -7,7 +7,7 @@ import {
 	TORRENT_CATEGORY_SUFFIX,
 	TORRENT_TAG,
 } from "../constants.js";
-import { memDB } from "../db.js";
+import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -711,7 +711,7 @@ export default class Deluge implements TorrentClient {
 		for (const [hash, torrent] of Object.entries(torrents)) {
 			const infoHash = hash.toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await memDB("torrent")
+			const dbTorrent = await db("client_searchees")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -711,7 +711,7 @@ export default class Deluge implements TorrentClient {
 		for (const [hash, torrent] of Object.entries(torrents)) {
 			const infoHash = hash.toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await db("client_searchees")
+			const dbTorrent = await db("client_searchee")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -642,7 +642,7 @@ export default class QBittorrent implements TorrentClient {
 				torrent.infohash_v1 || torrent.hash
 			).toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await db("client_searchees")
+			const dbTorrent = await db("client_searchee")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -9,7 +9,7 @@ import {
 	TORRENT_CATEGORY_SUFFIX,
 	TORRENT_TAG,
 } from "../constants.js";
-import { memDB } from "../db.js";
+import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -642,7 +642,7 @@ export default class QBittorrent implements TorrentClient {
 				torrent.infohash_v1 || torrent.hash
 			).toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await memDB("torrent")
+			const dbTorrent = await db("client_searchees")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -643,7 +643,7 @@ export default class RTorrent implements TorrentClient {
 		for (let i = 0; i < hashes.length; i++) {
 			const infoHash = hashes[i].toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await db("client_searchees")
+			const dbTorrent = await db("client_searchee")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -8,7 +8,7 @@ import {
 	InjectionResult,
 	TORRENT_TAG,
 } from "../constants.js";
-import { memDB } from "../db.js";
+import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -643,7 +643,7 @@ export default class RTorrent implements TorrentClient {
 		for (let i = 0; i < hashes.length; i++) {
 			const infoHash = hashes[i].toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await memDB("torrent")
+			const dbTorrent = await db("client_searchees")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -6,7 +6,7 @@ import {
 	InjectionResult,
 	TORRENT_TAG,
 } from "../constants.js";
-import { memDB } from "../db.js";
+import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
 import { Label, logger } from "../logger.js";
 import { Metafile } from "../parseTorrent.js";
@@ -348,7 +348,7 @@ export default class Transmission implements TorrentClient {
 		for (const torrent of torrents) {
 			const infoHash = torrent.hashString.toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await memDB("torrent")
+			const dbTorrent = await db("client_searchees")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -348,7 +348,7 @@ export default class Transmission implements TorrentClient {
 		for (const torrent of torrents) {
 			const infoHash = torrent.hashString.toLowerCase();
 			infoHashes.add(infoHash);
-			const dbTorrent = await db("client_searchees")
+			const dbTorrent = await db("client_searchee")
 				.where("info_hash", infoHash)
 				.where("client_host", this.clientHost)
 				.first();

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -343,6 +343,21 @@ program
 	);
 
 program
+	.command("clear-client-cache")
+	.description(
+		"Clear cross-seed's cache of your client's torrents. Only necessary if you have recently changed clients or modified the torrents in client and don't want to wait on the cleanup job.",
+	)
+	.action(
+		withMinimalRuntime(async () => {
+			console.log("Clearing client cache...");
+			await db("torrent").del();
+			await db("client_searchees").del();
+			await db("data").del();
+			await db("ensemble").del();
+		}),
+	);
+
+program
 	.command("api-key")
 	.description("Show the api key")
 	.addOption(apiKeyOption)

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -351,7 +351,7 @@ program
 		withMinimalRuntime(async () => {
 			console.log("Clearing client cache...");
 			await db("torrent").del();
-			await db("client_searchees").del();
+			await db("client_searchee").del();
 			await db("data").del();
 			await db("ensemble").del();
 		}),

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -86,6 +86,7 @@ module.exports = {
 	 * You can optionally add readonly: after the prefix to use a client as a
 	 * source for finding cross seeds but not for injecting.
 	 * e.g. "qbittorrent:readonly:http://username:password@localhost:8080"
+	 * https://www.cross-seed.org/docs/basics/options#torrentclients
 	 */
 	torrentClients: [],
 

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -481,20 +481,6 @@ function cacheTorrentFile(meta: Metafile): boolean {
 	return true;
 }
 
-export async function cleanupTorrentCache(): Promise<void> {
-	const torrentCacheDir = path.join(appDir(), TORRENT_CACHE_FOLDER);
-	const files = readdirSync(torrentCacheDir);
-	const now = Date.now();
-	for (const file of files) {
-		const filePath = path.join(torrentCacheDir, file);
-		if (now - statSync(filePath).atimeMs > ms("1 year")) {
-			logger.verbose(`Deleting ${filePath}`);
-			await db("decision").where("info_hash", file.split(".")[0]).del();
-			unlinkSync(filePath);
-		}
-	}
-}
-
 export async function updateTorrentCache(
 	oldStr: string,
 	newStr: string,

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,13 +1,12 @@
 import ms from "ms";
 import { Action } from "./constants.js";
-import { db } from "./db.js";
+import { cleanupDB, db } from "./db.js";
 import { exitOnCrossSeedErrors } from "./errors.js";
 import { injectSavedTorrents } from "./inject.js";
 import { Label, logger } from "./logger.js";
 import { bulkSearch, scanRssFeeds } from "./pipeline.js";
 import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import { updateCaps } from "./torznab.js";
-import { cleanupTorrentCache } from "./decide.js";
 
 export enum JobName {
 	RSS = "rss",
@@ -76,7 +75,7 @@ function createJobs(): void {
 	if (action === Action.INJECT) {
 		jobs.push(new Job(JobName.INJECT, ms("1 hour"), injectSavedTorrents));
 	}
-	jobs.push(new Job(JobName.CLEANUP, ms("1 day"), cleanupTorrentCache));
+	jobs.push(new Job(JobName.CLEANUP, ms("1 day"), cleanupDB));
 }
 
 export function getJobs(): Job[] {

--- a/src/migrations/09-clientAndDataSearchees.ts
+++ b/src/migrations/09-clientAndDataSearchees.ts
@@ -1,7 +1,7 @@
 import Knex from "knex";
 
 async function up(knex: Knex.Knex): Promise<void> {
-	await knex.schema.createTable("client_searchees", (table) => {
+	await knex.schema.createTable("client_searchee", (table) => {
 		table.string("client_host");
 		table.string("info_hash").index();
 		table.primary(["client_host", "info_hash"]);
@@ -31,7 +31,7 @@ async function up(knex: Knex.Knex): Promise<void> {
 }
 
 async function down(knex: Knex.Knex): Promise<void> {
-	knex.schema.dropTable("client_searchees");
+	knex.schema.dropTable("client_searchee");
 	knex.schema.dropTable("data");
 	knex.schema.dropTable("ensemble");
 }

--- a/src/migrations/09-clientAndDataSearchees.ts
+++ b/src/migrations/09-clientAndDataSearchees.ts
@@ -1,0 +1,39 @@
+import Knex from "knex";
+
+async function up(knex: Knex.Knex): Promise<void> {
+	await knex.schema.createTable("client_searchees", (table) => {
+		table.string("client_host");
+		table.string("info_hash").index();
+		table.primary(["client_host", "info_hash"]);
+		table.string("name");
+		table.string("title");
+		table.json("files");
+		table.integer("length");
+		table.string("save_path");
+		table.string("category");
+		table.json("tags");
+		table.json("trackers");
+	});
+
+	await knex.schema.createTable("data", (table) => {
+		table.string("path").primary();
+		table.string("title");
+	});
+
+	await knex.schema.createTable("ensemble", (table) => {
+		table.string("client_host");
+		table.string("path").index();
+		table.primary(["client_host", "path"]);
+		table.string("info_hash").index();
+		table.string("ensemble");
+		table.string("element");
+	});
+}
+
+async function down(knex: Knex.Knex): Promise<void> {
+	knex.schema.dropTable("client_searchees");
+	knex.schema.dropTable("data");
+	knex.schema.dropTable("ensemble");
+}
+
+export default { name: "09-clientAndDataSearchees", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -7,6 +7,7 @@ import caps from "./05-caps.js";
 import uniqueDecisions from "./06-uniqueDecisions.js";
 import limits from "./07-limits.js";
 import rss from "./08-rss.js";
+import clientAndDataSearchees from "./09-clientAndDataSearchees.js";
 
 export const migrations = {
 	getMigrations: () =>
@@ -20,6 +21,7 @@ export const migrations = {
 			uniqueDecisions,
 			limits,
 			rss,
+			clientAndDataSearchees,
 		]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -17,7 +17,7 @@ import {
 	findPotentialNestedRoots,
 	findSearcheesFromAllDataDirs,
 } from "./dataFiles.js";
-import { db, memDB } from "./db.js";
+import { db } from "./db.js";
 import {
 	assessCandidateCaching,
 	getGuidInfoHashMap,
@@ -422,7 +422,7 @@ async function getEnsembleForCandidate(
 	const candidateLog = `${chalk.bold.white(candidate.name)} from ${candidate.tracker}`;
 	const { ensembleTitles, keyTitles, season } = seasonKeys;
 	const keys = keyTitles.map((keyTitle) => `${keyTitle}.${season}`);
-	const ensemble = await memDB("ensemble").whereIn("ensemble", keys);
+	const ensemble = await db("ensemble").whereIn("ensemble", keys);
 	if (ensemble.length === 0) {
 		logger.verbose({
 			label: searcheeLabel,
@@ -456,8 +456,8 @@ async function getEnsembleForCandidate(
 		[],
 	);
 	await inBatches(Array.from(entriesToDelete), async (batch) => {
-		await memDB("data").whereIn("path", batch).del();
-		await memDB("ensemble").whereIn("path", batch).del();
+		await db("data").whereIn("path", batch).del();
+		await db("ensemble").whereIn("path", batch).del();
 	});
 	if (filesWithElement.length === 0) {
 		logger.verbose({
@@ -629,13 +629,10 @@ export async function findAllSearchees(
 		);
 	} else {
 		if (useClientTorrents) {
-			const refresh = searcheeLabel === Label.SEARCH ? [] : undefined;
 			rawSearchees.push(
 				...(
 					await Promise.all(
-						clients.map((client) =>
-							client.getClientSearchees({ refresh }),
-						),
+						clients.map((client) => client.getClientSearchees()),
 					)
 				)
 					.map((r) => r.searchees)

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -23,7 +23,7 @@ import {
 	SONARR_SUBFOLDERS_REGEX,
 	VIDEO_EXTENSIONS,
 } from "./constants.js";
-import { memDB } from "./db.js";
+import { db } from "./db.js";
 import { Label, logger } from "./logger.js";
 import { Metafile } from "./parseTorrent.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
@@ -318,16 +318,16 @@ export async function updateSearcheeClientDB(
 	infoHashes: Set<string>,
 ): Promise<void> {
 	const removedInfoHashes: string[] = (
-		await memDB("torrent").select({ infoHash: "info_hash" })
+		await db("client_searchees").select({ infoHash: "info_hash" })
 	)
 		.map((t) => t.infoHash)
 		.filter((infoHash) => !infoHashes.has(infoHash));
 	await inBatches(removedInfoHashes, async (batch) => {
-		await memDB("torrent")
+		await db("client_searchees")
 			.whereIn("info_hash", batch)
 			.where("client_host", clientHost)
 			.del();
-		await memDB("ensemble")
+		await db("ensemble")
 			.whereIn("info_hash", batch)
 			.where("client_host", clientHost)
 			.del();
@@ -346,7 +346,7 @@ export async function updateSearcheeClientDB(
 			trackers: JSON.stringify(searchee.trackers),
 		})),
 		async (batch) => {
-			await memDB("torrent")
+			await db("client_searchees")
 				.insert(batch)
 				.onConflict(["client_host", "info_hash"])
 				.merge();

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -318,12 +318,12 @@ export async function updateSearcheeClientDB(
 	infoHashes: Set<string>,
 ): Promise<void> {
 	const removedInfoHashes: string[] = (
-		await db("client_searchees").select({ infoHash: "info_hash" })
+		await db("client_searchee").select({ infoHash: "info_hash" })
 	)
 		.map((t) => t.infoHash)
 		.filter((infoHash) => !infoHashes.has(infoHash));
 	await inBatches(removedInfoHashes, async (batch) => {
-		await db("client_searchees")
+		await db("client_searchee")
 			.whereIn("info_hash", batch)
 			.where("client_host", clientHost)
 			.del();
@@ -346,7 +346,7 @@ export async function updateSearcheeClientDB(
 			trackers: JSON.stringify(searchee.trackers),
 		})),
 		async (batch) => {
-			await db("client_searchees")
+			await db("client_searchee")
 				.insert(batch)
 				.onConflict(["client_host", "info_hash"])
 				.merge();

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -11,7 +11,7 @@ import {
 } from "./clients/TorrentClient.js";
 import { customizeErrorMessage, VALIDATION_SCHEMA } from "./configSchema.js";
 import { NEWLINE_INDENT, PROGRAM_NAME, PROGRAM_VERSION } from "./constants.js";
-import { db, memDB } from "./db.js";
+import { db } from "./db.js";
 import { CrossSeedError, exitOnCrossSeedErrors } from "./errors.js";
 import { initializeLogger, Label, logger } from "./logger.js";
 import { initializePushNotifier } from "./pushNotifier.js";
@@ -25,7 +25,6 @@ import { Awaitable, wait } from "./utils.js";
 
 export async function exitGracefully() {
 	await db.destroy();
-	await memDB.destroy();
 	process.exit();
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -506,7 +506,7 @@ export async function indexTorrentsAndDataDirs(
 		const { dataDirs, seasonFromEpisodes, torrentDir, useClientTorrents } =
 			getRuntimeConfig();
 		if (!useClientTorrents) {
-			const hashes = await db("client_searchees").select("info_hash");
+			const hashes = await db("client_searchee").select("info_hash");
 			await inBatches(hashes, async (batch) => {
 				await db("ensemble")
 					.whereIn(
@@ -515,7 +515,7 @@ export async function indexTorrentsAndDataDirs(
 					)
 					.del();
 			});
-			await db("client_searchees").del();
+			await db("client_searchee").del();
 		}
 		if (!torrentDir) {
 			const hashes = await db("torrent").select("info_hash");
@@ -572,7 +572,7 @@ export async function indexTorrentsAndDataDirs(
 
 export async function getInfoHashesToExclude(): Promise<Set<string>> {
 	const { useClientTorrents } = getRuntimeConfig();
-	const database = useClientTorrents ? db("client_searchees") : db("torrent");
+	const database = useClientTorrents ? db("client_searchee") : db("torrent");
 	return new Set(
 		(await database.select({ infoHash: "info_hash" })).map(
 			(e) => e.infoHash,
@@ -683,7 +683,7 @@ export async function getSimilarByName(name: string): Promise<{
 
 	if (useClientTorrents) {
 		clientSearchees.push(
-			...(await filterEntries(await db("client_searchees"))).map(
+			...(await filterEntries(await db("client_searchee"))).map(
 				createSearcheeFromDB,
 			),
 		);
@@ -759,7 +759,7 @@ async function getTorrentByFuzzyName(
 	const { useClientTorrents } = getRuntimeConfig();
 
 	const database = useClientTorrents
-		? await db("client_searchees")
+		? await db("client_searchee")
 		: await db("torrent");
 
 	// @ts-expect-error fuse types are confused
@@ -789,7 +789,7 @@ export async function getTorrentByCriteria(
 	criteria: TorrentLocator,
 ): Promise<SearcheeWithInfoHash[]> {
 	const { useClientTorrents } = getRuntimeConfig();
-	const database = useClientTorrents ? db("client_searchees") : db("torrent");
+	const database = useClientTorrents ? db("client_searchee") : db("torrent");
 	const dbTorrents = await database.where((b) =>
 		b.where({ info_hash: criteria.infoHash }),
 	);


### PR DESCRIPTION
fixes #910

1. New migration for `client_searchees`, `data`, and `ensemble` tables.
2. Update the `cleanup` job to also handle these tables to ensure `client_searchees` are refreshed (catch renames, new categories, tags, trackers, etc), and that `data` and `ensemble` gets pruned for paths that no longer exists (only happens if `cross-seed` was down so files weren't being watched).
3. Upon startup, we will clear tables for the options the user has not configured. e.g. `torrent` gets cleared if no `torrentDir`, `data` is clear if no `dataDirs.length`, etc.
4. Added `cross-seed clear-client-cache` to clear the `torrent`, `client_searchees`, `data`, and `ensemble` tables. Only needed if the user doesn't want to want on the cleanup job for the refresh or if they moved to a new client with the same host.
5. No longer refreshing searchees at the start of every search, this will now be handled by the `cleanup` job (at the start of the action stage, we refresh the searchee so there is no chance of outdated names/save_path causing a failed injection).