### PR TITLE
perf(client): optimize client indexing

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -672,7 +672,12 @@ export async function findAllSearchees(
 						await flatMapAsync(
 							clients,
 							async (client) =>
-								(await client.getClientSearchees()).searchees,
+								(
+									await client.getClientSearchees({
+										includeFiles: true,
+										includeTrackers: true,
+									})
+								).searchees,
 						),
 					);
 				} else if (torrentDir) {

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -465,6 +465,8 @@ async function indexTorrents(options: { startup: boolean }): Promise<void> {
 					(
 						await client.getClientSearchees({
 							newSearcheesOnly: true,
+							includeFiles: true,
+							includeTrackers: true,
 						})
 					).newSearchees,
 			);


### PR DESCRIPTION
This should help prevent lots of queries if lots of torrents are missing metadata or long time between indexing.