### PR TITLE
fix: declare zod in shared package to fix settings save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11987,7 +11987,19 @@
 		},
 		"packages/shared": {
 			"name": "@cross-seed/shared",
-			"version": "0.0.0"
+			"version": "0.0.0",
+			"dependencies": {
+				"zod": "^4.3.6"
+			}
+		},
+		"packages/shared/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
 		},
 		"packages/webui": {
 			"version": "0.0.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,5 +20,8 @@
 	],
 	"scripts": {
 		"build": "tsc -p tsconfig.json"
+	},
+	"dependencies": {
+		"zod": "^4.3.6"
 	}
 }


### PR DESCRIPTION
## Summary

Trying to save any `/settings/*` page in the WebUI did nothing. Console showed:

- `Invalid element at key "<field>": expected a Zod schema`
- `async function passed to sync validator`


## Bug

`webui` and `cross-seed` were bumped to zod v4 in 82ed578, but `packages/shared` has no zod in its own `package.json`. So at install time `shared` ends up using the zod v3 from top-level `node_modules`, while `webui` and `cross-seed` get their own v4 copies. Schemas coming out of `shared` are then v3 objects, and v4 rejects them when the WebUI tries to wrap them into a `z.object(...)`.


## Fix

I've added `"zod": "^4.3.6"` to `packages/shared/package.json` so all three packages are on the same zod.


## LLM disclosure

*Developed with assistance from Claude Code (Opus 4.7). The LLM helped me identify the related files & code parts.*
*I've manually reviewed the code.*