### PR TITLE
enhancement(anime): support more anime title formats

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,9 @@ export const BAD_GROUP_PARSE_REGEX =
 export const JSON_VALUES_REGEX = /".+?"\s*:\s*"(?<value>.+?)"\s*(?:,|})/g;
 export const ABS_WIN_PATH_REGEX = /^[a-z]:|^\\/i;
 export const AKA_REGEX = /(?:[_.\s-]+|\b)a[_.\s-]?k[_.\s-]?a(?:[_.\s-]+|\b)/i;
+export const ALL_SPACES_REGEX = /\s+/g;
+export const ALL_SQUARE_BRACKETS_REGEX = /\[.*?\]|「.*?」|｢.*?｣|【.*?】/g;
+export const ALL_PARENTHESES_REGEX = /\(.*?\)/g;
 
 // Needs to be handled through helper functions since there are variations
 const SOURCE_REGEXES = {
@@ -161,6 +164,7 @@ export const LOGS_FOLDER = "logs";
 export const UNKNOWN_TRACKER = "UnknownTracker";
 export const MAX_PATH_BYTES = 255;
 export const LEVENSHTEIN_DIVISOR = 3;
+export const MIN_VIDEO_QUERY_LENGTH = 3;
 
 export enum MediaType {
 	EPISODE = "episode",

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -49,13 +49,13 @@ import {
 	getAnimeQueries,
 	getApikey,
 	getLogString,
+	getVideoQueries,
 	humanReadableDate,
 	isTruthy,
 	nMsAgo,
 	reformatTitleForSearching,
 	sanitizeUrl,
 	stripExtension,
-	stripMetaFromName,
 	wait,
 } from "./utils.js";
 
@@ -289,12 +289,10 @@ async function createTorznabSearchQueries(
 			q: animeQuery,
 		}));
 	} else if (mediaType === MediaType.VIDEO) {
-		return [
-			{
-				t: "search",
-				q: cleanTitle(stripMetaFromName(stem)),
-			},
-		] as const;
+		return getVideoQueries(stem).map((videoQuery) => ({
+			t: "search",
+			q: videoQuery,
+		}));
 	} else if (mediaType === MediaType.BOOK && searchee.path) {
 		return [
 			{


### PR DESCRIPTION
Anime that fails `MediaType.ANIME` often contains `[group] Title (Extra Info)`. These don't make sense to add to `ANIME_REGEX` and it's also much easier to simply strip the extra info and send as another query like we are doing for alternate titles. This will only affect items that fail `EPISODE`, `SEASON`, `MOVIE`, and `ANIME`, so parsed as `VIDEO`.

Edit: No longer sending as extra query as the stripped search seems to always be better for `VIDEO`.