### PR TITLE
fix(action/linking): require absolute file tree paths

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -246,7 +246,7 @@ export default class QBittorrent implements TorrentClient {
 				method: "post",
 				headers: { Cookie: this.cookie, ...headers },
 				body,
-				signal: AbortSignal.timeout(ms("5 minutes")),
+				signal: AbortSignal.timeout(ms("10 minutes")),
 			});
 			if (response.status === 403 && retries > 0) {
 				logger.verbose({
@@ -263,12 +263,13 @@ export default class QBittorrent implements TorrentClient {
 					label: this.label,
 					message: `Request failed, ${retries} retries remaining: ${e.message}`,
 				});
-				return this.request(path, body, headers, retries - 1);
+				return await this.request(path, body, headers, retries - 1);
 			}
 			logger.verbose({
 				label: this.label,
 				message: `Request failed after ${retries} retries: ${e.message}`,
 			});
+			logger.debug(e);
 		}
 		return response?.text();
 	}

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -122,6 +122,12 @@ export async function checkJobs(
 		async () => {
 			const now = Date.now();
 			for (const job of jobs) {
+				const lastRun = await getJobLastRun(job.name);
+				const eligibilityTs = lastRun ? lastRun + job.cadence : now;
+				if (options.isFirstRun) {
+					logNextRun(job.name, job.cadence, lastRun);
+				}
+
 				if (!job.runAheadOfSchedule) {
 					if (jobs.find((j) => j.name === JobName.RSS)?.isActive) {
 						continue;
@@ -134,13 +140,6 @@ export async function checkJobs(
 					if (job.name === JobName.CLEANUP) {
 						if (jobs.some((j) => j.isActive)) continue;
 					}
-				}
-				const lastRun = await getJobLastRun(job.name);
-
-				// if it's never been run, you are eligible immediately
-				const eligibilityTs = lastRun ? lastRun + job.cadence : now;
-				if (options.isFirstRun) {
-					logNextRun(job.name, job.cadence, lastRun);
 				}
 
 				if (job.runAheadOfSchedule || now >= eligibilityTs) {


### PR DESCRIPTION
The file tree paths should always be relative to save path per the spec and is necessary for `cross-seed` to function.