### PR TITLE
fix(inject/resume): only resume if partial match

### DIFF
--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -340,6 +340,7 @@ export default class Deluge implements TorrentClient {
 						!shouldResumeFromNonRelevantFiles(
 							meta,
 							torrentInfo.total_remaining!,
+							decision,
 							{ torrentLog, label: this.label },
 						)
 					) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -889,6 +889,7 @@ export default class QBittorrent implements TorrentClient {
 					!shouldResumeFromNonRelevantFiles(
 						meta,
 						torrentInfo.amount_left,
+						decision,
 						{ torrentLog, label: this.label },
 					)
 				) {

--- a/src/clients/RTorrent.ts
+++ b/src/clients/RTorrent.ts
@@ -771,6 +771,7 @@ export default class RTorrent implements TorrentClient {
 					!shouldResumeFromNonRelevantFiles(
 						meta,
 						torrentInfo.bytesLeft,
+						decision,
 						{ torrentLog, label: this.label },
 					)
 				) {

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -317,10 +317,13 @@ export function getResumeStopTime() {
 export function shouldResumeFromNonRelevantFiles(
 	meta: Metafile,
 	remainingSize: number,
+	decision: DecisionAnyMatch,
 	options?: { torrentLog: string; label: string },
 ): boolean {
-	const { ignoreNonRelevantFilesToResume } = getRuntimeConfig();
+	const { ignoreNonRelevantFilesToResume, matchMode } = getRuntimeConfig();
 	if (!ignoreNonRelevantFilesToResume) return false;
+	if (decision !== Decision.MATCH_PARTIAL) return false;
+	if (matchMode !== MatchMode.PARTIAL) return false;
 	if (remainingSize > 209715200) {
 		if (options) {
 			logger.warn({
@@ -371,9 +374,10 @@ export function shouldResumeFromNonRelevantFiles(
 export function estimatePausedStatus(
 	meta: Metafile,
 	searchee: Searchee,
+	decision: DecisionAnyMatch,
 ): boolean {
 	const { autoResumeMaxDownload } = getRuntimeConfig();
 	const remaining = (1 - getPartialSizeRatio(meta, searchee)) * meta.length;
 	if (remaining <= autoResumeMaxDownload) return false;
-	return !shouldResumeFromNonRelevantFiles(meta, remaining);
+	return !shouldResumeFromNonRelevantFiles(meta, remaining, decision);
 }

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -489,10 +489,15 @@ export default class Transmission implements TorrentClient {
 			}
 			if (leftUntilDone > maxRemainingBytes) {
 				if (
-					!shouldResumeFromNonRelevantFiles(meta, leftUntilDone, {
-						torrentLog,
-						label: this.label,
-					})
+					!shouldResumeFromNonRelevantFiles(
+						meta,
+						leftUntilDone,
+						decision,
+						{
+							torrentLog,
+							label: this.label,
+						},
+					)
 				) {
 					logger.warn({
 						label: this.label,

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -37,6 +37,7 @@ import {
 	areMediaTitlesSimilar,
 	comparing,
 	exists,
+	findFallback,
 	formatAsList,
 	getLogString,
 	humanReadableDate,
@@ -375,10 +376,11 @@ async function injectionAlreadyExists({
 		false,
 	);
 	const decision =
-		clientMatches.find((m) => m.decision === Decision.MATCH)?.decision ??
-		clientMatches.find((m) => m.decision === Decision.MATCH_SIZE_ONLY)
-			?.decision ??
-		Decision.MATCH_PARTIAL;
+		findFallback(
+			clientMatches,
+			[Decision.MATCH, Decision.MATCH_SIZE_ONLY],
+			(match, decision) => match.decision === decision,
+		)?.decision ?? Decision.MATCH_PARTIAL;
 	if (linkedNewFiles) {
 		logger.info({
 			label: Label.INJECT,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -358,6 +358,18 @@ export function fallback<T>(...args: T[]): T | undefined {
 	return undefined;
 }
 
+export function findFallback<T, U>(
+	arr: T[],
+	items: U[],
+	cb: (e: T, item: U) => boolean,
+): T | undefined {
+	for (const item of items) {
+		const found = arr.find((e) => cb(e, item));
+		if (found) return found;
+	}
+	return undefined;
+}
+
 export async function inBatches<T>(
 	items: T[],
 	cb: (batch: T[]) => Promise<void>,


### PR DESCRIPTION
This brings `ignoreNonRelevantFilesToResume` inline with `autoResumeMaxDownload` with preventing resuming if a non partial match or user doesn't not have partial matchMode.