### PR TITLE
update(search): determine caps using search types instead of cats

### DIFF
--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -13,6 +13,7 @@ export enum IndexerStatus {
 
 export interface DbIndexer {
 	id: number;
+	name: string | null;
 	url: string;
 	apikey: string;
 	/**
@@ -24,6 +25,9 @@ export interface DbIndexer {
 	searchCap: boolean;
 	tvSearchCap: boolean;
 	movieSearchCap: boolean;
+	musicSearchCap: boolean;
+	audioSearchCap: boolean;
+	bookSearchCap: boolean;
 	tvIdCaps: string;
 	movieIdCaps: string;
 	catCaps: string;
@@ -52,6 +56,9 @@ export interface Caps {
 	search: boolean;
 	tvSearch: boolean;
 	movieSearch: boolean;
+	musicSearch: boolean;
+	audioSearch: boolean;
+	bookSearch: boolean;
 	movieIdSearch: IdSearchCaps;
 	tvIdSearch: IdSearchCaps;
 	categories: IndexerCategories;
@@ -67,6 +74,7 @@ export interface IdSearchCaps {
 
 export interface Indexer {
 	id: number;
+	name: string | null;
 	url: string;
 	apikey: string;
 	/**
@@ -78,6 +86,9 @@ export interface Indexer {
 	searchCap: boolean;
 	tvSearchCap: boolean;
 	movieSearchCap: boolean;
+	musicSearchCap: boolean;
+	audioSearchCap: boolean;
+	bookSearchCap: boolean;
 	tvIdCaps: IdSearchCaps;
 	movieIdCaps: IdSearchCaps;
 	categories: IndexerCategories;
@@ -88,12 +99,16 @@ const allFields = {
 	id: "id",
 	url: "url",
 	apikey: "apikey",
+	name: "name",
 	active: "active",
 	status: "status",
 	retryAfter: "retry_after",
 	searchCap: "search_cap",
 	tvSearchCap: "tv_search_cap",
 	movieSearchCap: "movie_search_cap",
+	musicSearchCap: "music_search_cap",
+	audioSearchCap: "audio_search_cap",
+	bookSearchCap: "book_search_cap",
 	tvIdCaps: "tv_id_caps",
 	movieIdCaps: "movie_id_caps",
 	catCaps: "cat_caps",
@@ -117,6 +132,9 @@ export const ALL_CAPS: Caps = {
 	},
 	tvSearch: true,
 	movieSearch: true,
+	musicSearch: true,
+	audioSearch: true,
+	bookSearch: true,
 	movieIdSearch: {
 		tvdbId: true,
 		tmdbId: true,
@@ -224,6 +242,9 @@ export async function updateIndexerCapsById(indexerId: number, caps: Caps) {
 			search_cap: caps.search,
 			tv_search_cap: caps.tvSearch,
 			movie_search_cap: caps.movieSearch,
+			music_search_cap: caps.musicSearch,
+			audio_search_cap: caps.audioSearch,
+			book_search_cap: caps.bookSearch,
 			movie_id_caps: JSON.stringify(caps.movieIdSearch),
 			tv_id_caps: JSON.stringify(caps.tvIdSearch),
 			cat_caps: JSON.stringify(caps.categories),

--- a/src/migrations/10-indexerNameAudioBookCaps.ts
+++ b/src/migrations/10-indexerNameAudioBookCaps.ts
@@ -1,0 +1,21 @@
+import Knex from "knex";
+
+async function up(knex: Knex.Knex): Promise<void> {
+	await knex.schema.alterTable("indexer", (table) => {
+		table.string("name").after("id");
+		table.boolean("music_search_cap").nullable().after("movie_search_cap");
+		table.boolean("audio_search_cap").nullable().after("music_search_cap");
+		table.boolean("book_search_cap").nullable().after("audio_search_cap");
+	});
+}
+
+async function down(knex: Knex.Knex): Promise<void> {
+	return knex.schema.table("indexer", function (table) {
+		table.dropColumn("name");
+		table.dropColumn("music_search_cap");
+		table.dropColumn("audio_search_cap");
+		table.dropColumn("book_search_cap");
+	});
+}
+
+export default { name: "10-indexerNameAudioBookCaps", up, down };

--- a/src/migrations/migrations.ts
+++ b/src/migrations/migrations.ts
@@ -8,6 +8,7 @@ import uniqueDecisions from "./06-uniqueDecisions.js";
 import limits from "./07-limits.js";
 import rss from "./08-rss.js";
 import clientAndDataSearchees from "./09-clientAndDataSearchees.js";
+import indexerNameAudioBookCaps from "./10-indexerNameAudioBookCaps.js";
 
 export const migrations = {
 	getMigrations: () =>
@@ -22,6 +23,7 @@ export const migrations = {
 			limits,
 			rss,
 			clientAndDataSearchees,
+			indexerNameAudioBookCaps,
 		]),
 	getMigrationName: (migration) => migration.name,
 	getMigration: (migration) => migration,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -162,13 +162,7 @@ async function findOnOtherSites(
 	const cachedIndexers = cachedSearch.indexerCandidates.length;
 	const searchedIndexers = response.length - cachedIndexers;
 	cachedSearch.indexerCandidates = response;
-
-	const candidates: CandidateWithIndexerId[] = response.flatMap((e) =>
-		e.candidates.map((candidate) => ({
-			...candidate,
-			indexerId: e.indexerId,
-		})),
-	);
+	const candidates = response.flatMap((e) => e.candidates);
 
 	if (response.length) {
 		logger.verbose({

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -295,7 +295,7 @@ export async function filterTimestamps(
 			"indexer.id",
 			enabledIndexers
 				.filter((indexer) =>
-					indexerDoesSupportMediaType(mediaType, indexer.categories),
+					indexerDoesSupportMediaType(mediaType, indexer),
 				)
 				.map((indexer) => indexer.id),
 		)


### PR DESCRIPTION
The main change is using the search caps for `EPISODE`, `SEASON` and `MOVIE` MediaTypes in `indexerDoesSupportMediaType`. A movie tracker has a single tv category of miniseries which causes `cross-seed` to search all episodes and season packs. Using the `tvsearch` caps would address this issue instead of using cats. This seems to work well with all indexers.

I added a migration for audio, music, and book search caps for completeness. They are used in addition to categories for these media types. I also added a new column for name so we can log the names. This is updated on each torznab results call to avoid using the Prowlarr and Jackett APIs.

When we are updating indexer caps (startup and job), we will log the indexer mediatypes support in verbose to make the behavior more clear.