### PR TITLE
enhancement(announce): support cookie

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -92,6 +92,7 @@ export interface Candidate {
 	size?: number;
 	pubDate?: number;
 	indexerId?: number;
+	cookie?: string;
 }
 
 export type CandidateWithIndexerId = WithRequired<Candidate, "indexerId">;

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,10 @@ const ANNOUNCE_SCHEMA = z
 			.string()
 			.transform((tracker) => tracker.trim())
 			.refine((tracker) => tracker.length > 0),
+		cookie: z
+			.string()
+			.nullish()
+			.transform((cookie) => cookie?.trim() || undefined),
 	})
 	.strict()
 	.required()

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -154,7 +154,10 @@ async function snatchOnce(
 	let response: Response;
 	try {
 		response = await fetch(url, {
-			headers: { "User-Agent": USER_AGENT },
+			headers: {
+				...(candidate.cookie ? { Cookie: candidate.cookie } : {}),
+				"User-Agent": USER_AGENT,
+			},
 			signal:
 				typeof snatchTimeout === "number"
 					? AbortSignal.timeout(snatchTimeout)


### PR DESCRIPTION
Passes the cookie if autobrr supplies it: autobrr/autobrr#2107

To take advantage, users will need to update their payload but very few users will need to do this as these trackers are rare.