### PR TITLE
perf(inject): up to 16x speed up for job by reducing api calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"chalk": "^5.0.0",
 				"commander": "^8.3.0",
 				"fastest-levenshtein": "^1.0.16",
-				"fuse.js": "^6.6.2",
 				"knex": "^3.1.0",
 				"lodash-es": "^4.17.21",
 				"ms": "^2.1.3",
@@ -2649,14 +2648,6 @@
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/fuse.js": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-			"integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/get-package-type": {


### PR DESCRIPTION
For `cross-seed inject`, we check every searchee against the .torrent file and run the action stage for all of them. This is because one searchee might have a file that another doesn't that the candidate needs. e.g:
* Candidate: mkv, srt, nfo
* SearcheeA: mkv, srt
* SearcheeB: mkv, nfo

The issue is that a single candidate can easily have 10+ valid searchees that the user already has. The slowdown happens when we are in the action stage for each injection, we call `client.inject()` which first checks if the torrent exists in client to return `ALREADY_EXISTS`. This API call can take a bit if the client has a large amount of torrents.

Instead, we already know if the candidate already exists in client as we need to use that save path if it does, rather than any from `linkDirs`. By removing this extra exists check, I was able to reduce the time from `232s` to `14s` for injecting `10` .torrent files. This is because the first searchee injects the candidate then all others link the new files and recheck if necessary.