### PR TITLE
enhancement(clients): check for torrent modifications each poll

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -42,11 +42,9 @@ import {
 	withMutex,
 } from "./utils.js";
 
-const testLinkingSrcName = "a.cross-seed";
-const testLinkingDestName = "b.cross-seed";
-const linkDirSrcName = "c.cross-seed";
-const linkDirDestName = "d.cross-seed";
-const clientDestName = "e.cross-seed";
+const linkDirSrcName = "linkDirSrc.cross-seed";
+const linkDirDestName = "linkDirDest.cross-seed";
+const clientDestName = "torrentClientDest.cross-seed";
 
 type ActionReturn =
 	| {
@@ -727,8 +725,14 @@ function unwrapSymlinks(path: string): string {
 /**
  * Tests if srcDir supports linkType.
  * @param srcDir The directory to link from
+ * @param testSrcName A unique name.cross-seed to create in srcDir if necessary
+ * @param testDestName A unique name.cross-seed to create in the linkDir
  */
-export function testLinking(srcDir: string): void {
+export function testLinking(
+	srcDir: string,
+	testSrcName: string,
+	testDestName: string,
+): void {
 	const { linkDirs, linkType } = getRuntimeConfig();
 	let tempFile: string | undefined;
 	try {
@@ -743,7 +747,7 @@ export function testLinking(srcDir: string): void {
 				);
 				return;
 			}
-			tempFile = join(srcDir, testLinkingSrcName);
+			tempFile = join(srcDir, testSrcName);
 			try {
 				fs.writeFileSync(tempFile, "");
 				if (!fs.existsSync(tempFile)) {
@@ -763,7 +767,7 @@ export function testLinking(srcDir: string): void {
 		}
 		const linkDir = getLinkDir(srcDir);
 		if (!linkDir) throw new Error(`No valid linkDir found for ${srcDir}`);
-		const testPath = join(linkDir, testLinkingDestName);
+		const testPath = join(linkDir, testDestName);
 		linkFile(srcFile, testPath);
 		fs.rmSync(testPath);
 	} catch (e) {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -120,7 +120,11 @@ async function checkConfigPaths(): Promise<void> {
 	if (linkDirs.length) {
 		for (const dataDir of dataDirs) {
 			try {
-				testLinking(dataDir);
+				testLinking(
+					dataDir,
+					"dataDirSrc.cross-seed",
+					"dataDirDest.cross-seed",
+				);
 			} catch (e) {
 				logger.error(e);
 				logger.error("Failed to link from dataDirs to linkDir.");

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -389,6 +389,7 @@ async function indexTorrents(options: { startup: boolean }): Promise<void> {
 					searchees,
 					infoHashPathMap,
 					clients[0].label,
+					clients[0].clientPriority,
 				);
 			}
 		} else {
@@ -404,6 +405,7 @@ async function indexTorrents(options: { startup: boolean }): Promise<void> {
 								return map;
 							}, new Map<string, string>()),
 							client.label,
+							client.clientPriority,
 						);
 						return searchees;
 					}),


### PR DESCRIPTION
Instead of relying only on the `cleanup` job to catch modifications, we can check most of them each time we poll the client. We will update `name`, `savePath`, `category`, and `tags`, these will essentially never be out of sync.

`files` and `trackers` will only be handled in the `cleanup` job as qbit requires different api calls for each for every torrent. This is not a problem though as trackers will pretty much never be updated and files changing doesn't affect anything aside from `matchMode: "strict"`.

Searchees are still refreshed during the action stage regardless.