### PR TITLE
feat(qbittorrent): add categoryTemplate and tagsTemplate options

### DIFF
--- a/cross-seed/src/clients/QBittorrent.ts
+++ b/cross-seed/src/clients/QBittorrent.ts
@@ -419,50 +419,81 @@ export default class QBittorrent implements TorrentClient {
 		category: string,
 		savePath: string,
 		autoTMM: boolean,
+		searcheeInfo: TorrentInfo | undefined,
 	): Promise<string> {
-		const { duplicateCategories, linkCategory } = getRuntimeConfig();
+		const { categoryTemplate, duplicateCategories, linkCategory } =
+			getRuntimeConfig();
+		const searcheeCategory = searcheeInfo?.category;
 
-		if (!duplicateCategories) {
-			return category;
-		}
-		if (!category.length || category === linkCategory) {
-			return category; // Use tags for category duplication if linking
+		if (categoryTemplate !== undefined) {
+			if (
+				!searcheeCategory &&
+				categoryTemplate.includes("{searcheeCategory}")
+			) {
+				return category;
+			}
+			category = categoryTemplate.replaceAll(
+				"{searcheeCategory}",
+				() => searcheeCategory ?? "",
+			);
+		} else {
+			if (!duplicateCategories) return category;
+			if (!category.length || category === linkCategory) {
+				return category; // Use tags for category duplication if linking
+			}
+			category = category.endsWith(TORRENT_CATEGORY_SUFFIX)
+				? category
+				: `${category}${TORRENT_CATEGORY_SUFFIX}`;
 		}
 
-		const dupeCategory = category.endsWith(TORRENT_CATEGORY_SUFFIX)
-			? category
-			: `${category}${TORRENT_CATEGORY_SUFFIX}`;
-		if (!autoTMM) return dupeCategory;
+		if (!category.length || !autoTMM) return category;
 
 		// savePath is guaranteed to be the base category's save path due to autoTMM
 		const categories = await this.getAllCategories();
-		const newRes = categories.find((c) => c.name === dupeCategory);
+		const newRes = categories.find((c) => c.name === category);
 		if (!newRes) {
-			await this.createCategory(dupeCategory, savePath);
+			await this.createCategory(category, savePath);
 		} else if (newRes.savePath !== savePath) {
-			await this.editCategory(dupeCategory, savePath);
+			await this.editCategory(category, savePath);
 		}
-		return dupeCategory;
+		return category;
 	}
 
 	private getTagsForNewTorrent(
 		searcheeInfo: TorrentInfo | undefined,
 		destinationDir: string | undefined,
 	): string {
-		const { duplicateCategories, linkCategory } = getRuntimeConfig();
+		const { duplicateCategories, linkCategory, tagsTemplate } =
+			getRuntimeConfig();
+		const searcheeCategory = searcheeInfo?.category;
 
-		if (!duplicateCategories || !searcheeInfo || !destinationDir) {
+		if (tagsTemplate?.length) {
+			if (
+				!searcheeCategory &&
+				tagsTemplate.some((tag) => tag.includes("{searcheeCategory}"))
+			) {
+				return TORRENT_TAG;
+			}
+			return tagsTemplate
+				.map((tag) =>
+					tag.replaceAll(
+						"{searcheeCategory}",
+						() => searcheeCategory ?? "",
+					),
+				)
+				.join(",");
+		}
+
+		if (!duplicateCategories || !searcheeCategory || !destinationDir) {
 			return TORRENT_TAG; // Require destinationDir to duplicate category using tags
 		}
-		const searcheeCategory = searcheeInfo.category;
-		if (!searcheeCategory.length || searcheeCategory === linkCategory) {
-			return TORRENT_TAG;
-		}
+		if (searcheeCategory === linkCategory) return TORRENT_TAG;
 
-		if (searcheeCategory.endsWith(TORRENT_CATEGORY_SUFFIX)) {
-			return `${TORRENT_TAG},${searcheeCategory}`;
-		}
-		return `${TORRENT_TAG},${searcheeCategory}${TORRENT_CATEGORY_SUFFIX}`;
+		return `${TORRENT_TAG},${
+			searcheeCategory.endsWith(TORRENT_CATEGORY_SUFFIX)
+				? searcheeCategory
+				: `${searcheeCategory}${TORRENT_CATEGORY_SUFFIX}`
+		}`;
 	}
 
 	async createTag(): Promise<void> {
@@ -1126,6 +1157,7 @@ export default class QBittorrent implements TorrentClient {
 						category,
 						savePath,
 						autoTMM,
+						searcheeInfo,
 					),
 				);
 			}

--- a/cross-seed/src/configuration.ts
+++ b/cross-seed/src/configuration.ts
@@ -43,6 +43,8 @@ export interface FileConfig {
 	linkType?: string;
 	flatLinking?: boolean;
 	maxDataDepth?: number;
+	categoryTemplate?: string;
+	tagsTemplate?: string[] | string;
 	linkCategory?: string;
 	torrentDir?: string;
 	torznab?: string[];
@@ -127,6 +129,8 @@ export function getDefaultRuntimeConfig(): RuntimeConfig {
 		linkType: LinkType.HARDLINK,
 		flatLinking: false,
 		maxDataDepth: 2,
+		categoryTemplate: undefined,
+		tagsTemplate: undefined,
 		linkCategory: "cross-seed-link",
 		outputDir: path.join(appDir(), "cross-seeds"),
 		ignoreTitles: false,
@@ -241,6 +245,18 @@ export function transformFileConfig(
 
 	if (typeof fileConfig.maxDataDepth === "number") {
 		result.maxDataDepth = fileConfig.maxDataDepth;
+	}
+
+	if (typeof fileConfig.categoryTemplate === "string") {
+		result.categoryTemplate = fileConfig.categoryTemplate;
+	}
+
+	if (typeof fileConfig.tagsTemplate === "string") {
+		result.tagsTemplate = fileConfig.tagsTemplate
+			.split(",")
+			.map((tag) => tag.trim());
+	} else if (isStringArray(fileConfig.tagsTemplate)) {
+		result.tagsTemplate = fileConfig.tagsTemplate;
 	}
 
 	if (typeof fileConfig.linkCategory === "string") {

--- a/cross-seed/tests/clients/QBittorrent.test.ts
+++ b/cross-seed/tests/clients/QBittorrent.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConfig = {
+	categoryTemplate: undefined as string | undefined,
+	tagsTemplate: undefined as string[] | undefined,
+	duplicateCategories: false,
+	linkCategory: "cross-seed-link",
+};
+
+vi.mock("../../src/runtimeConfig.js", () => ({
+	getRuntimeConfig: () => mockConfig,
+}));
+
+type TemplateMethods = {
+	getCategoryForNewTorrent(
+		category: string,
+		savePath: string,
+		autoTMM: boolean,
+		searcheeInfo?: { category: string },
+	): Promise<string>;
+	getTagsForNewTorrent(
+		searcheeInfo?: { category: string },
+		destinationDir?: string,
+	): string;
+};
+
+let client: TemplateMethods;
+
+beforeAll(async () => {
+	const { default: QBittorrent } =
+		await import("../../src/clients/QBittorrent.js");
+	client = new QBittorrent(
+		"http://test:test@localhost:8080",
+		"localhost",
+		1,
+		false,
+	) as unknown as TemplateMethods;
+});
+
+beforeEach(() => {
+	mockConfig.categoryTemplate = undefined;
+	mockConfig.tagsTemplate = undefined;
+	mockConfig.duplicateCategories = false;
+});
+
+describe("qBittorrent category and tag templates", () => {
+	it("renders the searchee category", async () => {
+		mockConfig.categoryTemplate = "{searcheeCategory}.cross-seed";
+		mockConfig.tagsTemplate = ["cross-seed", "{searcheeCategory}"];
+
+		await expect(
+			client.getCategoryForNewTorrent("Movies", "/downloads", false, {
+				category: "Movies",
+			}),
+		).resolves.toBe("Movies.cross-seed");
+		expect(client.getTagsForNewTorrent({ category: "Movies" })).toBe(
+			"cross-seed,Movies",
+		);
+	});
+
+	it("preserves duplicateCategories behavior when templates are unset", async () => {
+		mockConfig.duplicateCategories = true;
+
+		await expect(
+			client.getCategoryForNewTorrent("Movies", "/downloads", false, {
+				category: "Movies",
+			}),
+		).resolves.toBe("Movies.cross-seed");
+		expect(
+			client.getTagsForNewTorrent({ category: "Movies" }, "/links"),
+		).toBe("cross-seed,Movies.cross-seed");
+	});
+
+	it("falls back when a template variable is unavailable", async () => {
+		mockConfig.categoryTemplate = "{searcheeCategory}.cross-seed";
+		mockConfig.tagsTemplate = ["{searcheeCategory}"];
+
+		await expect(
+			client.getCategoryForNewTorrent(
+				"cross-seed-link",
+				"/downloads",
+				false,
+			),
+		).resolves.toBe("cross-seed-link");
+		expect(client.getTagsForNewTorrent()).toBe("cross-seed");
+	});
+});

--- a/cross-seed/tests/configSchema.test.ts
+++ b/cross-seed/tests/configSchema.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils.js", () => ({ errorCode: vi.fn() }));
+
+import { parseRuntimeConfigOverrides } from "../src/configSchema.js";
+import { transformFileConfig } from "../src/configuration.js";
+
+describe("category and tag templates", () => {
+	it("transforms config-file values into runtime config", () => {
+		expect(
+			transformFileConfig({
+				categoryTemplate: "{searcheeCategory}.cross-seed",
+				tagsTemplate: "cross-seed, {searcheeCategory}",
+			}),
+		).toEqual({
+			categoryTemplate: "{searcheeCategory}.cross-seed",
+			tagsTemplate: ["cross-seed", "{searcheeCategory}"],
+		});
+	});
+
+	it("accepts template runtime overrides", () => {
+		expect(
+			parseRuntimeConfigOverrides({
+				categoryTemplate: "cross-seed",
+				tagsTemplate: ["cross-seed"],
+			}),
+		).toEqual({
+			categoryTemplate: "cross-seed",
+			tagsTemplate: ["cross-seed"],
+		});
+	});
+});

--- a/shared/configSchema.ts
+++ b/shared/configSchema.ts
@@ -22,6 +22,8 @@ export const RUNTIME_CONFIG_SCHEMA = z.object({
 	linkType: z.nativeEnum(LinkType),
 	flatLinking: z.boolean(),
 	maxDataDepth: z.number().int().min(1),
+	categoryTemplate: z.string().optional(),
+	tagsTemplate: z.array(z.string()).optional(),
 	linkCategory: z.string().optional(),
 	torrentDir: z.string().optional(),
 	outputDir: z.string(),

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -120,6 +120,8 @@ export const defaultConfig: RuntimeConfig = {
 	linkType: LinkType.HARDLINK,
 	flatLinking: false,
 	maxDataDepth: 2,
+	categoryTemplate: undefined,
+	tagsTemplate: undefined,
 	torrentDir: undefined,
 	outputDir: "",
 	injectDir: "",


### PR DESCRIPTION
(proposal)

This PR follows up on https://github.com/cross-seed/cross-seed/discussions/901 and adds the following configuration options (see [config template](https://github.com/cross-seed/cross-seed/commit/6113a17fe7ac9ab93e7a1f1262d4ccf833fb2a25#diff-15fff026bce4fedcf9bc7e8b8bd8b19fcecb75ab072483bed46b487f07e7d89eR125) for full description) in order to customize how category and tags are set on cross-seeds.
- `categoryTemplate`
- `tagsTemplate`

My specific need was to be able to set `category = 'searcheeCategory' / tags = ['cross-seed']` with linking enabled (I use post-import categories on *arr to avoid endless import loop)

If accepted, I'll handle the documentation part (mostly adding some warnings for *arr users)

Notes:

- Not really familiar with the project + not a TS practitioner by day, sorry for the
- I refactored the QBittorrent inject method a bit to move all category/tag logic into `getCategoryForNewTorrent` and `getTagsForNewTorrent`
- The current behavior (with and w/o linking) should be retained
- Only implemented this for QBittorrent for now
- I feel these options could replace `linkCategory` and `duplicateCategories` at some point / but having boolean knobs for usual "presets" is also cool, so I don't know
- Test suite was scaffolded with Claude Code