### PR TITLE
refactor(async): replace fs sync functions with async

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,10 +12,14 @@
 		"plugin:@typescript-eslint/recommended"
 	],
 	"parserOptions": {
-		"ecmaVersion": 2022
+		"ecmaVersion": 2022,
+		"project": "./tsconfig.eslint.json"
 	},
 	"rules": {
 		"no-mixed-spaces-and-tabs": "off",
-		"@typescript-eslint/no-var-requires": "off"
+		"@typescript-eslint/no-var-requires": "off",
+		"@typescript-eslint/no-unnecessary-type-assertion": "error",
+		"@typescript-eslint/return-await": "error",
+		"@typescript-eslint/no-floating-promises": "error"
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,15 @@
 		"@typescript-eslint/no-var-requires": "off",
 		"@typescript-eslint/no-unnecessary-type-assertion": "error",
 		"@typescript-eslint/return-await": "error",
-		"@typescript-eslint/no-floating-promises": "error"
+		"@typescript-eslint/await-thenable": "error",
+		"@typescript-eslint/no-floating-promises": "error",
+		"@typescript-eslint/no-misused-promises": [
+			"error",
+			{
+				"checksVoidReturn": {
+					"arguments": false
+				}
+			}
+		]
 	}
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -586,7 +586,7 @@ export async function performActionWithoutMutex(
 				message: `Rechecking ${getLogString(newMeta)} as new files were linked from ${getLogString(searchee)}`,
 			});
 			await client.recheckTorrent(newMeta.infoHash);
-			client.resumeInjection(newMeta, decision, {
+			void client.resumeInjection(newMeta, decision, {
 				checkOnce: false,
 			});
 		}

--- a/src/action.ts
+++ b/src/action.ts
@@ -408,18 +408,9 @@ export async function performAction(
 	searchee: SearcheeWithLabel,
 	tracker: string,
 ): Promise<ActionReturn> {
-	return withMutex(
-		Mutex.CLIENT_INJECTION,
-		async () => {
-			return performActionWithoutMutex(
-				newMeta,
-				decision,
-				searchee,
-				tracker,
-			);
-		},
-		{ useQueue: true },
-	);
+	return withMutex(Mutex.CLIENT_INJECTION, { useQueue: true }, async () => {
+		return performActionWithoutMutex(newMeta, decision, searchee, tracker);
+	});
 }
 
 export async function performActionWithoutMutex(

--- a/src/action.ts
+++ b/src/action.ts
@@ -24,6 +24,7 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import {
 	createSearcheeFromPath,
+	getMediaType,
 	getRoot,
 	getRootFolder,
 	getSearcheeSource,
@@ -37,7 +38,6 @@ import {
 	findAFileWithExt,
 	formatAsList,
 	getLogString,
-	getMediaType,
 	Mutex,
 	withMutex,
 } from "./utils.js";

--- a/src/arr.ts
+++ b/src/arr.ts
@@ -171,7 +171,7 @@ async function getMediaFromArr(
 	uArrL: string,
 	title: string,
 ): Promise<Result<ParsedMedia, Error>> {
-	return await makeArrApiCall<ParsedMedia>(
+	return makeArrApiCall<ParsedMedia>(
 		uArrL,
 		"/api/v3/parse",
 		new URLSearchParams({ title }),
@@ -282,10 +282,10 @@ export async function scanAllArrsForMedia(
 	return resultOfErr(false);
 }
 
-export async function getRelevantArrIds(
+export function getRelevantArrIds(
 	caps: Caps,
 	parsedMedia: ParsedMedia,
-): Promise<IdSearchParams> {
+): IdSearchParams {
 	const idSearchCaps = parsedMedia.movie
 		? caps.movieIdSearch
 		: caps.tvIdSearch;

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -378,10 +378,10 @@ export default class Deluge implements TorrentClient {
 		torrentInfo: TorrentInfo,
 	): string {
 		const { linkCategory, duplicateCategories } = getRuntimeConfig();
-		if (!searchee.infoHash || !torrentInfo!.label) {
+		if (!searchee.infoHash || !torrentInfo.label) {
 			return this.delugeLabel;
 		}
-		const ogLabel = torrentInfo!.label;
+		const ogLabel = torrentInfo.label;
 		if (!duplicateCategories) {
 			return ogLabel;
 		}
@@ -518,7 +518,7 @@ export default class Deluge implements TorrentClient {
 					// leaves torrent ready to download - ~99%
 					await wait(1000);
 					await this.recheckTorrent(newTorrent.infoHash);
-					this.resumeInjection(newTorrent, decision, {
+					void this.resumeInjection(newTorrent, decision, {
 						checkOnce: false,
 					});
 				}
@@ -591,7 +591,7 @@ export default class Deluge implements TorrentClient {
 		if (!torrentResponse) {
 			return resultOfErr("UNKNOWN_ERROR");
 		}
-		const torrent = torrentResponse![meta.infoHash!];
+		const torrent = torrentResponse[meta.infoHash];
 		if (!torrent) {
 			return resultOfErr("NOT_FOUND");
 		}

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { readdir } from "fs/promises";
 import ms from "ms";
 import { basename } from "path";
 import { inspect } from "util";
@@ -116,7 +116,7 @@ export default class Deluge implements TorrentClient {
 		});
 
 		if (!torrentDir) return;
-		if (!readdirSync(torrentDir).some((f) => f.endsWith(".state"))) {
+		if (!(await readdir(torrentDir)).some((f) => f.endsWith(".state"))) {
 			throw new CrossSeedError(
 				`[${this.label}] Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir`,
 			);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { readdir } from "fs/promises";
 import ms from "ms";
 import path from "path";
 import { BodyInit } from "undici-types";
@@ -212,7 +212,9 @@ export default class QBittorrent implements TorrentClient {
 				`[${this.label}] torrentDir is not compatible with SQLite mode in qBittorrent, use https://www.cross-seed.org/docs/basics/options#useclienttorrents`,
 			);
 		}
-		if (!readdirSync(torrentDir).some((f) => f.endsWith(".fastresume"))) {
+		if (
+			!(await readdir(torrentDir)).some((f) => f.endsWith(".fastresume"))
+		) {
 			throw new CrossSeedError(
 				`[${this.label}] Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir`,
 			);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -254,7 +254,7 @@ export default class QBittorrent implements TorrentClient {
 						"Received 403 from API. Logging in again and retrying",
 				});
 				await this.login();
-				return this.request(path, body, headers, retries - 1);
+				return await this.request(path, body, headers, retries - 1);
 			}
 		} catch (e) {
 			if (retries > 0) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -936,7 +936,7 @@ export default class QBittorrent implements TorrentClient {
 				return InjectionResult.TORRENT_NOT_COMPLETE;
 			}
 			const filename = `${newTorrent.getFileSystemSafeName()}.${TORRENT_TAG}.torrent`;
-			const buffer = new Blob([newTorrent.encode()], {
+			const buffer = new Blob([new Uint8Array(newTorrent.encode())], {
 				type: "application/x-bittorrent",
 			});
 			const toRecheck = shouldRecheck(searchee, decision);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -995,7 +995,7 @@ export default class QBittorrent implements TorrentClient {
 			}
 			if (toRecheck) {
 				await this.recheckTorrent(newInfo.hash);
-				this.resumeInjection(newTorrent, decision, {
+				void this.resumeInjection(newTorrent, decision, {
 					checkOnce: false,
 				});
 			}

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -368,26 +368,24 @@ export default class RTorrent implements TorrentClient {
 			hashes,
 			async (batch) => {
 				const args = [
-					batch
-						.map((hash) => {
-							const arg = [
-								{
-									methodName: "d.directory",
-									params: [hash],
-								},
-								{
-									methodName: "d.is_multi_file",
-									params: [hash],
-								},
-								{
-									methodName: "d.complete",
-									params: [hash],
-								},
-							];
-							numMethods = arg.length;
-							return arg;
-						})
-						.flat(),
+					batch.flatMap((hash) => {
+						const arg = [
+							{
+								methodName: "d.directory",
+								params: [hash],
+							},
+							{
+								methodName: "d.is_multi_file",
+								params: [hash],
+							},
+							{
+								methodName: "d.complete",
+								params: [hash],
+							},
+						];
+						numMethods = arg.length;
+						return arg;
+					}),
 				];
 				try {
 					const res = await this.methodCallP<ReturnType>(
@@ -573,47 +571,40 @@ export default class RTorrent implements TorrentClient {
 			hashes,
 			async (batch) => {
 				const args = [
-					batch
-						.map((hash) => {
-							const arg = [
-								{
-									methodName: "d.name",
-									params: [hash],
-								},
-								{
-									methodName: "d.size_bytes",
-									params: [hash],
-								},
-								{
-									methodName: "d.directory",
-									params: [hash],
-								},
-								{
-									methodName: "d.is_multi_file",
-									params: [hash],
-								},
-								{
-									methodName: "d.custom1",
-									params: [hash],
-								},
-								{
-									methodName: "f.multicall",
-									params: [
-										hash,
-										"",
-										"f.path=",
-										"f.size_bytes=",
-									],
-								},
-								{
-									methodName: "t.multicall",
-									params: [hash, "", "t.url=", "t.group="],
-								},
-							];
-							numMethods = arg.length;
-							return arg;
-						})
-						.flat(),
+					batch.flatMap((hash) => {
+						const arg = [
+							{
+								methodName: "d.name",
+								params: [hash],
+							},
+							{
+								methodName: "d.size_bytes",
+								params: [hash],
+							},
+							{
+								methodName: "d.directory",
+								params: [hash],
+							},
+							{
+								methodName: "d.is_multi_file",
+								params: [hash],
+							},
+							{
+								methodName: "d.custom1",
+								params: [hash],
+							},
+							{
+								methodName: "f.multicall",
+								params: [hash, "", "f.path=", "f.size_bytes="],
+							},
+							{
+								methodName: "t.multicall",
+								params: [hash, "", "t.url=", "t.group="],
+							},
+						];
+						numMethods = arg.length;
+						return arg;
+					}),
 				];
 				try {
 					const res = await this.methodCallP<ReturnType>(

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -28,6 +28,7 @@ import {
 	fromBatches,
 	humanReadableSize,
 	isTruthy,
+	mapAsync,
 	sanitizeInfoHash,
 	wait,
 } from "../utils.js";
@@ -96,7 +97,7 @@ async function createLibTorrentResumeTree(
 		};
 	}
 
-	const fileResumes = await Promise.all(meta.files.map(getFileResumeData));
+	const fileResumes = await mapAsync(meta.files, getFileResumeData);
 	return {
 		bitfield: Math.ceil(meta.length / meta.pieceLength),
 		files: fileResumes.filter(isTruthy),

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -1,5 +1,5 @@
-import { readdirSync, type Stats } from "fs";
-import { stat } from "fs/promises";
+import { type Stats } from "fs";
+import { readdir, stat } from "fs/promises";
 import { basename, dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
 import xmlrpc, { Client } from "xmlrpc";
@@ -328,7 +328,7 @@ export default class RTorrent implements TorrentClient {
 		});
 
 		if (!torrentDir) return;
-		if (!readdirSync(torrentDir).some((f) => f.endsWith("_resume"))) {
+		if (!(await readdir(torrentDir)).some((f) => f.endsWith("_resume"))) {
 			throw new CrossSeedError(
 				`[${this.label}] Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir`,
 			);

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -538,7 +538,7 @@ export default class RTorrent implements TorrentClient {
 			return hashes.map((hash, index) => ({
 				infoHash: hash.toLowerCase(),
 				tags:
-					(results[index] as string[]).length !== 1
+					results[index].length !== 1
 						? results[index]
 						: results[index][0].length
 							? decodeURIComponent(results[index][0])
@@ -840,7 +840,7 @@ export default class RTorrent implements TorrentClient {
 					].filter((e) => e !== null),
 				);
 				if (toRecheck) {
-					this.resumeInjection(meta, decision, {
+					void this.resumeInjection(meta, decision, {
 						checkOnce: false,
 					});
 				}

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -222,7 +222,7 @@ export async function validateClientSavePaths(
 			);
 		}
 		try {
-			testLinking(
+			await testLinking(
 				savePath,
 				`torrentClient${clientPriority}Src.cross-seed`,
 				`torrentClient${clientPriority}Dest.cross-seed`,

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -193,7 +193,7 @@ export async function validateClientSavePaths(
 
 	const removedSavePaths = new Set<string>();
 	for (const searchee of searchees) {
-		if (!filterByContent({ ...searchee, label: Label.SEARCH })) {
+		if (!(await filterByContent({ ...searchee, label: Label.SEARCH }))) {
 			if (infoHashPathMap.has(searchee.infoHash)) {
 				removedSavePaths.add(infoHashPathMap.get(searchee.infoHash)!);
 				infoHashPathMap.delete(searchee.infoHash);

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -532,7 +532,7 @@ export default class Transmission implements TorrentClient {
 				},
 			);
 			if (toRecheck) {
-				this.resumeInjection(newTorrent, decision, {
+				void this.resumeInjection(newTorrent, decision, {
 					checkOnce: false,
 				});
 			}

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "fs";
+import { readdir } from "fs/promises";
 import ms from "ms";
 import { basename } from "path";
 import { inspect } from "util";
@@ -193,7 +193,7 @@ export default class Transmission implements TorrentClient {
 		});
 
 		if (!torrentDir) return;
-		if (!readdirSync(torrentDir).some((f) => f.endsWith(".torrent"))) {
+		if (!(await readdir(torrentDir)).some((f) => f.endsWith(".torrent"))) {
 			throw new CrossSeedError(
 				`[${this.label}] Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir`,
 			);

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -401,7 +401,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 		withFullRuntime(async (options) => {
 			await indexTorrentsAndDataDirs({ startup: true });
 			// technically this will never resolve, but it's necessary to keep the process running
-			await Promise.all([serve(options.port!, options.host), jobsLoop()]);
+			await Promise.all([serve(options.port, options.host), jobsLoop()]);
 		}),
 	);
 

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -321,14 +321,14 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 
 /**
  * check a potential child path being inside a array of parent paths
- * @param childDir path of the potential child (e.g outputDir)
+ * @param childPath path of the potential child (e.g outputDir)
  * @param parentDirs array of parentDir paths (e.g dataDirs)
  * @returns true if `childDir` is inside any `parentDirs` at any nesting level, false otherwise.
  */
-function isChildPath(childDir: string, parentDirs: string[]): boolean {
+export function isChildPath(childPath: string, parentDirs: string[]): boolean {
 	return parentDirs.some((parentDir) => {
 		const resolvedParent = resolve(parentDir);
-		const resolvedChild = resolve(childDir);
+		const resolvedChild = resolve(childPath);
 		const relativePath = relative(resolvedParent, resolvedChild);
 		// if the path does not start with '..' and is not absolute
 		return !(relativePath.startsWith("..") || isAbsolute(relativePath));

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -680,7 +680,8 @@ export const VALIDATION_SCHEMA = z
 		return true;
 	})
 	.refine(
-		(config) => config.action === Action.INJECT || !config.injectDir,
+		(config) =>
+			config.action === Action.INJECT || config.injectDir === undefined,
 		ZodErrorMessages.injectNeedsInjectMode,
 	)
 	.refine(

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -141,11 +141,7 @@ async function indexDataPaths(paths: string[]): Promise<void> {
 		if (!title) continue;
 		dataRows.push({ title, path });
 		if (seasonFromEpisodes) {
-			const ensembleEntries = await indexEnsembleDataEntry(
-				title,
-				path,
-				files,
-			);
+			const ensembleEntries = indexEnsembleDataEntry(title, path, files);
 			if (ensembleEntries) ensembleRows.push(...ensembleEntries);
 		}
 	}
@@ -160,11 +156,11 @@ async function indexDataPaths(paths: string[]): Promise<void> {
 	});
 }
 
-async function indexEnsembleDataEntry(
+function indexEnsembleDataEntry(
 	title: string,
 	path: string,
 	files: File[],
-): Promise<EnsembleEntry[] | null> {
+): EnsembleEntry[] | null {
 	const ensemblePieces = createEnsemblePieces(title, files);
 	if (!ensemblePieces || !ensemblePieces.length) return null;
 	return ensemblePieces.map((ensemblePiece) => ({

--- a/src/dataFiles.ts
+++ b/src/dataFiles.ts
@@ -69,7 +69,7 @@ export async function indexDataDirs(options: {
 				);
 			}
 		}
-		return await indexDataPaths(searcheePaths);
+		return indexDataPaths(searcheePaths);
 	}
 
 	await mapAsync(dataDirs, async (dataDir) => {
@@ -165,7 +165,7 @@ async function indexEnsembleDataEntry(
 	path: string,
 	files: File[],
 ): Promise<EnsembleEntry[] | null> {
-	const ensemblePieces = await createEnsemblePieces(title, files);
+	const ensemblePieces = createEnsemblePieces(title, files);
 	if (!ensemblePieces || !ensemblePieces.length) return null;
 	return ensemblePieces.map((ensemblePiece) => ({
 		client_host: null,

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,5 @@
 import Sqlite from "better-sqlite3";
-import { readdirSync, statSync, unlinkSync } from "fs";
+import { readdir, stat, unlink } from "fs/promises";
 import knex from "knex";
 import ms from "ms";
 import { join } from "path";
@@ -82,16 +82,16 @@ export async function cleanupDB(): Promise<void> {
 		})(),
 		(async () => {
 			const torrentCacheDir = join(appDir(), TORRENT_CACHE_FOLDER);
-			const files = readdirSync(torrentCacheDir);
+			const files = await readdir(torrentCacheDir);
 			const now = Date.now();
 			for (const file of files) {
 				const filePath = join(torrentCacheDir, file);
-				if (now - statSync(filePath).atimeMs > ms("1 year")) {
+				if (now - (await stat(filePath)).atimeMs > ms("1 year")) {
 					logger.verbose(`Deleting ${filePath}`);
 					await db("decision")
 						.where("info_hash", file.split(".")[0])
 						.del();
-					unlinkSync(filePath);
+					await unlink(filePath);
 				}
 			}
 		})(),

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -34,6 +34,9 @@ import { Result, resultOf, resultOfErr } from "./Result.js";
 import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import {
 	File,
+	getFuzzySizeFactor,
+	getMediaType,
+	getMinSizeRatio,
 	getReleaseGroup,
 	Searchee,
 	SearcheeWithLabel,
@@ -41,10 +44,7 @@ import {
 import { parseTorrentFromFilename, snatch, SnatchError } from "./torrent.js";
 import {
 	extractInt,
-	getFuzzySizeFactor,
 	getLogString,
-	getMediaType,
-	getMinSizeRatio,
 	sanitizeInfoHash,
 	stripExtension,
 } from "./utils.js";

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -475,7 +475,7 @@ async function cacheTorrentFile(meta: Metafile): Promise<boolean> {
 		TORRENT_CACHE_FOLDER,
 		`${meta.infoHash}.cached.torrent`,
 	);
-	await writeFile(torrentPath, meta.encode());
+	await writeFile(torrentPath, new Uint8Array(meta.encode()));
 	return true;
 }
 
@@ -525,7 +525,12 @@ export async function updateTorrentCache(
 					}),
 				);
 			}
-			if (updated) await writeFile(filePath, bencode.encode(torrent));
+			if (updated) {
+				await writeFile(
+					filePath,
+					new Uint8Array(bencode.encode(torrent)),
+				);
+			}
 		} catch (e) {
 			console.error(`Error reading ${filePath}: ${e}`);
 		}

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -595,11 +595,11 @@ export async function getGuidInfoHashMap(): Promise<Map<string, string>> {
  * @param guidInfoHashMap The map of guids to info hashes. Necessary for optimal fuzzy lookups.
  * @returns The info hash of the torrent if found
  */
-async function guidLookup(
+function guidLookup(
 	guid: string,
 	link: string,
 	guidInfoHashMap: Map<string, string>,
-): Promise<string | undefined> {
+): string | undefined {
 	const infoHash = guidInfoHashMap.get(guid) ?? guidInfoHashMap.get(link);
 	if (infoHash) return infoHash;
 
@@ -636,7 +636,7 @@ export async function assessCandidateCaching(
 		.join("searchee", "decision.searchee_id", "searchee.id")
 		.where({ name: searchee.title, guid })
 		.first();
-	const metaInfoHash = await guidLookup(guid, link, guidInfoHashMap);
+	const metaInfoHash = guidLookup(guid, link, guidInfoHashMap);
 	const metaOrCandidate = metaInfoHash
 		? (await existsInTorrentCache(metaInfoHash))
 			? (await getCachedTorrentFile(metaInfoHash)).orElse(candidate)

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -612,7 +612,7 @@ function logInjectSummary(
 			message: `Some torrents could be linked to linkDir/${UNKNOWN_TRACKER} - follow .torrent naming format in the docs to avoid this`,
 		});
 	}
-	if (injectDir) {
+	if (injectDir !== undefined) {
 		logger.info({
 			label: Label.INJECT,
 			message: `Waiting on post-injection tasks to complete...`,
@@ -642,7 +642,7 @@ export async function injectSavedTorrents(): Promise<void> {
 	const targetDir = injectDir ?? outputDir;
 	const targetDirLog = chalk.bold.magenta(targetDir);
 
-	if (injectDir) {
+	if (injectDir !== undefined) {
 		logger.warn({
 			label: Label.INJECT,
 			message: `Manually injecting torrents performs minimal filtering which slightly increases chances of false positives, see the docs for more info`,

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { stat, unlink } from "fs/promises";
 import ms from "ms";
-import { copyFileSync, existsSync } from "fs";
+import { copyFileSync } from "fs";
 import path, { basename } from "path";
 import { performActionWithoutMutex } from "./action.js";
 import {
@@ -36,6 +36,7 @@ import {
 import {
 	areMediaTitlesSimilar,
 	comparing,
+	exists,
 	formatAsList,
 	getLogString,
 	humanReadableDate,
@@ -719,7 +720,7 @@ export async function restoreFromTorrentCache(): Promise<void> {
 			outputDir,
 			`[${MediaType.OTHER}][${UNKNOWN_TRACKER}]${basename(torrentFilePath)}`,
 		);
-		if (existsSync(dest)) {
+		if (await exists(dest)) {
 			existed++;
 			continue;
 		}

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -431,7 +431,7 @@ async function injectionAlreadyExists({
 	}
 }
 
-async function injectionSuccess({
+function injectionSuccess({
 	progress,
 	torrentFilePath,
 	client,
@@ -554,7 +554,7 @@ async function injectSavedTorrent(
 
 	switch (injectionResult) {
 		case InjectionResult.SUCCESS:
-			await injectionSuccess(injectionAftermath);
+			injectionSuccess(injectionAftermath);
 			break;
 		case InjectionResult.FAILURE:
 			injectionFailed(injectionAftermath);

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -672,25 +672,16 @@ export async function injectSavedTorrents(): Promise<void> {
 		message: `Found ${chalk.bold.white(torrentFilePaths.length)} torrent file(s) to inject in ${targetDirLog}`,
 	});
 	const summary = createSummary(torrentFilePaths.length);
-	const { realSearchees, ensembleSearchees } = await withMutex(
-		Mutex.CREATE_ALL_SEARCHEES,
-		async () => {
-			const realSearchees = await findAllSearchees(Label.INJECT);
-			const ensembleSearchees = await createEnsembleSearchees(
-				realSearchees,
-				{
-					useFilters: false,
-				},
-			);
-			return { realSearchees, ensembleSearchees };
-		},
-		{ useQueue: true },
-	);
+	const realSearchees = await findAllSearchees(Label.INJECT);
+	const ensembleSearchees = await createEnsembleSearchees(realSearchees, {
+		useFilters: false,
+	});
 	const searchees = [...realSearchees, ...ensembleSearchees];
 	for (const [i, torrentFilePath] of torrentFilePaths.entries()) {
 		const progress = chalk.blue(`(${i + 1}/${torrentFilePaths.length})`);
 		await withMutex(
 			Mutex.CLIENT_INJECTION,
+			{ useQueue: true },
 			async () => {
 				return injectSavedTorrent(
 					progress,
@@ -700,7 +691,6 @@ export async function injectSavedTorrents(): Promise<void> {
 					ignoreTitles ?? false,
 				);
 			},
-			{ useQueue: true },
 		);
 	}
 	logInjectSummary(summary, flatLinking, injectDir);

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { stat, unlink } from "fs/promises";
 import ms from "ms";
-import { copyFileSync } from "fs";
+import { copyFile } from "fs/promises";
 import path, { basename } from "path";
 import { performActionWithoutMutex } from "./action.js";
 import {
@@ -724,7 +724,7 @@ export async function restoreFromTorrentCache(): Promise<void> {
 			existed++;
 			continue;
 		}
-		copyFileSync(torrentFilePath, dest);
+		await copyFile(torrentFilePath, dest);
 		if ((i + 1) % 100 === 0) {
 			console.log(
 				`${chalk.blue(`(${i + 1}/${torrentFilePaths.length})`)} ${chalk.bold.magenta(dest)}`,

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -323,7 +323,7 @@ async function injectFromStalledTorrent({
 			message: `${progress} Rechecking ${filePathLog} as new files were linked - ${chalk.green(injectionResult)}`,
 		});
 		await client!.recheckTorrent(meta.infoHash);
-		client!.resumeInjection(meta, stalledDecision, {
+		void client!.resumeInjection(meta, stalledDecision, {
 			checkOnce: false,
 		});
 	} else {
@@ -389,7 +389,7 @@ async function injectionAlreadyExists({
 			label: Label.INJECT,
 			message: `${progress} ${filePathLog} is being checked by client - ${chalk.green(injectionResult)}`,
 		});
-		client!.resumeInjection(meta, decision, {
+		void client!.resumeInjection(meta, decision, {
 			checkOnce: false,
 		});
 	} else if (!isComplete && decision !== Decision.MATCH_PARTIAL) {
@@ -400,7 +400,7 @@ async function injectionAlreadyExists({
 			message: `${progress} Rechecking ${filePathLog} as it's not complete but has all files (final check at ${humanReadableDate(finalCheckTime)}) - ${chalk.yellow(injectionResult)}`,
 		});
 		await client!.recheckTorrent(meta.infoHash);
-		client!.resumeInjection(meta, decision, {
+		void client!.resumeInjection(meta, decision, {
 			checkOnce: false,
 		});
 		if (Date.now() >= finalCheckTime) {
@@ -417,7 +417,7 @@ async function injectionAlreadyExists({
 				label: Label.INJECT,
 				message: `${progress} ${filePathLog} - ${chalk.yellow(injectionResult)} (incomplete)`,
 			});
-			client!.resumeInjection(meta, decision, {
+			void client!.resumeInjection(meta, decision, {
 				checkOnce: true,
 			});
 		}
@@ -427,7 +427,11 @@ async function injectionAlreadyExists({
 	if (isComplete) {
 		await deleteTorrentFileIfSafe(torrentFilePath);
 	} else {
-		deleteTorrentFileIfComplete(torrentFilePath, client!, meta.infoHash);
+		void deleteTorrentFileIfComplete(
+			torrentFilePath,
+			client!,
+			meta.infoHash,
+		);
 	}
 }
 
@@ -460,7 +464,7 @@ function injectionSuccess({
 	} else {
 		summary.FULL_MATCHES++;
 	}
-	deleteTorrentFileIfComplete(torrentFilePath, client!, meta.infoHash);
+	void deleteTorrentFileIfComplete(torrentFilePath, client!, meta.infoHash);
 }
 
 async function loadMetafile(

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -118,6 +118,7 @@ export async function checkJobs(
 ): Promise<void> {
 	return withMutex(
 		Mutex.CHECK_JOBS,
+		{ useQueue: options.useQueue },
 		async () => {
 			const now = Date.now();
 			for (const job of jobs) {
@@ -150,7 +151,6 @@ export async function checkJobs(
 				}
 			}
 		},
-		{ useQueue: options.useQueue },
 	);
 }
 

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -7,7 +7,7 @@ import { Label, logger } from "./logger.js";
 import { bulkSearch, scanRssFeeds } from "./pipeline.js";
 import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import { updateCaps } from "./torznab.js";
-import { Mutex, withMutex } from "./utils.js";
+import { humanReadableDate, Mutex, withMutex } from "./utils.js";
 
 export enum JobName {
 	RSS = "rss",
@@ -92,7 +92,11 @@ function logNextRun(
 
 	const eligibilityTs = lastRun ? lastRun + cadence : now;
 
-	const lastRunStr = lastRun ? `${ms(now - lastRun)} ago` : "never";
+	const lastRunStr = !lastRun
+		? "never"
+		: now >= lastRun
+			? `${ms(now - lastRun)} ago`
+			: `at ${humanReadableDate(lastRun - cadence)}`;
 	const nextRunStr =
 		now >= eligibilityTs ? "now" : `in ${ms(eligibilityTs - now)}`;
 

--- a/src/migrations/09-clientAndDataSearchees.ts
+++ b/src/migrations/09-clientAndDataSearchees.ts
@@ -31,9 +31,9 @@ async function up(knex: Knex.Knex): Promise<void> {
 }
 
 async function down(knex: Knex.Knex): Promise<void> {
-	knex.schema.dropTable("client_searchee");
-	knex.schema.dropTable("data");
-	knex.schema.dropTable("ensemble");
+	void knex.schema.dropTable("client_searchee");
+	void knex.schema.dropTable("data");
+	void knex.schema.dropTable("ensemble");
 }
 
 export default { name: "09-clientAndDataSearchees", up, down };

--- a/src/parseTorrent.ts
+++ b/src/parseTorrent.ts
@@ -82,7 +82,7 @@ function ensure(bool: unknown, fieldName: string) {
 
 function sha1(buf: Buffer): string {
 	const hash = createHash("sha1");
-	hash.update(buf);
+	hash.update(new Uint8Array(buf));
 	return hash.digest("hex");
 }
 

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -18,6 +18,7 @@ import { getEnabledIndexers } from "./indexers.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import {
+	getMediaType,
 	getSearcheeNewestFileAge,
 	Searchee,
 	SearcheeWithLabel,
@@ -29,7 +30,6 @@ import {
 	extractInt,
 	filesWithExt,
 	getLogString,
-	getMediaType,
 	hasExt,
 	humanReadableDate,
 	nMsAgo,

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -1,4 +1,4 @@
-import { statSync } from "fs";
+import { stat } from "fs/promises";
 import ms from "ms";
 import { basename, dirname } from "path";
 import {
@@ -82,14 +82,14 @@ function isCrossSeed(searchee: Searchee): boolean {
 	return false;
 }
 
-export function filterByContent(
+export async function filterByContent(
 	searchee: SearcheeWithLabel,
 	options?: {
 		configOverride: Partial<RuntimeConfig>;
 		allowSeasonPackEpisodes: boolean;
 		ignoreCrossSeeds: boolean;
 	},
-): boolean {
+): Promise<boolean> {
 	const {
 		fuzzySizeThreshold,
 		includeNonVideos,
@@ -156,7 +156,7 @@ export function filterByContent(
 
 	if (
 		searchee.path &&
-		statSync(searchee.path).isDirectory() &&
+		(await stat(searchee.path)).isDirectory() &&
 		ARR_DIR_REGEX.test(basename(searchee.path)) &&
 		nonVideoSizeRatio < 0.02 &&
 		![MediaType.EPISODE, MediaType.SEASON].includes(mediaType) &&

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -109,7 +109,7 @@ export function sendResultsNotification(
 			: "Saved";
 		const decisions = notableSuccesses.map(([{ decision }]) => decision);
 
-		pushNotifier.notify({
+		void pushNotifier.notify({
 			body: `${source}: ${performedAction} ${name} on ${numTrackers} tracker${numTrackers !== 1 ? "s" : ""} by ${formatAsList(decisions, { sort: true })} from ${searcheeSource}: ${trackersListStr}`,
 			extra: {
 				event: Event.RESULTS,
@@ -145,7 +145,7 @@ export function sendResultsNotification(
 		const trackersListStr = formatAsList(trackers, { sort: true });
 		const decisions = failures.map(([{ decision }]) => decision);
 
-		pushNotifier.notify({
+		void pushNotifier.notify({
 			body: `${source}: Failed to inject ${name} on ${numTrackers} tracker${numTrackers !== 1 ? "s" : ""} by ${formatAsList(decisions, { sort: true })} from ${searcheeSource}: ${trackersListStr}`,
 			extra: {
 				event: Event.RESULTS,

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -10,7 +10,7 @@ import { ResultAssessment } from "./decide.js";
 import { logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { getSearcheeSource, SearcheeWithLabel } from "./searchee.js";
-import { formatAsList } from "./utils.js";
+import { formatAsList, mapAsync } from "./utils.js";
 
 export let pushNotifier: PushNotifier;
 
@@ -39,37 +39,35 @@ export class PushNotifier {
 		body,
 		...rest
 	}: PushNotification): Promise<void[]> {
-		return Promise.all(
-			this.urls.map(async (url) => {
-				try {
-					const response = await fetch(url, {
-						method: "POST",
-						headers: {
-							"Content-Type": "application/json",
-							"User-Agent": USER_AGENT,
-						},
-						body: JSON.stringify({ title, body, ...rest }),
-					});
+		return mapAsync(this.urls, async (url) => {
+			try {
+				const response = await fetch(url, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"User-Agent": USER_AGENT,
+					},
+					body: JSON.stringify({ title, body, ...rest }),
+				});
 
-					if (!response.ok) {
-						const responseText = await response.clone().text();
-						logger.error(
-							`${url} rejected push notification: ${response.status} ${response.statusText}`,
-						);
-						logger.debug(
-							`${url}: ${responseText.slice(0, 100)}${
-								responseText.length > 100 ? "..." : ""
-							}"`,
-						);
-					}
-				} catch (e) {
+				if (!response.ok) {
+					const responseText = await response.clone().text();
 					logger.error(
-						`${url} failed to send push notification: ${e.message}`,
+						`${url} rejected push notification: ${response.status} ${response.statusText}`,
 					);
-					logger.debug(e);
+					logger.debug(
+						`${url}: ${responseText.slice(0, 100)}${
+							responseText.length > 100 ? "..." : ""
+						}"`,
+					);
 				}
-			}),
-		);
+			} catch (e) {
+				logger.error(
+					`${url} failed to send push notification: ${e.message}`,
+				);
+				logger.debug(e);
+			}
+		});
 	}
 }
 

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -239,7 +239,7 @@ export async function getFilesFromDataRoot(
 ): Promise<File[]> {
 	const parentDir = dirname(rootPath);
 	try {
-		return mapAsync(
+		return await mapAsync(
 			await getFileNamesFromRootRec(rootPath, memoizedPaths),
 			async (file) => ({
 				path: relative(parentDir, file),

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -189,9 +189,7 @@ export async function getNewestFileAge(
 	absoluteFilePaths: string[],
 ): Promise<number> {
 	return (
-		await Promise.all(
-			absoluteFilePaths.map((file) => stat(file).then((s) => s.mtimeMs)),
-		)
+		await mapAsync(absoluteFilePaths, async (f) => (await stat(f)).mtimeMs)
 	).reduce((a, b) => Math.max(a, b));
 }
 

--- a/src/searchee.ts
+++ b/src/searchee.ts
@@ -560,10 +560,10 @@ export function getEpisodeKeys(stem: string): {
 	const match = stem.match(EP_REGEX);
 	if (!match) return null;
 	const titles = getAllTitles([match.groups!.title]);
-	const season = match!.groups!.season
-		? `S${extractInt(match!.groups!.season)}`
-		: match!.groups!.year
-			? `S${match!.groups!.year}`
+	const season = match.groups!.season
+		? `S${extractInt(match.groups!.season)}`
+		: match.groups!.year
+			? `S${match.groups!.year}`
 			: undefined;
 	const keyTitles: string[] = [];
 	const ensembleTitles: string[] = [];
@@ -574,9 +574,9 @@ export function getEpisodeKeys(stem: string): {
 		ensembleTitles.push(`${title}${season ? `.${season}` : ""}`);
 	}
 	if (!keyTitles.length) return null;
-	const episode = match!.groups!.episode
-		? extractInt(match!.groups!.episode)
-		: `${match!.groups!.month}.${match!.groups!.day}`;
+	const episode = match.groups!.episode
+		? extractInt(match.groups!.episode)
+		: `${match.groups!.month}.${match.groups!.day}`;
 	return { ensembleTitles, keyTitles, season, episode };
 }
 
@@ -599,7 +599,7 @@ export function getAnimeKeys(stem: string): {
 		ensembleTitles.push(title);
 	}
 	if (!keyTitles.length) return null;
-	const release = extractInt(match!.groups!.release);
+	const release = extractInt(match.groups!.release);
 	return { ensembleTitles, keyTitles, release };
 }
 
@@ -608,7 +608,7 @@ export function getReleaseGroup(stem: string): string | null {
 	if (!predictedGroupMatch) {
 		return null;
 	}
-	const parsedGroupMatchString = predictedGroupMatch!.groups!.group.trim();
+	const parsedGroupMatchString = predictedGroupMatch.groups!.group.trim();
 	if (BAD_GROUP_PARSE_REGEX.test(parsedGroupMatchString)) return null;
 	const match =
 		stem.match(EP_REGEX) ??

--- a/src/server.ts
+++ b/src/server.ts
@@ -154,7 +154,7 @@ async function search(
 	const injectJob = getJobs().find((job) => job.name === JobName.INJECT);
 	if (injectJob) {
 		injectJob.runAheadOfSchedule = true;
-		checkJobs({ isFirstRun: false, useQueue: true });
+		void checkJobs({ isFirstRun: false, useQueue: true });
 	}
 	await indexTorrentsAndDataDirs();
 	const dataStr = await getData(req);
@@ -408,7 +408,7 @@ async function runJob(
 			? Number.MAX_SAFE_INTEGER
 			: undefined,
 	};
-	checkJobs({ isFirstRun: false, useQueue: true });
+	void checkJobs({ isFirstRun: false, useQueue: true });
 	res.writeHead(200);
 	res.end(`${job.name}: running ahead of schedule`);
 }

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,5 +1,4 @@
-import { mkdirSync } from "fs";
-import { access, constants, stat } from "fs/promises";
+import { access, constants, mkdir, stat } from "fs/promises";
 import ms from "ms";
 import { sep } from "path";
 import { inspect } from "util";
@@ -88,7 +87,7 @@ async function checkConfigPaths(): Promise<void> {
 
 	if (await notExists(outputDir)) {
 		logger.info(`Creating outputDir: ${outputDir}`);
-		mkdirSync(outputDir, { recursive: true });
+		await mkdir(outputDir, { recursive: true });
 	}
 	if (!(await verifyPath(outputDir, "outputDir", READ_AND_WRITE))) {
 		pathFailure++;
@@ -97,7 +96,7 @@ async function checkConfigPaths(): Promise<void> {
 	for (const linkDir of linkDirs) {
 		if (await notExists(linkDir)) {
 			logger.info(`Creating linkDir: ${linkDir}`);
-			mkdirSync(linkDir, { recursive: true });
+			await mkdir(linkDir, { recursive: true });
 		}
 		if (!(await verifyPath(linkDir, "linkDir", READ_AND_WRITE))) {
 			pathFailure++;
@@ -165,7 +164,7 @@ async function retry<T>(
 export async function doStartupValidation(): Promise<void> {
 	await checkConfigPaths(); // ensure paths are valid first
 	instantiateDownloadClients();
-	const validateClientConfig = async () =>
+	const validateClientConfig = () =>
 		Promise.all(getClients().map((client) => client.validateConfig()));
 	const errors = (
 		await Promise.allSettled([

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync } from "fs";
+import { mkdirSync } from "fs";
 import { access, constants, stat } from "fs/promises";
 import ms from "ms";
 import { sep } from "path";
@@ -21,7 +21,7 @@ import {
 	setRuntimeConfig,
 } from "./runtimeConfig.js";
 import { validateTorznabUrls } from "./torznab.js";
-import { Awaitable, wait } from "./utils.js";
+import { Awaitable, notExists, wait } from "./utils.js";
 
 export async function exitGracefully() {
 	await db.destroy();
@@ -86,7 +86,7 @@ async function checkConfigPaths(): Promise<void> {
 		pathFailure++;
 	}
 
-	if (!existsSync(outputDir)) {
+	if (await notExists(outputDir)) {
 		logger.info(`Creating outputDir: ${outputDir}`);
 		mkdirSync(outputDir, { recursive: true });
 	}
@@ -95,7 +95,7 @@ async function checkConfigPaths(): Promise<void> {
 	}
 
 	for (const linkDir of linkDirs) {
-		if (!existsSync(linkDir)) {
+		if (await notExists(linkDir)) {
 			logger.info(`Creating linkDir: ${linkDir}`);
 			mkdirSync(linkDir, { recursive: true });
 		}
@@ -116,7 +116,7 @@ async function checkConfigPaths(): Promise<void> {
 	if (linkDirs.length) {
 		for (const dataDir of dataDirs) {
 			try {
-				testLinking(
+				await testLinking(
 					dataDir,
 					"dataDirSrc.cross-seed",
 					"dataDirDest.cross-seed",

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -20,7 +20,7 @@ import {
 	setRuntimeConfig,
 } from "./runtimeConfig.js";
 import { validateTorznabUrls } from "./torznab.js";
-import { Awaitable, notExists, wait } from "./utils.js";
+import { Awaitable, mapAsync, notExists, wait } from "./utils.js";
 
 export async function exitGracefully() {
 	await db.destroy();
@@ -165,7 +165,7 @@ export async function doStartupValidation(): Promise<void> {
 	await checkConfigPaths(); // ensure paths are valid first
 	instantiateDownloadClients();
 	const validateClientConfig = () =>
-		Promise.all(getClients().map((client) => client.validateConfig()));
+		mapAsync(getClients(), (client) => client.validateConfig());
 	const errors = (
 		await Promise.allSettled([
 			retry(validateTorznabUrls, 5, ms("1 minute")),

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -529,6 +529,7 @@ export async function indexTorrentsAndDataDirs(
 	}
 	return withMutex(
 		Mutex.INDEX_TORRENTS_AND_DATA_DIRS,
+		{ useQueue: false },
 		async () => {
 			const maxRetries = 3;
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -550,7 +551,6 @@ export async function indexTorrentsAndDataDirs(
 				}
 			}
 		},
-		{ useQueue: false },
 	);
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -1,7 +1,6 @@
 import { distance } from "fastest-levenshtein";
 import bencode from "bencode";
-import fs, { statSync } from "fs";
-import { readdir, readFile, writeFile } from "fs/promises";
+import { readdir, readFile, stat, utimes, writeFile } from "fs/promises";
 import Fuse from "fuse.js";
 import { extname, join, resolve } from "path";
 import { inspect } from "util";
@@ -274,7 +273,7 @@ export async function saveTorrentFile(
 		)}[${meta.infoHash}].torrent`,
 	);
 	if (await exists(filePath)) {
-		fs.utimesSync(filePath, new Date(), fs.statSync(filePath).mtime);
+		await utimes(filePath, new Date(), (await stat(filePath)).mtime);
 		return;
 	}
 	await writeFile(filePath, buf, { mode: 0o644 });
@@ -730,7 +729,7 @@ export async function getSimilarByName(name: string): Promise<{
 				(await notExists(path)) ||
 				shouldIgnorePathHeuristically(
 					path,
-					statSync(path).isDirectory(),
+					(await stat(path)).isDirectory(),
 				)
 			) {
 				entriesToDelete.push(path);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -266,7 +266,6 @@ export async function saveTorrentFile(
 	meta: Metafile,
 ): Promise<void> {
 	const { outputDir } = getRuntimeConfig();
-	const buf = meta.encode();
 	// Be sure to update parseInfoFromSavedTorrent if changing the format
 	const filePath = join(
 		outputDir,
@@ -278,7 +277,7 @@ export async function saveTorrentFile(
 		await utimes(filePath, new Date(), (await stat(filePath)).mtime);
 		return;
 	}
-	await writeFile(filePath, buf, { mode: 0o644 });
+	await writeFile(filePath, new Uint8Array(meta.encode()));
 }
 
 export function parseMetadataFromFilename(

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -222,7 +222,7 @@ async function createTorznabSearchQueries(
 ): Promise<Query[]> {
 	const stem = stripExtension(searchee.title);
 	const relevantIds: IdSearchParams = parsedMedia
-		? await getRelevantArrIds(caps, parsedMedia)
+		? getRelevantArrIds(caps, parsedMedia)
 		: {};
 	const useIds = Object.values(relevantIds).some(isTruthy);
 	if (mediaType === MediaType.EPISODE && caps.tvSearch) {
@@ -488,7 +488,7 @@ export async function searchTorznab(
 				categories: indexer.categories,
 				limits: indexer.limits,
 			};
-			return await createTorznabSearchQueries(
+			return createTorznabSearchQueries(
 				searchee,
 				mediaType,
 				caps,

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -36,6 +36,7 @@ import { Label, logger } from "./logger.js";
 import { Candidate } from "./pipeline.js";
 import { getRuntimeConfig, RuntimeConfig } from "./runtimeConfig.js";
 import {
+	getMediaType,
 	getSearcheeNewestFileAge,
 	Searchee,
 	SearcheeWithLabel,
@@ -49,7 +50,6 @@ import {
 	getAnimeQueries,
 	getApikey,
 	getLogString,
-	getMediaType,
 	humanReadableDate,
 	isTruthy,
 	nMsAgo,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,7 +123,7 @@ export function wait(n: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, n));
 }
 
-export async function time<R>(cb: () => R, times: number[]) {
+export async function time<R>(cb: () => Promise<R>, times: number[]) {
 	const before = performance.now();
 	try {
 		return await cb();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -586,14 +586,14 @@ const mutexes = new Map<Mutex, Promise<unknown>>();
 /**
  * Executes a callback function within a mutex for the given name.
  * @param name The name of the mutex to create/use.
- * @param cb The callback to execute.
  * @param options.useQueue If false, concurrent calls will share the pending result.
+ * @param cb The callback to execute.
  * @returns The result of the callback.
  */
 export async function withMutex<T>(
 	name: Mutex,
-	cb: () => Promise<T>,
 	options: { useQueue: boolean },
+	cb: () => Promise<T>,
 ): Promise<T> {
 	const existingMutex = mutexes.get(name) as Promise<T> | undefined;
 	if (existingMutex) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -532,7 +532,7 @@ export function replaceLastOccurrence(
 	const matches = Array.from(str.matchAll(globalRegExp));
 	if (matches.length === 0) return str;
 	const lastMatch = matches[matches.length - 1];
-	const lastMatchIndex = lastMatch.index!;
+	const lastMatchIndex = lastMatch.index;
 	const lastMatchStr = lastMatch[0];
 	return (
 		str.slice(0, lastMatchIndex) +

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -3,12 +3,8 @@ import { fileFactory } from "./factories/file";
 import { searcheeFactory } from "./factories/searchee";
 
 import { MediaType, SEASON_REGEX } from "../src/constants";
-import {
-	extractInt,
-	getMediaType,
-	humanReadableSize,
-	sanitizeUrl,
-} from "../src/utils";
+import { getMediaType } from "../src/searchee";
+import { extractInt, humanReadableSize, sanitizeUrl } from "../src/utils";
 
 describe("humanReadableSize", () => {
 	it("returns a human-readable size", () => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"outDir": "./dist",
+		"allowJs": true,
+		"target": "es2022",
+		"lib": ["es2023"],
+		"module": "nodenext",
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"sourceMap": true,
+		"strictNullChecks": true
+	},
+	"include": ["./src/**/*", "./tests/**/*"]
+}


### PR DESCRIPTION
This ends up being a pretty large refactor. The goal is to replace all the `fs.*Sync` with their async versions as mentioned a while back by @mmgoodnow. I organized `utils.ts` and when through a lot of the async functions with `eslint` rules to clean up their usages.

1. Reorganized utils
2. Use `fs/promises` instead of `*Sync` function calls in `fs`. The exceptions are for zod schema parsing which of course is low value. It would require `parseAsync` which seems to have performance issues reported at the very least.
3. Created and used `mapAsync`, `flatMapAsync`, `reduceAsync`, `findAsync`, `everyAsync`, and `someAsync` functions in addition to the existing `filterAsync` to standardize async usage for functional pipelines.
4. Use `Uint8Array` instead of `Buffer` for saving .torrent files. `Buffer` has been essentially been deprecated for JS. `Metafile` still returns `Buffer` as we use some of the functions for injecting into clients.
5. For `injectDir`, check against `undefined` to know if the user is running the command `cross-seed inject` for the warning logs.
6. Reduce the stress that the `rss job` has on the event loop by adding a `100ms` wait between candidates. Lots of API requests would fail or other operations freeze during the duration of the `rss job`. It's still not perfect as even `/api/ping` has a noticeable delay while the candidates are being processed or announces flooding in after the job is complete.
7. Update `withMutex` usage per https://github.com/cross-seed/cross-seed/pull/868#discussion_r1920717798 to reduce the chance of user error. Instead of the caller handling the mutex, the functions that need it will always use it. It's not perfect but we need the flexibility of the footgun.
8. Add extra checks to `eslint` to require more explicit usage of async functions and variables. This should help preventing a significant amount of bugs that can be introduced from `sync` to `async` transition or vice versa. Things like non-awaited promises will need `void asyncFunc()` to show it's itentional, await must be used in places like `try/catch` so errors are handled, await cannot be used on sync operations, no unnecessary type assertions (e.g `neverNullishVar!`), etc...