### PR TITLE
fix(pushNotifier): always send paused for `action: "save"`

### DIFF
--- a/src/arr.ts
+++ b/src/arr.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import ms from "ms";
 import { join as posixJoin } from "node:path/posix";
 import { URLSearchParams } from "node:url";
-import { MediaType, SCENE_TITLE_REGEX } from "./constants.js";
+import { MediaType, SCENE_TITLE_REGEX, USER_AGENT } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
 import { Caps } from "./indexers.js";
 import { Label, logger } from "./logger.js";
@@ -133,7 +133,7 @@ async function makeArrApiCall<ResponseType>(
 	try {
 		response = await fetch(url, {
 			signal: AbortSignal.timeout(ms("30 seconds")),
-			headers: { "X-Api-Key": apikey },
+			headers: { "X-Api-Key": apikey, "User-Agent": USER_AGENT },
 		});
 		clonedResponse = response.clone();
 	} catch (networkError) {

--- a/src/clients/Deluge.ts
+++ b/src/clients/Deluge.ts
@@ -7,6 +7,7 @@ import {
 	InjectionResult,
 	TORRENT_CATEGORY_SUFFIX,
 	TORRENT_TAG,
+	USER_AGENT,
 } from "../constants.js";
 import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
@@ -212,7 +213,10 @@ export default class Deluge implements TorrentClient {
 				`[${this.label}] delugeRpcUrl must be percent-encoded`,
 			),
 		);
-		const headers = new Headers({ "Content-Type": "application/json" });
+		const headers = new Headers({
+			"Content-Type": "application/json",
+			"User-Agent": USER_AGENT,
+		});
 		if (this.delugeCookie) headers.set("Cookie", this.delugeCookie);
 
 		let response: Response, json: DelugeJSON<ResultType>;

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -8,6 +8,7 @@ import {
 	InjectionResult,
 	TORRENT_CATEGORY_SUFFIX,
 	TORRENT_TAG,
+	USER_AGENT,
 } from "../constants.js";
 import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
@@ -205,6 +206,7 @@ export default class QBittorrent implements TorrentClient {
 			response = await fetch(`${href}/auth/login`, {
 				method: "POST",
 				body: new URLSearchParams({ username, password }),
+				headers: { "User-Agent": USER_AGENT },
 				signal: AbortSignal.timeout(ms("10 seconds")),
 			});
 		} catch (e) {
@@ -303,7 +305,11 @@ export default class QBittorrent implements TorrentClient {
 		try {
 			response = await fetch(`${this.url.href}${path}`, {
 				method: "post",
-				headers: { Cookie: this.cookie, ...headers },
+				headers: {
+					Cookie: this.cookie,
+					"User-Agent": USER_AGENT,
+					...headers,
+				},
 				body,
 				signal: AbortSignal.timeout(ms("10 minutes")),
 			});

--- a/src/clients/TorrentClient.ts
+++ b/src/clients/TorrentClient.ts
@@ -168,7 +168,7 @@ export async function validateClientSavePaths(
 	const { linkDirs } = getRuntimeConfig();
 	logger.info({
 		label,
-		message: `Validating all existing torrent save paths...`,
+		message: `Validating save paths for all ${searchees.length} torrents...`,
 	});
 	const infoHashPathMap = new Map(infoHashPathMapOrig);
 

--- a/src/clients/Transmission.ts
+++ b/src/clients/Transmission.ts
@@ -6,6 +6,7 @@ import {
 	DecisionAnyMatch,
 	InjectionResult,
 	TORRENT_TAG,
+	USER_AGENT,
 } from "../constants.js";
 import { db } from "../db.js";
 import { CrossSeedError } from "../errors.js";
@@ -120,7 +121,7 @@ export default class Transmission implements TorrentClient {
 			),
 		);
 
-		const headers = new Headers();
+		const headers = new Headers({ "User-Agent": USER_AGENT });
 		headers.set("Content-Type", "application/json");
 		if (this.xTransmissionSessionId) {
 			headers.set(XTransmissionSessionId, this.xTransmissionSessionId);

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -68,45 +68,46 @@ function logDecision(
 	let reason: string;
 	let match = "no match";
 	switch (decision) {
-		case Decision.MATCH_PARTIAL:
-			match = decision;
-			reason = `${(
-				getPartialSizeRatio(metafile!, searchee) * 100
-			).toFixed(3)}% match`;
-			break;
-		case Decision.MATCH_SIZE_ONLY:
-			match = decision;
-			reason = "100% match";
-			break;
-		case Decision.MATCH:
-			match = decision;
-			reason = "100% match";
-			break;
-		case Decision.FUZZY_SIZE_MISMATCH:
-			reason = `the total sizes are outside of the fuzzySizeThreshold range: ${Math.abs((candidate.size! - searchee.length) / searchee.length).toFixed(3)} > ${getFuzzySizeFactor(searchee)}`;
-			break;
-		case Decision.SIZE_MISMATCH:
-			reason = `some files are missing or have different sizes${compareFileTreesPartial(metafile!, searchee) ? ` (will match in partial match mode)` : ""}`;
-			break;
-		case Decision.PARTIAL_SIZE_MISMATCH:
-			reason = `too many files are missing or have different sizes: torrent progress would be ${(getPartialSizeRatio(metafile!, searchee) * 100).toFixed(3)}%`;
+		case Decision.RELEASE_GROUP_MISMATCH:
+			reason = `it has a different release group: ${getReleaseGroup(
+				stripExtension(searchee.title),
+			)} -> ${getReleaseGroup(stripExtension(candidate.name))}`;
 			break;
 		case Decision.RESOLUTION_MISMATCH:
 			reason = `its resolution does not match: ${
 				searchee.title.match(RES_STRICT_REGEX)?.groups?.res
 			} -> ${candidate.name.match(RES_STRICT_REGEX)?.groups?.res}`;
 			break;
-		case Decision.NO_DOWNLOAD_LINK:
-			reason = "it doesn't have a download link";
+		case Decision.SOURCE_MISMATCH:
+			reason = `it has a different source: ${parseSource(searchee.title)} -> ${parseSource(candidate.name)}`;
 			break;
-		case Decision.RATE_LIMITED:
-			reason = "cross-seed has reached this tracker's rate limit";
+		case Decision.PROPER_REPACK_MISMATCH:
+			reason = `one is a different subsequent release: ${
+				searchee.title.match(REPACK_PROPER_REGEX)?.groups?.type ??
+				"INITIAL"
+			} -> ${candidate.name.match(REPACK_PROPER_REGEX)?.groups?.type ?? "INITIAL"}`;
 			break;
-		case Decision.DOWNLOAD_FAILED:
-			reason = "the torrent file failed to download";
+		case Decision.FUZZY_SIZE_MISMATCH:
+			reason = `the total sizes are outside of the fuzzySizeThreshold range: ${Math.abs((candidate.size! - searchee.length) / searchee.length).toFixed(3)} > ${getFuzzySizeFactor(searchee)}`;
 			break;
-		case Decision.MAGNET_LINK:
-			reason = "the torrent is a magnet link";
+		case Decision.MATCH:
+			match = decision;
+			reason =
+				"all file sizes and file names match: torrent progress will be 100%";
+			break;
+		case Decision.MATCH_SIZE_ONLY:
+			match = decision;
+			reason = "all file sizes match: torrent progress will be 100%";
+			break;
+		case Decision.MATCH_PARTIAL:
+			match = decision;
+			reason = `most file sizes match: torrent progress will be ~${(getPartialSizeRatio(metafile!, searchee) * 100).toFixed(3)}%`;
+			break;
+		case Decision.PARTIAL_SIZE_MISMATCH:
+			reason = `too many files are missing or have different sizes: torrent progress would be ${(getPartialSizeRatio(metafile!, searchee) * 100).toFixed(3)}%`;
+			break;
+		case Decision.SIZE_MISMATCH:
+			reason = `some files are missing or have different sizes${compareFileTreesPartial(metafile!, searchee) ? ` (will match in partial match mode)` : ""}`;
 			break;
 		case Decision.SAME_INFO_HASH:
 			reason = "the info hash is the same";
@@ -117,19 +118,17 @@ function logDecision(
 		case Decision.FILE_TREE_MISMATCH:
 			reason = `it has a different file tree${matchMode === MatchMode.STRICT ? " (will match in flexible or partial matchMode)" : ""}`;
 			break;
-		case Decision.RELEASE_GROUP_MISMATCH:
-			reason = `it has a different release group: ${getReleaseGroup(
-				stripExtension(searchee.title),
-			)} -> ${getReleaseGroup(stripExtension(candidate.name))}`;
+		case Decision.MAGNET_LINK:
+			reason = "the torrent is a magnet link";
 			break;
-		case Decision.PROPER_REPACK_MISMATCH:
-			reason = `one is a different subsequent release: ${
-				searchee.title.match(REPACK_PROPER_REGEX)?.groups?.type ??
-				"INITIAL"
-			} -> ${candidate.name.match(REPACK_PROPER_REGEX)?.groups?.type ?? "INITIAL"}`;
+		case Decision.RATE_LIMITED:
+			reason = "cross-seed has reached this tracker's rate limit";
 			break;
-		case Decision.SOURCE_MISMATCH:
-			reason = `it has a different source: ${parseSource(searchee.title)} -> ${parseSource(candidate.name)}`;
+		case Decision.DOWNLOAD_FAILED:
+			reason = "the torrent file failed to download";
+			break;
+		case Decision.NO_DOWNLOAD_LINK:
+			reason = "it doesn't have a download link";
 			break;
 		case Decision.BLOCKED_RELEASE:
 			reason = `it matches the blocklist: ${

--- a/src/indexers.ts
+++ b/src/indexers.ts
@@ -197,12 +197,12 @@ export async function updateIndexerStatus(
 	status: IndexerStatus,
 	retryAfter: number,
 	indexerIds: number[],
-	indexerNames: string[],
+	indexerNames: Set<string>,
 ) {
 	if (indexerIds.length > 0) {
 		logger.verbose({
 			label: Label.TORZNAB,
-			message: `Snoozing indexers ${indexerNames} with ${status} until ${humanReadableDate(
+			message: `Snoozing indexers [${Array.from(indexerNames).join(", ")}] with ${status} until ${humanReadableDate(
 				retryAfter,
 			)}`,
 		});

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -179,7 +179,7 @@ async function findOnOtherSites(
 	);
 
 	const allIndexers = await getAllIndexers();
-	const rateLimitedNames: string[] = [];
+	const rateLimitedNames = new Set<string>();
 	const { rateLimited, notRateLimited } = assessments.reduce(
 		(acc, cur, idx) => {
 			const candidate = candidates[idx];
@@ -187,7 +187,7 @@ async function findOnOtherSites(
 				const indexer = allIndexers.find(
 					(i) => i.id === candidate.indexerId,
 				)!;
-				rateLimitedNames.push(indexer.name ?? indexer.url);
+				rateLimitedNames.add(indexer.name ?? indexer.url);
 				acc.rateLimited.add(candidate.indexerId);
 				acc.notRateLimited.delete(candidate.indexerId);
 			}

--- a/src/pushNotifier.ts
+++ b/src/pushNotifier.ts
@@ -102,19 +102,24 @@ export function sendResultsNotification(
 		);
 		const trackers = notableSuccesses.map(([, tracker]) => tracker);
 		const trackersListStr = formatAsList(trackers, { sort: true });
-		const paused = notableSuccesses.some(([{ metafile }]) =>
-			estimatePausedStatus(
-				metafile!,
-				searchee,
-				(findFallback(
-					notableSuccesses,
-					[Decision.MATCH, Decision.MATCH_SIZE_ONLY],
-					(success, decision) =>
-						success[0].decision === decision &&
-						success[2] === InjectionResult.SUCCESS,
-				)?.[0].decision ?? Decision.MATCH_PARTIAL) as DecisionAnyMatch,
-			),
-		);
+		const paused = notableSuccesses.every(
+			([, , actionResult]) => actionResult === SaveResult.SAVED,
+		)
+			? true
+			: notableSuccesses.some(([{ metafile }]) =>
+					estimatePausedStatus(
+						metafile!,
+						searchee,
+						(findFallback(
+							notableSuccesses,
+							[Decision.MATCH, Decision.MATCH_SIZE_ONLY],
+							(success, decision) =>
+								success[0].decision === decision &&
+								success[2] === InjectionResult.SUCCESS,
+						)?.[0].decision ??
+							Decision.MATCH_PARTIAL) as DecisionAnyMatch,
+					),
+				);
 		const injected = notableSuccesses.some(
 			([, , actionResult]) => actionResult === InjectionResult.SUCCESS,
 		);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -569,10 +569,8 @@ export async function indexTorrentsAndDataDirs(
 			const maxRetries = 3;
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				try {
-					await Promise.all([
-						indexTorrents(options),
-						indexDataDirs(options),
-					]);
+					await indexDataDirs(options); // Running together may increase failures
+					await indexTorrents(options); // Run second so this data is more fresh
 					break;
 				} catch (e) {
 					const msg = `Indexing failed (${maxRetries - attempt}): ${e.message}`;

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -805,7 +805,7 @@ async function onResponseNotOk(
 			: IndexerStatus.UNKNOWN_ERROR,
 		retryAfter,
 		[indexerId],
-		[indexerName],
+		new Set([indexerName]),
 	);
 	return retryAfter;
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -629,7 +629,10 @@ async function fetchCaps(indexer: Indexer): Promise<Caps> {
 	try {
 		response = await fetch(
 			assembleUrl(indexer.url, indexer.apikey, { t: "caps" }),
-			{ signal: AbortSignal.timeout(ms("1 minute")) },
+			{
+				headers: { "User-Agent": USER_AGENT },
+				signal: AbortSignal.timeout(ms("1 minute")),
+			},
 		);
 	} catch (e) {
 		const error = new Error(


### PR DESCRIPTION
This case was missed and effectively depended on what the actual torrent resume state would be. It makes more sense to always have these as `paused` since the value has little meaning for these.

Also updated some logging, added `User-Agent` to all `fetch()` requests, and no longer indexing dataDirs and torrents simultaneously.