### PR TITLE
refactor: modularize path and linking problem providers

### DIFF
--- a/src/problems.ts
+++ b/src/problems.ts
@@ -4,7 +4,8 @@ import {
 	collectClientProblems,
 } from "./clients/TorrentClient.js";
 import { collectIndexerProblems } from "./indexers.js";
-import { collectPathProblems } from "./startup.js";
+import { collectLinkingProblems } from "./problems/linking.js";
+import { collectPathProblems } from "./problems/path.js";
 import { collectRecommendationProblems } from "./runtimeConfig.js";
 import { collectSearcheeProblems } from "./searchee.js";
 
@@ -34,7 +35,8 @@ const registeredProblemProviders: RegisteredProblemProvider[] = [
 	{ id: "clients", provider: collectClientProblems },
 	{ id: "client-linking", provider: collectClientLinkingProblems },
 	{ id: "arr", provider: collectArrProblems },
-	{ id: "paths", provider: collectPathProblems },
+        { id: "paths", provider: collectPathProblems },
+        { id: "linking", provider: collectLinkingProblems },
 	{ id: "searchees", provider: collectSearcheeProblems },
 	{ id: "recommendations", provider: collectRecommendationProblems },
 ];

--- a/src/problems/linking.ts
+++ b/src/problems/linking.ts
@@ -1,0 +1,112 @@
+import { stat } from "fs/promises";
+
+import { testLinking } from "../action.js";
+import { Label, logger } from "../logger.js";
+import type { Problem } from "../problems.js";
+import { getRuntimeConfig } from "../runtimeConfig.js";
+import {
+        buildPathProblem,
+        diagnoseDirForProblems,
+        PathProblemDescriptor,
+} from "./path.js";
+
+async function collectLinkingProblemDescriptors(
+        linkDirs: string[],
+        dataDirs: string[],
+): Promise<PathProblemDescriptor[]> {
+        const problems: PathProblemDescriptor[] = [];
+        if (!linkDirs.length || !dataDirs.length) return problems;
+
+        const linkDirStats = await Promise.all(
+                linkDirs.map(async (dir, index) => {
+                        const descriptor = await diagnoseDirForProblems(
+                                dir,
+                                `linkDir${index}`,
+                                "linkDirs",
+                                { read: true, write: true },
+                        );
+                        return {
+                                path: dir,
+                                problem: descriptor,
+                                dev: descriptor ? null : (await stat(dir)).dev,
+                        };
+                }),
+        );
+
+        for (const { problem } of linkDirStats) {
+                if (problem) problems.push(problem);
+        }
+
+        const validLinkDirs = linkDirStats
+                .filter(({ problem }) => problem === null)
+                .map(({ path, dev }) => ({ path, dev }));
+
+        if (!validLinkDirs.length) return problems;
+
+        for (const [index, dataDir] of dataDirs.entries()) {
+                const descriptor = await diagnoseDirForProblems(
+                        dataDir,
+                        `dataDir${index}`,
+                        "dataDirs",
+                        { read: true },
+                );
+                if (descriptor) {
+                        problems.push(descriptor);
+                        continue;
+                }
+
+                try {
+                        const dataDev = (await stat(dataDir)).dev;
+                        const matchingLinkDir = validLinkDirs.find(
+                                (linkDir) => linkDir.dev === dataDev,
+                        );
+                        if (!matchingLinkDir) {
+                                problems.push({
+                                        category: "linkDirs",
+                                        name: "linkDir",
+                                        path: validLinkDirs.map((dir) => dir.path).join(", "),
+                                        issue: "cross-platform-linking",
+                                        message:
+                                                "No linkDir shares a filesystem with this dataDir, so linking will fail. Add a linkDir on the same device.",
+                                        severity: "error",
+                                });
+                                continue;
+                        }
+
+                        const result = await testLinking(
+                                dataDir,
+                                `healthCheckSrc.cross-seed`,
+                                `healthCheckDest.cross-seed`,
+                        );
+                        if (!result) {
+                                problems.push({
+                                        category: "linkDirs",
+                                        name: "linkDir",
+                                        path: matchingLinkDir.path,
+                                        issue: "linking-failed",
+                                        message:
+                                                "Linking test failed. Check filesystem permissions and mounts.",
+                                        severity: "warning",
+                                });
+                        }
+                } catch (error) {
+                        logger.debug({ label: Label.INJECT, message: error });
+                        problems.push({
+                                category: "linkDirs",
+                                name: "linkDir",
+                                path: dataDir,
+                                issue: "linking-failed",
+                                message: "Linking test threw an error. See logs for details.",
+                                severity: "error",
+                        });
+                }
+        }
+
+        return problems;
+}
+
+export async function collectLinkingProblems(): Promise<Problem[]> {
+        const { linkDirs, dataDirs } = getRuntimeConfig();
+        const descriptors = await collectLinkingProblemDescriptors(linkDirs ?? [], dataDirs ?? []);
+        return descriptors.map(buildPathProblem);
+}

--- a/src/problems/path.ts
+++ b/src/problems/path.ts
@@ -1,0 +1,116 @@
+import { constants, stat } from "fs/promises";
+
+import type { Problem } from "../problems.js";
+import { getRuntimeConfig } from "../runtimeConfig.js";
+import { verifyDir } from "../utils.js";
+
+export type PathIssue =
+        | "missing"
+        | "unreadable"
+        | "unwritable"
+        | "cross-platform-linking"
+        | "linking-failed";
+
+export type PathProblemCategory =
+        | "torrentDir"
+        | "outputDir"
+        | "injectDir"
+        | "linkDirs"
+        | "dataDirs";
+
+export interface PathProblemDescriptor {
+        category: PathProblemCategory;
+        name: string;
+        path: string;
+        issue: PathIssue;
+        message: string;
+        severity: Problem["severity"];
+}
+
+export function buildPathProblem(descriptor: PathProblemDescriptor): Problem {
+        const { category, name, path, issue, message, severity } = descriptor;
+        return {
+                id: `path:${category}:${issue}:${path}`,
+                severity,
+                summary: `${name}: ${message}`,
+                details: `Path: ${path}`,
+                metadata: { category, path, issue },
+        };
+}
+
+export async function diagnoseDirForProblems(
+        path: string,
+        name: string,
+        category: PathProblemCategory,
+        options: { read?: boolean; write?: boolean },
+): Promise<PathProblemDescriptor | null> {
+        const mode =
+                (options.read ? constants.R_OK : 0) |
+                (options.write ? constants.W_OK : 0);
+        const exists = await verifyDir(path, name, mode);
+
+        if (exists) return null;
+
+        try {
+                await stat(path);
+        } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                        return {
+                                category,
+                                name,
+                                path,
+                                issue: "missing",
+                                message: "Directory does not exist.",
+                                severity: "error",
+                        };
+                }
+        }
+
+        return {
+                category,
+                name,
+                path,
+                issue: options.write ? "unwritable" : "unreadable",
+                message: options.write
+                        ? "cross-seed cannot write to this directory."
+                        : "cross-seed cannot read from this directory.",
+                severity: "error",
+        };
+}
+
+export async function collectPathProblems(): Promise<Problem[]> {
+        const { torrentDir, outputDir, injectDir } = getRuntimeConfig();
+        const descriptors: PathProblemDescriptor[] = [];
+
+        if (torrentDir) {
+                const descriptor = await diagnoseDirForProblems(
+                        torrentDir,
+                        "torrentDir",
+                        "torrentDir",
+                        { read: true },
+                );
+                if (descriptor) descriptors.push(descriptor);
+        }
+
+        if (outputDir) {
+                const descriptor = await diagnoseDirForProblems(
+                        outputDir,
+                        "outputDir",
+                        "outputDir",
+                        { read: true, write: true },
+                );
+                if (descriptor) descriptors.push(descriptor);
+        }
+
+        if (injectDir) {
+                const descriptor = await diagnoseDirForProblems(
+                        injectDir,
+                        "injectDir",
+                        "injectDir",
+                        { read: true, write: true },
+                );
+                if (descriptor) descriptors.push(descriptor);
+        }
+
+        return descriptors.map(buildPathProblem);
+}

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,6 +1,5 @@
-import { constants, mkdir, stat } from "fs/promises";
+import { mkdir } from "fs/promises";
 import { spawn } from "node:child_process";
-import { testLinking } from "./action.js";
 import { resetApiKey } from "./auth.js";
 import { instantiateDownloadClients } from "./clients/TorrentClient.js";
 import {
@@ -18,14 +17,13 @@ import {
 	Label,
 	logger,
 } from "./logger.js";
-import type { Problem } from "./problems.js";
 import { initializePushNotifier } from "./pushNotifier.js";
 import {
-	getRuntimeConfig,
-	RuntimeConfig,
-	setRuntimeConfig,
+        getRuntimeConfig,
+        RuntimeConfig,
+        setRuntimeConfig,
 } from "./runtimeConfig.js";
-import { Awaitable, notExists, verifyDir } from "./utils.js";
+import { Awaitable, notExists } from "./utils.js";
 import { getLogWatcher } from "./utils/logWatcher.js";
 import { omitUndefined } from "./utils/object.js";
 
@@ -38,8 +36,8 @@ process.on("SIGINT", exitGracefully);
 process.on("SIGTERM", exitGracefully);
 
 async function ensureConfiguredDirectories(): Promise<void> {
-	const { outputDir, linkDirs = [] } = getRuntimeConfig();
-	const directories: { path: string; label: string }[] = [];
+        const { outputDir, linkDirs = [] } = getRuntimeConfig();
+        const directories: { path: string; label: string }[] = [];
 
 	if (outputDir) {
 		directories.push({ path: outputDir, label: "outputDir" });
@@ -62,226 +60,12 @@ async function ensureConfiguredDirectories(): Promise<void> {
 				label: Label.SERVER,
 				message: `Failed to create ${label} at ${path}: ${message}`,
 			});
-		}
-	}
 }
-
-type PathIssue =
-	| "missing"
-	| "unreadable"
-	| "unwritable"
-	| "cross-platform-linking"
-	| "linking-failed";
-
-interface PathProblemDescriptor {
-	category:
-		| "torrentDir"
-		| "outputDir"
-		| "injectDir"
-		| "linkDirs"
-		| "dataDirs";
-	name: string;
-	path: string;
-	issue: PathIssue;
-	message: string;
-	severity: Problem["severity"];
-}
-
-function buildPathProblem(descriptor: PathProblemDescriptor): Problem {
-	const { category, name, path, issue, message, severity } = descriptor;
-	return {
-		id: `path:${category}:${issue}:${path}`,
-		severity,
-		summary: `${name}: ${message}`,
-		details: `Path: ${path}`,
-		metadata: { category, path, issue },
-	};
-}
-
-async function diagnoseDirForProblems(
-	path: string,
-	name: string,
-	category: PathProblemDescriptor["category"],
-	options: { read?: boolean; write?: boolean },
-): Promise<PathProblemDescriptor | null> {
-	const mode =
-		(options.read ? constants.R_OK : 0) |
-		(options.write ? constants.W_OK : 0);
-	const exists = await verifyDir(path, name, mode);
-
-	if (exists) return null;
-
-	try {
-		await stat(path);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return {
-				category,
-				name,
-				path,
-				issue: "missing",
-				message: "Directory does not exist.",
-				severity: "error",
-			};
-		}
-	}
-
-	return {
-		category,
-		name,
-		path,
-		issue: options.write ? "unwritable" : "unreadable",
-		message: options.write
-			? "cross-seed cannot write to this directory."
-			: "cross-seed cannot read from this directory.",
-		severity: "error",
-	};
-}
-
-async function collectLinkingProblems(
-	linkDirs: string[],
-	dataDirs: string[],
-): Promise<PathProblemDescriptor[]> {
-	const problems: PathProblemDescriptor[] = [];
-	if (!linkDirs.length || !dataDirs.length) return problems;
-
-	const linkDirStats = await Promise.all(
-		linkDirs.map(async (dir, index) => {
-			const descriptor = await diagnoseDirForProblems(
-				dir,
-				`linkDir${index}`,
-				"linkDirs",
-				{ read: true, write: true },
-			);
-			return {
-				path: dir,
-				problem: descriptor,
-				dev: descriptor ? null : (await stat(dir)).dev,
-			};
-		}),
-	);
-
-	for (const { problem } of linkDirStats) {
-		if (problem) problems.push(problem);
-	}
-
-	const validLinkDirs = linkDirStats
-		.filter(({ problem }) => problem === null)
-		.map(({ path, dev }) => ({ path, dev }));
-
-	if (!validLinkDirs.length) return problems;
-
-	for (const [index, dataDir] of dataDirs.entries()) {
-		const descriptor = await diagnoseDirForProblems(
-			dataDir,
-			`dataDir${index}`,
-			"dataDirs",
-			{ read: true },
-		);
-		if (descriptor) {
-			problems.push(descriptor);
-			continue;
-		}
-
-		try {
-			const dataDev = (await stat(dataDir)).dev;
-			const matchingLinkDir = validLinkDirs.find(
-				(linkDir) => linkDir.dev === dataDev,
-			);
-			if (!matchingLinkDir) {
-				problems.push({
-					category: "linkDirs",
-					name: "linkDir",
-					path: validLinkDirs.map((dir) => dir.path).join(", "),
-					issue: "cross-platform-linking",
-					message:
-						"No linkDir shares a filesystem with this dataDir, so linking will fail. Add a linkDir on the same device.",
-					severity: "error",
-				});
-				continue;
-			}
-
-			const result = await testLinking(
-				dataDir,
-				`healthCheckSrc.cross-seed`,
-				`healthCheckDest.cross-seed`,
-			);
-			if (!result) {
-				problems.push({
-					category: "linkDirs",
-					name: "linkDir",
-					path: matchingLinkDir.path,
-					issue: "linking-failed",
-					message:
-						"Linking test failed. Check filesystem permissions and mounts.",
-					severity: "warning",
-				});
-			}
-		} catch (error) {
-			logger.debug({ label: Label.INJECT, message: error });
-			problems.push({
-				category: "linkDirs",
-				name: "linkDir",
-				path: dataDir,
-				issue: "linking-failed",
-				message: "Linking test threw an error. See logs for details.",
-				severity: "error",
-			});
-		}
-	}
-
-	return problems;
-}
-
-export async function collectPathProblems(): Promise<Problem[]> {
-	const { torrentDir, outputDir, injectDir, linkDirs, dataDirs } =
-		getRuntimeConfig();
-	const problems: Problem[] = [];
-
-	if (torrentDir) {
-		const descriptor = await diagnoseDirForProblems(
-			torrentDir,
-			"torrentDir",
-			"torrentDir",
-			{ read: true },
-		);
-		if (descriptor) problems.push(buildPathProblem(descriptor));
-	}
-
-	if (outputDir) {
-		const descriptor = await diagnoseDirForProblems(
-			outputDir,
-			"outputDir",
-			"outputDir",
-			{ read: true, write: true },
-		);
-		if (descriptor) problems.push(buildPathProblem(descriptor));
-	}
-
-	if (injectDir) {
-		const descriptor = await diagnoseDirForProblems(
-			injectDir,
-			"injectDir",
-			"injectDir",
-			{ read: true, write: true },
-		);
-		if (descriptor) problems.push(buildPathProblem(descriptor));
-	}
-
-	const linkProblems = await collectLinkingProblems(
-		linkDirs ?? [],
-		dataDirs ?? [],
-	);
-	for (const descriptor of linkProblems) {
-		problems.push(buildPathProblem(descriptor));
-	}
-
-	return problems;
 }
 
 export async function doStartupValidation(): Promise<void> {
-	await ensureConfiguredDirectories();
-	instantiateDownloadClients();
+        await ensureConfiguredDirectories();
+        instantiateDownloadClients();
 }
 
 /**


### PR DESCRIPTION
## Summary
- move shared path diagnostic helpers into a dedicated module
- isolate the linking problem provider into its own module that reuses those helpers
- update the problem registry to reference the new provider modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69005ab66344832786af5b8519055fc1