### PR TITLE
enhancement(torrent_cache): save entries with mediaType and tracker

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -481,6 +481,7 @@ export async function performActionWithoutMutex(
 		searchee.label !== Label.INJECT ? logger.warn : logger.verbose;
 	const infoOrVerbose =
 		searchee.label !== Label.INJECT ? logger.info : logger.verbose;
+	const mediaType = getMediaType(newMeta);
 
 	if (action === Action.SAVE) {
 		logActionResult(
@@ -492,7 +493,7 @@ export async function performActionWithoutMutex(
 			infoOrVerbose,
 			warnOrVerbose,
 		);
-		await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+		await saveTorrentFile(newMeta, mediaType, tracker);
 		return { actionResult: SaveResult.SAVED };
 	}
 
@@ -525,7 +526,7 @@ export async function performActionWithoutMutex(
 					infoOrVerbose,
 					warnOrVerbose,
 				);
-				await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+				await saveTorrentFile(newMeta, mediaType, tracker);
 				return { client, actionResult, linkedNewFiles };
 			}
 			const actionResult = InjectionResult.FAILURE;
@@ -542,7 +543,7 @@ export async function performActionWithoutMutex(
 				infoOrVerbose,
 				warnOrVerbose,
 			);
-			await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+			await saveTorrentFile(newMeta, mediaType, tracker);
 			return { actionResult, linkedNewFiles };
 		}
 		savePath = savePathRes.unwrap();
@@ -577,7 +578,7 @@ export async function performActionWithoutMutex(
 			infoOrVerbose,
 			warnOrVerbose,
 		);
-		await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+		await saveTorrentFile(newMeta, mediaType, tracker);
 		return { actionResult, linkedNewFiles };
 	}
 	for (const otherClient of clients) {
@@ -648,7 +649,7 @@ export async function performActionWithoutMutex(
 				infoOrVerbose,
 				warnOrVerbose,
 			);
-			await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+			await saveTorrentFile(newMeta, mediaType, tracker);
 			return { actionResult, linkedNewFiles };
 		}
 		const linkResult = res.unwrap();
@@ -674,7 +675,7 @@ export async function performActionWithoutMutex(
 				infoOrVerbose,
 				warnOrVerbose,
 			);
-			await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+			await saveTorrentFile(newMeta, mediaType, tracker);
 			return { actionResult, linkedNewFiles };
 		}
 		destinationDir = savePath;
@@ -706,7 +707,7 @@ export async function performActionWithoutMutex(
 	if (actionResult === InjectionResult.SUCCESS) {
 		// cross-seed may need to process these with the inject job
 		if (shouldRecheck(newMeta, decision) || !searchee.infoHash) {
-			await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+			await saveTorrentFile(newMeta, mediaType, tracker);
 		}
 	} else if (actionResult === InjectionResult.ALREADY_EXISTS) {
 		if (linkedNewFiles) {
@@ -720,7 +721,7 @@ export async function performActionWithoutMutex(
 			});
 		}
 	} else {
-		await saveTorrentFile(tracker, getMediaType(newMeta), newMeta);
+		await saveTorrentFile(newMeta, mediaType, tracker);
 		if (unlinkOk && destinationDir) {
 			await unlinkMetafile(newMeta, destinationDir, searchee.label);
 			linkedNewFiles = false;

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -7,6 +7,7 @@ import { appDir } from "./configuration.js";
 import {
 	Action,
 	BlocklistType,
+	INFOHASH_REGEX,
 	LinkType,
 	MatchMode,
 	NEWLINE_INDENT,
@@ -279,7 +280,7 @@ function transformBlocklist(blockList: string[], ctx: RefinementCtx) {
 				}
 				break;
 			case BlocklistType.INFOHASH:
-				if (!/^[a-z0-9]{40}$/i.test(blocklistValue)) {
+				if (!INFOHASH_REGEX.test(blocklistValue)) {
 					addZodIssue(blockRaw, ZodErrorMessages.blocklistHash, ctx);
 				}
 				blockList[index] =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,8 +39,9 @@ export const SONARR_SUBFOLDERS_REGEX =
 	/^(?:S(?:eason )?(?<seasonNum>\d{1,4}))$/i;
 export const NON_UNICODE_ALPHANUM_REGEX = /[^\p{L}\p{N}]+/giu;
 export const CALIBRE_INDEXNUM_REGEX = /\s?\(\d+\)$/;
+export const INFOHASH_REGEX = /^[a-z0-9]{40}$/i;
 export const SAVED_TORRENTS_INFO_REGEX =
-	/^\[(?<mediaType>.+?)\]\[(?<tracker>.+?)\](?<name>.+?)(?:\[[^\]]*?\])?\.torrent$/i;
+	/^\[(?<mediaType>.+?)\]\[(?<tracker>.+?)\](?<name>.+?)(?:\[(?<infoHash>[a-z0-9]{40})\])?(?<cached>.cached)?\.torrent$/i;
 export const BAD_GROUP_PARSE_REGEX =
 	/^(?<badmatch>(?:dl|DDP?|aac|eac3|atmos|dts|ma|hd|[heav.c]{3.5}|[xh.]{1,2}[2456]|[0-9]+[ip]?|dxva|full|blu|ray|s(?:eason)?\W\d+|\W){3,})$/i;
 export const JSON_VALUES_REGEX = /".+?"\s*:\s*"(?<value>.+?)"\s*(?:,|})/g;
@@ -157,6 +158,7 @@ export const ALL_EXTENSIONS = [
 
 export const TORRENT_CACHE_FOLDER = "torrent_cache";
 export const UNKNOWN_TRACKER = "UnknownTracker";
+export const MAX_PATH_BYTES = 255;
 export const LEVENSHTEIN_DIVISOR = 3;
 
 export enum MediaType {
@@ -200,7 +202,7 @@ export enum Decision {
 	MAGNET_LINK = "MAGNET_LINK",
 	RATE_LIMITED = "RATE_LIMITED",
 	/**
-	 * Searchee and Candidate info hash matches. Usually happens with public
+	 * Searchee and Candidate infoHash matches. Usually happens with public
 	 * torrents and torrents added by radarr/sonarr before cross-seed on announces.
 	 * Useful for the inject job as we ignore INFO_HASH_ALREADY_EXISTS and
 	 * for reporting a 204 announce status code instead of 200 from exists.

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -48,6 +48,11 @@ class Job {
 			});
 			if (this.runAheadOfSchedule && this.name === JobName.SEARCH) {
 				await bulkSearch({ configOverride: this.configOverride });
+			} else if (
+				this.runAheadOfSchedule &&
+				this.name === JobName.CLEANUP
+			) {
+				await cleanupDB({ runAll: true });
 			} else {
 				await this.exec();
 			}
@@ -130,11 +135,6 @@ export async function checkJobs(
 
 				if (!job.runAheadOfSchedule) {
 					if (jobs.find((j) => j.name === JobName.RSS)?.isActive) {
-						continue;
-					}
-					if (
-						jobs.find((j) => j.name === JobName.CLEANUP)?.isActive
-					) {
 						continue;
 					}
 					if (job.name === JobName.CLEANUP) {


### PR DESCRIPTION
This means when a user runs `cross-seed restore` after losing their torrent data, the injected torrents will be linked to `linkDir/Tracker` instead of `linkDir/UnknownTracker` for all.

The format is now the same as the one used for `outputDir` exception with `.cached`, `[mediaType][tracker]name[infoHash].cached.torrent`. The `.cached` is keep when copying to `outputDir` so they can still be distinguished from regular outputDir` entries.

This change is only future facing, it will not modify existing entries in the cache unless it's seen again. Instead, when a user runs `cross-seed restore`, it uses the updated format for the new entries and applies `[tracker]` to them when copying based on the tracker hosts in the .torrent files. So if the users has at least one of the new format for each tracker, we should be able to rebuild the entire filename metadata for all torrents.

Before we were only saving the infoHash in the cache, which means all entries were the same size. But now since we are saving the name, we can run into max path length issues, so now for both `outputDir` and `torrent_cache`, it will truncate the .torrent title if the name is too long (`255 bytes` for total path). It's also now easier to find torrents in the cache since it has the name and tracker.

We will now also prune the `decision` table for invalid entries with the cleanup job. First we remove all entries with a `null` infoHash as we no longer save those. We also check each infoHash to see if it's still present in the torrent cache. This should ensure the number of unique infoHashes in the table is the same as the number of .torrent files in the cache.

Cleaning the decision table is rarely needed so it's done roughly once per month using `Math.random()`. If the `cleanup` job is triggered from `/api/job`, it will always be done.