### PR TITLE
update(video-formats): add sonarr supported valid video extensions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,46 @@ export function sourceRegexRemove(title: string): string {
 	return title;
 }
 
-export const VIDEO_EXTENSIONS = [".mkv", ".mp4", ".avi", ".ts"];
+export const VIDEO_EXTENSIONS = [
+	// OG extensions
+	".mkv",
+	".mp4",
+	".avi",
+	".ts",
+	// extensions from the sonarr
+	".m4v",
+	".3gp",
+	".nsv",
+	".ty",
+	".strm",
+	".rm",
+	".rmvb",
+	".mov",
+	".qt",
+	".divx",
+	".xvid",
+	".bivx",
+	".pva",
+	".wmv",
+	".asf",
+	".asx",
+	".ogm",
+	".ogv",
+	".m2v",
+	".dvr-ms",
+	".mpg",
+	".mpeg",
+	".avc",
+	".vp3",
+	".svq3",
+	".nuv",
+	".viv",
+	".dv",
+	".fli",
+	".flv",
+	".wpl",
+	".wtv",
+];
 export const VIDEO_DISC_EXTENSIONS = [".m2ts", ".ifo", ".vob", ".bup"];
 export const AUDIO_EXTENSIONS = [
 	".wav",


### PR DESCRIPTION
this PR adds all valid non-previously assigned video extension formats the constant for `VIDEO_EXTENSIONS` in constants.ts expanding support for more niche formats and older generation video formats

@bakerboy448 supplied the link to sonarr's extensions list which I used to expand this list https://github.com/Sonarr/Sonarr/blob/66633b9b07cf09da18809f789dc92b9c7dbf7105/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs

some of these formats are used to identify discs and were omitted deliberately, the rest were added.