### PR TITLE
enhancement(cmd/inject): add `--ignore-titles` to skip fuzzy matching

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -433,11 +433,19 @@ createCommandWithSharedOptions(
 	"inject",
 	"Inject saved cross-seeds into your client (without filtering, see docs)",
 )
-	.addOption(
-		new Option(
-			"--inject-dir <dir>",
-			"Directory of torrent files to try to inject",
-		).default(fileConfig.outputDir),
+	.option(
+		"--inject-dir <dir>",
+		"Directory of torrent files to try to inject",
+		fallback(fileConfig.injectDir, fileConfig.outputDir),
+	)
+	.option(
+		"--ignore-titles",
+		"Searchee and candidate titles do not need to pass the fuzzy matching check (useful if `cross-seed inject` erroneously rejects by title)",
+		fallback(fileConfig.ignoreTitles, false),
+	)
+	.option(
+		"--no-ignore-titles",
+		"Searchee and candidate titles need to pass the fuzzy matching check (default)",
 	)
 	.action(withFullRuntime(injectSavedTorrents));
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -415,6 +415,7 @@ export const VALIDATION_SCHEMA = z
 				return true;
 			}),
 		injectDir: z.string().nullish(),
+		ignoreTitles: z.boolean().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
 		fuzzySizeThreshold: z

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,6 +15,8 @@ export interface FileConfig {
 	delay?: number;
 	includeSingleEpisodes?: boolean;
 	outputDir?: string;
+	injectDir?: string;
+	ignoreTitles?: boolean;
 	includeNonVideos?: boolean;
 	seasonFromEpisodes?: number;
 	fuzzySizeThreshold?: number;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -17,6 +17,7 @@ export interface RuntimeConfig {
 	torrentDir?: string;
 	outputDir: string;
 	injectDir?: string;
+	ignoreTitles?: boolean;
 	includeSingleEpisodes: boolean;
 	verbose: boolean;
 	includeNonVideos: boolean;

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -109,10 +109,6 @@ async function checkConfigPaths(): Promise<void> {
 		}
 	}
 	if (injectDir) {
-		logger.warn({
-			label: Label.INJECT,
-			message: `Manually injecting torrents performs minimal filtering which slightly increases chances of false positives, see the docs for more info`,
-		});
 		if (!(await verifyPath(injectDir, "injectDir", READ_AND_WRITE))) {
 			pathFailure++;
 		}


### PR DESCRIPTION
Occasionally there might be torrents that are matches but fail the `cross-seed inject` fuzzy lookup. This adds a command to bypass this check if the user is confident the torrents are simply named badly.

This defaults to false (current behavior) and is only available with the `cross-seed inject` command. If a potential match was rejected due to a title mismatch, the torrent will not be deleted.