### PR TITLE
update(inject): don't refresh searchee for inject job

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -248,14 +248,17 @@ async function getSavePath(
 			: clients.find((c) => c.clientHost === searchee.clientHost)!;
 	let savePath: string;
 	if (searchee.savePath) {
-		const refreshedSearchee = (
-			await client.getClientSearchees({
-				newSearcheesOnly: true,
-				refresh: [searchee.infoHash],
-			})
-		).newSearchees.find((s) => s.infoHash === searchee.infoHash);
-		if (!refreshedSearchee) return resultOfErr("TORRENT_NOT_FOUND");
-		Object.assign(searchee, refreshedSearchee);
+		if (searchee.label !== Label.INJECT) {
+			// This check is too slow for the number of searchees from the inject job
+			const refreshedSearchee = (
+				await client.getClientSearchees({
+					newSearcheesOnly: true,
+					refresh: [searchee.infoHash],
+				})
+			).newSearchees.find((s) => s.infoHash === searchee.infoHash);
+			if (!refreshedSearchee) return resultOfErr("TORRENT_NOT_FOUND");
+			Object.assign(searchee, refreshedSearchee);
+		}
 		if (
 			!(await client.isTorrentComplete(searchee.infoHash)).orElse(false)
 		) {

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -297,7 +297,7 @@ export default class QBittorrent implements TorrentClient {
 			body instanceof URLSearchParams || body instanceof FormData
 				? JSON.stringify(Object.fromEntries(body))
 				: JSON.stringify(body).replace(
-						/(?:hashes=)([a-z0-9]{40})/i,
+						/(?:hash(?:es)?=)([a-z0-9]{40})/i,
 						(match, hash) =>
 							match.replace(hash, sanitizeInfoHash(hash)),
 					);


### PR DESCRIPTION
This check is unnecessary for the inject job and can significantly slow down the process since each candidate can have 10+ searchees to try with.

Also now explicitly awaiting the long running promises created during the inject job as the change in startup/shutdown behavior no longer implicitly awaits for them. This only matters for `cross-seed inject`, not daemon mode.