### PR TITLE
update(search/delay): remove delay between cached searches

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -150,7 +150,7 @@ async function makeArrApiCall<ResponseType>(
 		const bodySampleMessage = getBodySampleMessage(responseText);
 		return resultOfErr(
 			new Error(
-				`${response.status} ${response.statusText} ${bodySampleMessage}`,
+				`${response.status === 401 ? "401 Unauthorized (check apikey)" : response.status} ${response.statusText} ${bodySampleMessage}`,
 			),
 		);
 	}


### PR DESCRIPTION
This better supports #947.

Also adding more detail to torznab failures. This should reduce some support tickets.