### PR TITLE
enhancement(preFilter): prevent searching for bad episode/season naming formats

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,9 +12,13 @@ export const NEWLINE_INDENT = "\n\t\t\t\t";
 
 export const EP_REGEX =
 	/^(?<title>.+?)[_.\s-]+(?:(?<season>S\d+)?[_.\s-]{0,3}(?!(?:19|20)\d{2})(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?(?!(?:19|20)\d{2})E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
+export const BAD_EP_REGEX =
+	/^[_.\s-]*[^_.\s-]*?(?:(?<season>S\d+)?[_.\s-]{0,3}(?!(?:19|20)\d{2})(?<episode>(?:E|(?<=S\d+[_\s-]{1,3}))\d+(?:[\s-]?(?!(?:19|20)\d{2})E?\d+)?(?![pix]))(?!\d+[pix])|(?<date>(?<year>(?:19|20)\d{2})[_.\s-](?<month>\d{2})[_.\s-](?<day>\d{2})))/i;
 export const IS_MULTI_EP_REGEX = /E\d+(?:[-.]?S\d+E\d|[-.]?E\d|[-.]\d)/i;
 export const SEASON_REGEX =
 	/^(?<title>.+?)[[(_.\s-]+(?<season>S(?:eason)?\s*\d+)(?=\b(?![_.\s~-]*E\d+))/i;
+export const BAD_SEASON_REGEX =
+	/^[[_.\s-]*[^[_.\s-]*?(?<season>S(?:eason)?\s*\d+)(?=\b(?![_.\s~-]*E\d+))/i;
 export const MOVIE_REGEX =
 	/^(?<title>.+?)-?[_.\s][[(]?(?<year>(?:18|19|20)\d{2})[)\]]?(?![pix])/i;
 export const ANIME_REGEX =
@@ -77,7 +81,7 @@ export const VIDEO_EXTENSIONS = [
 	".mp4",
 	".avi",
 	".ts",
-	// extensions from the sonarr
+	// extensions from sonarr
 	".m4v",
 	".3gp",
 	".nsv",

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -12,6 +12,8 @@ import {
 	VIDEO_EXTENSIONS,
 	TORRENT_TAG,
 	TORRENT_CATEGORY_SUFFIX,
+	BAD_EP_REGEX,
+	BAD_SEASON_REGEX,
 } from "./constants.js";
 import { db } from "./db.js";
 import { getEnabledIndexers } from "./indexers.js";
@@ -181,6 +183,19 @@ export async function filterByContent(
 		extractInt(searchee.title.match(SEASON_REGEX)!.groups!.season) === 0
 	) {
 		logReason("it is a Specials folder", searchee, mediaType);
+		return false;
+	}
+
+	if (
+		[Label.SEARCH, Label.WEBHOOK].includes(searchee.label) &&
+		(BAD_EP_REGEX.test(searchee.title) ||
+			BAD_SEASON_REGEX.test(searchee.title))
+	) {
+		logReason(
+			"it has a non-standard episode/season naming format",
+			searchee,
+			mediaType,
+		);
 		return false;
 	}
 


### PR DESCRIPTION
Titles such as `S01E02...` or `S03...` fails the episode and season regex since they do not start with a title. These fallback to the generic `VIDEO` mediaType since they usually have the right extensions.

These will no longer be searched, as we cannot properly determine the `mediaType`. There is also no reliable way to know what the title for these entries. Users can rename them in client if using `useClientTorrents: true` or rename the files if from `dataDirs` if they want to search these.

This only applies to `search` and `webhook`. `rss`, `announce`, and `inject` does not get filtered since they do not search.