### PR TITLE
update(gh/README) update and simplify README.md file on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,14 @@
-# cross-seed: Fully-automatic, no false positives
+# cross-seed: Fully-automatic cross-seeding
 
-`cross-seed` is a tool that automatically finds and downloads torrents that
+`cross-seed` automatically finds and downloads torrents that
 are "cross seeds" existing across your other trackers, all based on your
 existing torrents and/or data. It is designed to match conservatively to
 minimize manual intervention, but is also highly configurable to match your
 preferences.
 
-## Supported Clients
+## Torrent Client Integration
 
-`cross-seed` can inject (our terminology for "add") new torrents it finds directly into your torrent client.
-
-Currently, the supported clients are fully supported:
-
--   rTorrent
--   qBittorrent
--   Transmission
--   Deluge 2.x (limited 1.3.x support)
-
-If your client isn't supported, `cross-seed` will download it's found matching
-torrent files to a folder you specify. Following that, you will need to find a
-means (or write a script) to add the files to your client.
+`cross-seed` can inject new torrents it finds directly into your torrent client. 
 
 If you use another client we do not currently support, and would like to help integrate it into
 `cross-seed`, [please open an issue here on GitHub to discuss it with us](https://github.com/cross-seed/cross-seed/issues).
@@ -43,7 +32,3 @@ If you are migrating version to the latest available, please read
 Feel free to
 [start a discussion](https://github.com/cross-seed/cross-seed/discussions/new),
 or reach out on [Discord](https://discord.gg/jpbUFzS5Wb).
-
-## Development Overview
-
-![Alt](https://repobeats.axiom.co/api/embed/8a8e3b335b4b322f1d37f5981b6de2dad546a730.svg "Repobeats analytics image")d

--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # cross-seed: Fully-automatic, no false positives
 
-`cross-seed` is an app designed to help you download torrents that you can cross
-seed based on your existing torrents. It is designed to match conservatively to
-minimize manual intervention.
+`cross-seed` is a tool that automatically finds and downloads torrents that
+are "cross seeds" existing across your other trackers, all based on your
+existing torrents and/or data. It is designed to match conservatively to
+minimize manual intervention, but is also highly configurable to match your
+preferences.
 
-`cross-seed` can inject the torrents it finds directly into your torrent client.
-Currently, the supported clients are
+## Supported Clients
+
+`cross-seed` can inject (our terminology for "add") new torrents it finds directly into your torrent client.
+
+Currently, the supported clients are fully supported:
 
 -   rTorrent
 -   qBittorrent
 -   Transmission
--   Deluge
+-   Deluge 2.x (limited 1.3.x support)
 
-If your client isn't supported, `cross-seed` will download a bunch of torrent
-files to a folder you specify. After that, I recommend using
-[AutoTorrent2](https://github.com/JohnDoee/autotorrent2) to do the last-mile
-delivery into your client.
+If your client isn't supported, `cross-seed` will download it's found matching
+torrent files to a folder you specify. Following that, you will need to find a
+means (or write a script) to add the files to your client.
 
-## 🚨🚨🚨 Breaking changes in cross-seed v6 🚨🚨🚨
+If you use another client we do not currently support, and would like to help integrate it into
+`cross-seed`, [please open an issue here on GitHub to discuss it with us](https://github.com/cross-seed/cross-seed/issues).
 
-Head on over to the
-[v6 migration guide](https://www.cross-seed.org/docs/v6-migration)
-to see the steps required for migration.
- 
 ## Requirements
 
 -   [Node >= 20](https://nodejs.org/en/download)
--   Any number of indexers that support Torznab (use Jackett or Prowlarr to
-    help)
+-   Indexers that support Torznab or an tracker/indexer manager such as Prowlarr/Jackett (Prowlarr is preferred)
 
 ## Tutorial
 
@@ -35,8 +35,15 @@ Head on over to
 [cross-seed.org](https://www.cross-seed.org/docs/basics/getting-started) to get
 started.
 
+If you are migrating version to the latest available, please read
+[the v6 migration guide](https://www.cross-seed.org/docs/v6-migration).
+
 ## Troubleshooting
 
 Feel free to
 [start a discussion](https://github.com/cross-seed/cross-seed/discussions/new),
 or reach out on [Discord](https://discord.gg/jpbUFzS5Wb).
+
+## Development Overview
+
+![Alt](https://repobeats.axiom.co/api/embed/8a8e3b335b4b322f1d37f5981b6de2dad546a730.svg "Repobeats analytics image")d


### PR DESCRIPTION
This PR updates the README to have more flowing language, removes the reference to the "New breaking changes in v6" for a gentle mention of "if you're migrating", and removes autotorrent entirely - as we now support all of the clients AT2 supported, and it's of no benefit.

I also added a Repobeats graph at the bottom to gauge everyone's thoughts on the new look. You can see it at the link below.


https://github.com/cross-seed/cross-seed/tree/update-gh-readme

<hr>
Update our "description" to "Fully-automatic cross-seeding"

- [x] documentation
- [x] unraid template
- [ ] README.md (this)