### PR TITLE
Allow users to filter out undesired words from titles

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -268,6 +268,12 @@ function createCommandWithSharedOptions(name: string, description: string) {
 			fallback(fileConfig.blockList, []),
 		)
 		.option(
+			"--title-filter-list <strings...>",
+			"Text which should be ignored if it appears in the torrent title (eg, tracker names)",
+			// @ts-expect-error commander supports non-string defaults
+			fallback(fileConfig.titleFilterList, []),
+		)
+		.option(
 			"--sonarr <urls...>",
 			"Sonarr API URL(s)",
 			// @ts-expect-error commander supports non-string defaults

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -387,4 +387,10 @@ module.exports = {
 	 * https://www.cross-seed.org/docs/basics/options#blocklist
 	 */
 	blockList: [],
+
+	/**
+	 * Remove these words/substrings from titles before searching.
+	 * Text in brackets is always removed
+	 */
+	titleFilterList: []
 };

--- a/src/configSchema.ts
+++ b/src/configSchema.ts
@@ -522,6 +522,7 @@ export const VALIDATION_SCHEMA = z
 		verbose: z.boolean(),
 		torrents: z.array(z.string()).optional(),
 		blockList: z.array(z.string()).nullish().transform(transformBlocklist),
+		titleFilterList: z.array(z.string()),
 		apiKey: z.string().min(24).nullish(),
 		radarr: z
 			.array(z.string().url())

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,6 +57,7 @@ export interface FileConfig {
 	searchTimeout?: string;
 	searchLimit?: number;
 	blockList?: string[];
+	titleFilterList?: string[];
 	apiKey?: string;
 	sonarr?: string[];
 	radarr?: string[];

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -38,6 +38,7 @@ export interface RuntimeConfig {
 	searchTimeout?: number;
 	searchLimit?: number;
 	blockList: string[];
+	titleFilterList: string[];
 	apiKey?: string;
 	sonarr: string[];
 	radarr: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,7 @@ import {
 import { logger } from "./logger.js";
 import { Result, resultOf, resultOfErr } from "./Result.js";
 import { File, getAllTitles, Searchee } from "./searchee.js";
+import { getRuntimeConfig } from "./runtimeConfig.js";
 
 // ================================== TYPES ==================================
 
@@ -330,6 +331,10 @@ export function cleanseSeparators(str: string): string {
 }
 
 export function cleanTitle(title: string): string {
+	const { titleFilterList } = getRuntimeConfig();
+	for(const toRemove of titleFilterList){
+		title = title.replace(toRemove,"");
+	}
 	return cleanseSeparators(title).match(SCENE_TITLE_REGEX)!.groups!.title;
 }
 


### PR DESCRIPTION
Sometimes a torrent title will include extra words (eg, "- Copy"), or the name of the tracker it is uploaded to.  Other examples include phrases like "epub/mobi" in book torrent titles, or made-up public tracker identities.  While this is obviously bad for uploaders to do, it is a pain to manually work around.

While it could be possible to expand the existing filtering, removing those extra words for all users, doing so risks bugs; for instance, blindly removing "epub" and "mobi" from all book titles would make "Republican mobility problems" into "Rlican lity problems".  Thus, this option lets users test out these changes on their own, and potentially report back with working changes.  If combined with an allowlist mode, users can experiment much more easily; but I'm not going to try and implement such an option.