### PR TITLE
enhancement(snatch): temporarily store failed history for tracker

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -90,13 +90,16 @@ export async function cleanupDB(): Promise<void> {
 			label: Label.CLEANUP,
 			message: "Pruning failed snatch history entries",
 		});
-		for (const [url, ts] of snatchHistory.entries()) {
-			if (Date.now() - ts > ms("1 day")) {
+		for (const [
+			str,
+			{ initialFailureAt, numFailures },
+		] of snatchHistory.entries()) {
+			if (Date.now() - initialFailureAt > ms("1 day")) {
 				logger.verbose({
 					label: Label.CLEANUP,
-					message: `Deleting snatch history entry for ${url}`,
+					message: `Deleting snatch history entry for ${str}: ${numFailures} failures`,
 				});
-				snatchHistory.delete(url);
+				snatchHistory.delete(str);
 			}
 		}
 	})();

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -667,9 +667,7 @@ export async function getSimilarByName(name: string): Promise<{
 		return { keys: [], clientSearchees, dataSearchees };
 	}
 	const candidateMaxDistance = Math.floor(
-		keyTitles.reduce((sum, title) => sum + title.length, 0) /
-			keyTitles.length /
-			LEVENSHTEIN_DIVISOR,
+		Math.min(...keyTitles.map((t) => t.length)) / LEVENSHTEIN_DIVISOR,
 	);
 
 	const filterEntries = (dbEntries: { title?: string; name?: string }[]) => {
@@ -677,14 +675,10 @@ export async function getSimilarByName(name: string): Promise<{
 			const entry = getKeysFromName(dbEntry.title ?? dbEntry.name!);
 			if (entry.element !== element) return false;
 			if (!entry.keyTitles.length) return false;
-			const maxDistance = Math.max(
+			const maxDistance = Math.min(
 				candidateMaxDistance,
 				Math.floor(
-					entry.keyTitles.reduce(
-						(sum, title) => sum + title.length,
-						0,
-					) /
-						entry.keyTitles.length /
+					Math.min(...entry.keyTitles.map((t) => t.length)) /
 						LEVENSHTEIN_DIVISOR,
 				),
 			);


### PR DESCRIPTION
Expands on #986 to prevent retrying snatches if a tracker has failed too many times recently, on top of just a link. A snatch is always attempted at least once regardless of previous failures.

Also made the reverse lookup levenshtein fuzzy more conservative by basing on the length of the shortest title, instead of average.