### PR TITLE
fix: tracker import

### DIFF
--- a/packages/cross-seed/src/dbConfig.ts
+++ b/packages/cross-seed/src/dbConfig.ts
@@ -6,6 +6,7 @@ import {
 	parseRuntimeConfig,
 	parseRuntimeConfigOverrides,
 } from "./configSchema.js";
+import { createIndexer } from "./services/indexerService.js";
 
 export async function getDbConfig(): Promise<
 	Partial<RuntimeConfig> | undefined
@@ -38,6 +39,26 @@ export async function setDbConfig(
 				apikey: null,
 				settings_json: JSON.stringify(overrides),
 			});
+		}
+		// Also add any torznab links to indexers table
+		if (validatedConfig.torznab && Array.isArray(validatedConfig.torznab)) {
+			for (const tracker of validatedConfig.torznab) {
+				const baseUrl = new URL(tracker);
+				const url = `${baseUrl.origin}${baseUrl.pathname}`;
+				const apiKey = new URLSearchParams(baseUrl.searchParams).get(
+					"apikey",
+				);
+				const existingIndexer = await trx("indexer").where({
+					url: url,
+				});
+				if (existingIndexer.length === 0) {
+					await createIndexer({
+						url,
+						apikey: apiKey ?? "",
+						enabled: true,
+					});
+				}
+			}
 		}
 	});
 }

--- a/packages/cross-seed/src/dbConfig.ts
+++ b/packages/cross-seed/src/dbConfig.ts
@@ -28,6 +28,7 @@ export async function setDbConfig(
 	};
 	const validatedConfig = parseRuntimeConfig(mergedConfig);
 	const overrides = stripDefaults(validatedConfig);
+	const indexersToAdd: { url: string; apikey: string }[] = [];
 	await db.transaction(async (trx) => {
 		const existingRow = await trx("settings").first();
 		if (existingRow) {
@@ -52,15 +53,22 @@ export async function setDbConfig(
 					url: url,
 				});
 				if (existingIndexer.length === 0) {
-					await createIndexer({
+					indexersToAdd.push({
 						url,
 						apikey: apiKey ?? "",
-						enabled: true,
 					});
 				}
 			}
 		}
 	});
+
+	for (const tracker of indexersToAdd) {
+		await createIndexer({
+			url: tracker.url,
+			apikey: tracker.apikey ?? "",
+			enabled: true,
+		});
+	}
 }
 
 export async function updateDbConfig(


### PR DESCRIPTION
Updates `dbConfig` to check if trackers from the `config.js` file exist in the db. If not, they are added to the indexer table. Only works on initial install (clean db), for now. If the install is already using the webui, trackers should be added with that instead of the `config.js`. Does not work with config files using functions to list out the torznab URLs.