### PR TITLE
fix(torznab/search): fallback to raw query if parsing fails

### DIFF
--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -243,10 +243,15 @@ async function createTorznabSearchQueries(
 	if (mediaType === MediaType.EPISODE && caps.tvSearch) {
 		const match = stem.match(EP_REGEX);
 		const groups = match!.groups!;
+		let query: string | undefined;
+		if (!useIds) {
+			query = reformatTitleForSearching(stem);
+			if (!query.length) query = stem;
+		}
 		return [
 			{
 				t: "tvsearch",
-				q: useIds ? undefined : reformatTitleForSearching(stem),
+				q: query,
 				season: groups.season ? extractInt(groups.season) : groups.year,
 				ep: groups.episode
 					? extractInt(groups.episode)
@@ -257,19 +262,29 @@ async function createTorznabSearchQueries(
 	} else if (mediaType === MediaType.SEASON && caps.tvSearch) {
 		const match = stem.match(SEASON_REGEX);
 		const groups = match!.groups!;
+		let query: string | undefined;
+		if (!useIds) {
+			query = reformatTitleForSearching(stem);
+			if (!query.length) query = stem;
+		}
 		return [
 			{
 				t: "tvsearch",
-				q: useIds ? undefined : reformatTitleForSearching(stem),
+				q: query,
 				season: extractInt(groups.season),
 				...relevantIds,
 			},
 		] as const;
 	} else if (mediaType === MediaType.MOVIE && caps.movieSearch) {
+		let query: string | undefined;
+		if (!useIds) {
+			query = reformatTitleForSearching(stem);
+			if (!query.length) query = stem;
+		}
 		return [
 			{
 				t: "movie",
-				q: useIds ? undefined : reformatTitleForSearching(stem),
+				q: query,
 				...relevantIds,
 			},
 		] as const;
@@ -294,17 +309,19 @@ async function createTorznabSearchQueries(
 			q: videoQuery,
 		}));
 	} else if (mediaType === MediaType.BOOK && searchee.path) {
+		const query = cleanTitle(stem.replace(CALIBRE_INDEXNUM_REGEX, ""));
 		return [
 			{
 				t: "search",
-				q: cleanTitle(stem.replace(CALIBRE_INDEXNUM_REGEX, "")),
+				q: query.length ? query : stem,
 			},
 		] as const;
 	}
+	const query = cleanTitle(stem);
 	return [
 		{
 			t: "search",
-			q: cleanTitle(stem),
+			q: query.length ? query : stem,
 		},
 	] as const;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,11 +377,17 @@ export function getAnimeQueries(stem: string): string[] {
 	const animeQueries: string[] = [];
 	const { title, altTitle, release } = stem.match(ANIME_REGEX)?.groups ?? {};
 	if (title) {
-		animeQueries.push(cleanTitle(`${title} ${release}`));
+		const strippedTitle = cleanTitle(title);
+		animeQueries.push(
+			`${strippedTitle.length ? strippedTitle : title} ${release}`,
+		);
 	}
 	if (altTitle) {
 		if (isBadTitle(altTitle)) return animeQueries;
-		animeQueries.push(cleanTitle(`${altTitle} ${release}`));
+		const strippedAltTitle = cleanTitle(altTitle);
+		animeQueries.push(
+			`${strippedAltTitle.length ? strippedAltTitle : altTitle} ${release}`,
+		);
 	}
 	return animeQueries;
 }
@@ -394,6 +400,10 @@ export function getAnimeQueries(stem: string): string[] {
  */
 export function getVideoQueries(stem: string): string[] {
 	const videoQueries: string[] = [cleanTitle(stripMetaFromName(stem))];
+	if (!videoQueries[0].length) {
+		videoQueries[0] = stripMetaFromName(stem);
+		if (!videoQueries[0].length) videoQueries[0] = stem;
+	}
 	const noParentheses = cleanTitle(
 		stripMetaFromName(
 			stem


### PR DESCRIPTION
This should prevent empty torznab queries if we can't parse the title properly.