### PR TITLE
Allow for ignoring the release group

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -84,6 +84,11 @@ function createCommandWithSharedOptions(name: string, description: string) {
 				.makeOptionMandatory(),
 		)
 		.option(
+			"--ignore-release-group",
+			"Don't consider the release group during matching",
+			fallback(fileConfig.ignoreReleaseGroup, false)
+		)
+		.option(
 			"--skip-recheck",
 			"Skip rechecking torrents before resuming, unless necessary.",
 			fallback(fileConfig.skipRecheck, true),

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -417,6 +417,7 @@ export const VALIDATION_SCHEMA = z
 			}),
 		injectDir: z.string().nullish(),
 		ignoreTitles: z.boolean().optional(),
+		ignoreReleaseGroup: z.boolean().optional(),
 		includeSingleEpisodes: z.boolean(),
 		includeNonVideos: z.boolean(),
 		fuzzySizeThreshold: z

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,7 @@ export interface FileConfig {
 	outputDir?: string;
 	injectDir?: string;
 	ignoreTitles?: boolean;
+	ignoreReleaseGroup?: boolean;
 	includeNonVideos?: boolean;
 	seasonFromEpisodes?: number;
 	fuzzySizeThreshold?: number;

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -323,7 +323,7 @@ export async function assessCandidate(
 	blockList: string[],
 	options?: { configOverride: Partial<RuntimeConfig> },
 ): Promise<ResultAssessment> {
-	const { includeSingleEpisodes, matchMode } = getRuntimeConfig(
+	const { includeSingleEpisodes, matchMode, ignoreReleaseGroup } = getRuntimeConfig(
 		options?.configOverride,
 	);
 
@@ -332,7 +332,7 @@ export async function assessCandidate(
 	const isCandidate = !(metaOrCandidate instanceof Metafile);
 	if (isCandidate) {
 		const name = metaOrCandidate.name;
-		if (!releaseGroupDoesMatch(searchee.title, name)) {
+		if (!ignoreReleaseGroup && !releaseGroupDoesMatch(searchee.title, name)) {
 			return { decision: Decision.RELEASE_GROUP_MISMATCH };
 		}
 		if (!resolutionDoesMatch(searchee.title, name)) {

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -18,6 +18,7 @@ export interface RuntimeConfig {
 	outputDir: string;
 	injectDir?: string;
 	ignoreTitles?: boolean;
+	ignoreReleaseGroup?: boolean;
 	includeSingleEpisodes: boolean;
 	verbose: boolean;
 	includeNonVideos: boolean;


### PR DESCRIPTION
Sometimes, the release group is actively changed by reuploaders moving files around.  Obviously, this makes matching much more difficult.  This is a quick hack to ignore release groups.

I couldn't figure out how to make the cache be ignored when this option is used; and I've thought of an alternate approach to this problem that I think I would like to try as well.  Submitting this PR in case this approach is preferred.