### PR TITLE
enhancement(inject): add injected candidates to searchee pool

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -399,7 +399,10 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 	.addOption(apiKeyOption)
 	.action(
 		withFullRuntime(async (options) => {
-			await indexTorrentsAndDataDirs({ startup: true });
+			await indexTorrentsAndDataDirs({
+				startup: true,
+				indexDataDirs: true,
+			});
 			// technically this will never resolve, but it's necessary to keep the process running
 			await Promise.all([serve(options.port, options.host), jobsLoop()]);
 		}),
@@ -407,7 +410,7 @@ createCommandWithSharedOptions("daemon", "Start the cross-seed daemon")
 
 createCommandWithSharedOptions("rss", "Run an rss scan").action(
 	withFullRuntime(async () => {
-		await indexTorrentsAndDataDirs({ startup: true });
+		await indexTorrentsAndDataDirs({ startup: true, indexDataDirs: true });
 		await scanRssFeeds();
 	}),
 );

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -627,6 +627,12 @@ export async function checkNewCandidateMatch(
 			[matchedAssessment!, candidate.tracker, actionResult!],
 		]);
 	}
+	if (actionResult === InjectionResult.SUCCESS) {
+		await indexTorrentsAndDataDirs({
+			startup: false,
+			indexDataDirs: false,
+		});
+	}
 	return { decision, actionResult };
 }
 

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -526,7 +526,7 @@ async function indexTorrentDir(dir: string): Promise<SearcheeWithInfoHash[]> {
 }
 
 export async function indexTorrentsAndDataDirs(
-	options = { startup: false },
+	options = { startup: false, indexDataDirs: true },
 ): Promise<void> {
 	if (options.startup) {
 		const { dataDirs, seasonFromEpisodes, torrentDir, useClientTorrents } =
@@ -587,7 +587,7 @@ export async function indexTorrentsAndDataDirs(
 			const maxRetries = 3;
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {
 				try {
-					await indexDataDirs(options); // Running together may increase failures
+					if (options.indexDataDirs) await indexDataDirs(options); // Running together may increase failures
 					await indexTorrents(options); // Run second so this data is more fresh
 					break;
 				} catch (e) {


### PR DESCRIPTION
This in support of this [FAQ](https://www.cross-seed.org/docs/basics/faq-troubleshooting#my-partial-matches-from-related-searches-are-missing-the-same-data-how-can-i-only-download-it-once) for rss/announce/inject. Since these process once candidate at a time, we can add the injected candidate for the searchee pool for the next candidate.

For search/webhook, this does not apply. Since these process one searchee at a time and all valid candidates are injected, there is no value to be derived unless the newly injected torrents recheck+complete in a couple seconds.