### PR TITLE
fix(webhook): move advanced-toggle state into form data | show/hide advanced section immediately

### DIFF
--- a/packages/webui/src/lib/formatConfigData.ts
+++ b/packages/webui/src/lib/formatConfigData.ts
@@ -4,23 +4,12 @@ import {
   WebhookObjectSchema,
 } from '../../../shared/configSchema';
 
-let webhookIdCounter = 0;
-
-/**
- * Generates a stable, unique id for a webhook form row. Used as the React key
- * and as the key for per-row UI state so it survives add/remove reordering.
- * A counter is used rather than `crypto.randomUUID()` because the WebUI may be
- * served from a non-secure context (LAN IP over HTTP) where it is unavailable.
- */
-export function nextWebhookId(): string {
-  webhookIdCounter += 1;
-  return `webhook-${webhookIdCounter}`;
-}
-
 /**
  * Transforms API config data for the WebUI form. Webhook entries are normalized
- * to the form's `{ id, url, payload, headers }` shape, with payload/headers
- * serialized back to JSON text for editing in the textareas.
+ * to the form's `{ url, payload, headers, advancedOpen }` shape, with
+ * payload/headers serialized back to JSON text for editing in the textareas.
+ * `advancedOpen` is seeded from whether the saved entry has any custom
+ * headers/payload, so saved-with-data webhooks render expanded.
  */
 export function formatConfigDataForForm(config: RuntimeConfig) {
   return {
@@ -29,26 +18,28 @@ export function formatConfigDataForForm(config: RuntimeConfig) {
       notificationWebhookUrls: config.notificationWebhookUrls.map(
         (e: WebhookEntry) => {
           if (typeof e === 'string') {
-            return { id: nextWebhookId(), url: e, payload: '', headers: '' };
+            return { url: e, payload: '', headers: '', advancedOpen: false };
           }
           const parsed = WebhookObjectSchema.safeParse(e);
           if (parsed.success) {
+            const payload = parsed.data.payload
+              ? JSON.stringify(parsed.data.payload)
+              : '';
+            const headers = parsed.data.headers
+              ? JSON.stringify(parsed.data.headers)
+              : '';
             return {
-              id: nextWebhookId(),
               url: parsed.data.url,
-              payload: parsed.data.payload
-                ? JSON.stringify(parsed.data.payload)
-                : '',
-              headers: parsed.data.headers
-                ? JSON.stringify(parsed.data.headers)
-                : '',
+              payload,
+              headers,
+              advancedOpen: Boolean(payload) || Boolean(headers),
             };
           }
           return {
-            id: nextWebhookId(),
             url: '',
             payload: '',
             headers: '',
+            advancedOpen: false,
           };
         },
       ),

--- a/packages/webui/src/routes/settings/connect.tsx
+++ b/packages/webui/src/routes/settings/connect.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Loader2, TestTube } from 'lucide-react';
 import { FieldInfo } from '@/components/Form/FieldInfo';
@@ -15,7 +15,7 @@ import { defaultConnectFormValues } from '@/components/Form/shared-form';
 import { useAppForm } from '@/hooks/form';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc';
-import { formatConfigDataForForm, nextWebhookId } from '@/lib/formatConfigData';
+import { formatConfigDataForForm } from '@/lib/formatConfigData';
 import { connectValidationSchema } from '@/types/config';
 import { FormValidationProvider } from '@/contexts/Form/form-validation-provider';
 import { pickSchemaFields } from '@/lib/pick-schema-fields';
@@ -26,10 +26,10 @@ import { RuntimeConfig, WebhookEntry } from '../../../../shared/configSchema';
 type ConnectFormData = z.infer<typeof connectValidationSchema>;
 
 type WebhookFormEntry = {
-  id: string;
   url: string;
   payload: string;
   headers: string;
+  advancedOpen: boolean;
 };
 
 function transformWebhooksForApi(entries: WebhookFormEntry[]): WebhookEntry[] {
@@ -62,22 +62,20 @@ function ConnectSettings() {
   const { isFieldRequired } = useConfigForm(connectValidationSchema);
 
   const trpc = useTRPC();
+  const selectConfig = useCallback(
+    (data: {
+      config: RuntimeConfig;
+      apiKey: string;
+    }): Partial<ConnectFormData> => {
+      const fullDataset = formatConfigDataForForm(data.config);
+      return pickSchemaFields(connectValidationSchema, fullDataset, {
+        includeUndefined: true,
+      });
+    },
+    [],
+  );
   const { data: configData } = useQuery(
-    trpc.settings.get.queryOptions(undefined, {
-      select: (data: {
-        config: RuntimeConfig;
-        apiKey: string;
-      }): Partial<ConnectFormData> => {
-        const fullDataset = formatConfigDataForForm(data.config);
-        const filteredData = pickSchemaFields(
-          connectValidationSchema,
-          fullDataset,
-          { includeUndefined: true },
-        );
-
-        return filteredData;
-      },
-    }),
+    trpc.settings.get.queryOptions(undefined, { select: selectConfig }),
   );
 
   const baseHandleSubmit = useSettingsFormSubmit();
@@ -129,20 +127,6 @@ function ConnectSettings() {
     }),
   );
 
-  const [advancedOpen, setAdvancedOpen] = useState<Set<string>>(new Set());
-  // Seed the expanded-advanced state once, from webhooks that load with
-  // custom headers/payload, so they render expanded without coupling the
-  // toggle's open/closed state to whether data is present.
-  const seededAdvancedRef = useRef(false);
-  useEffect(() => {
-    if (seededAdvancedRef.current || !configData) return;
-    seededAdvancedRef.current = true;
-    const entries = (configData.notificationWebhookUrls ??
-      []) as WebhookFormEntry[];
-    setAdvancedOpen(
-      new Set(entries.filter((e) => e.headers || e.payload).map((e) => e.id)),
-    );
-  }, [configData]);
   const [lastFieldAdded, setLastFieldAdded] = useState<string | null>(null);
   useEffect(() => {
     if (lastFieldAdded) {
@@ -355,7 +339,7 @@ function ConnectSettings() {
                           {field.state.value?.map(
                             (entry: WebhookFormEntry, index: number) => (
                               <fieldset
-                                key={entry.id}
+                                key={index}
                                 className="border-border space-y-2 rounded-md border p-3"
                               >
                                 <div className="flex items-center gap-2">
@@ -400,21 +384,19 @@ function ConnectSettings() {
                                   )}
                                 </form.Subscribe>
                                 <div className="mt-1 flex items-center gap-2">
-                                  <Switch
-                                    id={`notificationWebhookUrls-${index}-advanced`}
-                                    checked={advancedOpen.has(entry.id)}
-                                    onCheckedChange={(checked) => {
-                                      setAdvancedOpen((prev) => {
-                                        const next = new Set(prev);
-                                        if (checked) {
-                                          next.add(entry.id);
-                                        } else {
-                                          next.delete(entry.id);
+                                  <form.Field
+                                    name={`notificationWebhookUrls[${index}].advancedOpen`}
+                                  >
+                                    {(subfield) => (
+                                      <Switch
+                                        id={`notificationWebhookUrls-${index}-advanced`}
+                                        checked={subfield.state.value}
+                                        onCheckedChange={(checked) =>
+                                          subfield.handleChange(checked)
                                         }
-                                        return next;
-                                      });
-                                    }}
-                                  />
+                                      />
+                                    )}
+                                  </form.Field>
                                   <Label
                                     htmlFor={`notificationWebhookUrls-${index}-advanced`}
                                     className="text-muted-foreground text-xs"
@@ -422,7 +404,7 @@ function ConnectSettings() {
                                     Custom headers & payload
                                   </Label>
                                 </div>
-                                {advancedOpen.has(entry.id) && (
+                                {entry.advancedOpen && (
                                   <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div>
                                       <Label className="text-muted-foreground text-xs">
@@ -505,10 +487,10 @@ function ConnectSettings() {
                               type="button"
                               onClick={() => {
                                 field.pushValue({
-                                  id: nextWebhookId(),
                                   url: '',
                                   payload: '',
                                   headers: '',
+                                  advancedOpen: false,
                                 });
                                 setLastFieldAdded(
                                   `notificationWebhookUrls-${field.state.value?.length ?? 0}-url`,

--- a/packages/webui/src/routes/settings/connect.tsx
+++ b/packages/webui/src/routes/settings/connect.tsx
@@ -337,7 +337,7 @@ function ConnectSettings() {
                             )}
                           </Label>
                           {field.state.value?.map(
-                            (entry: WebhookFormEntry, index: number) => (
+                            (_: WebhookFormEntry, index: number) => (
                               <fieldset
                                 key={index}
                                 className="border-border space-y-2 rounded-md border p-3"
@@ -404,80 +404,95 @@ function ConnectSettings() {
                                     Custom headers & payload
                                   </Label>
                                 </div>
-                                {entry.advancedOpen && (
-                                  <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                                    <div>
-                                      <Label className="text-muted-foreground text-xs">
-                                        Headers (JSON)
-                                      </Label>
-                                      <form.Field
-                                        name={`notificationWebhookUrls[${index}].headers`}
-                                      >
-                                        {(subfield) => (
-                                          <Textarea
-                                            name={subfield.name}
-                                            value={subfield.state.value}
-                                            onChange={(e) =>
-                                              subfield.handleChange(
-                                                e.target.value,
-                                              )
+                                <form.Subscribe
+                                  selector={(s) =>
+                                    (
+                                      s.values
+                                        .notificationWebhookUrls as WebhookFormEntry[]
+                                    )?.[index]?.advancedOpen
+                                  }
+                                >
+                                  {(isOpen) =>
+                                    isOpen ? (
+                                      <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                        <div>
+                                          <Label className="text-muted-foreground text-xs">
+                                            Headers (JSON)
+                                          </Label>
+                                          <form.Field
+                                            name={`notificationWebhookUrls[${index}].headers`}
+                                          >
+                                            {(subfield) => (
+                                              <Textarea
+                                                name={subfield.name}
+                                                value={subfield.state.value}
+                                                onChange={(e) =>
+                                                  subfield.handleChange(
+                                                    e.target.value,
+                                                  )
+                                                }
+                                                onBlur={subfield.handleBlur}
+                                                placeholder='{"Authorization": "Bearer token"}'
+                                                rows={2}
+                                                className="resize-y font-mono text-xs"
+                                              />
+                                            )}
+                                          </form.Field>
+                                          <form.Subscribe
+                                            selector={(f) =>
+                                              f.fieldMeta[
+                                                `notificationWebhookUrls[${index}].headers` as keyof typeof f.fieldMeta
+                                              ]
                                             }
-                                            onBlur={subfield.handleBlur}
-                                            placeholder='{"Authorization": "Bearer token"}'
-                                            rows={2}
-                                            className="resize-y font-mono text-xs"
-                                          />
-                                        )}
-                                      </form.Field>
-                                      <form.Subscribe
-                                        selector={(f) =>
-                                          f.fieldMeta[
-                                            `notificationWebhookUrls[${index}].headers` as keyof typeof f.fieldMeta
-                                          ]
-                                        }
-                                      >
-                                        {(fieldMeta) => (
-                                          <FieldInfo fieldMeta={fieldMeta} />
-                                        )}
-                                      </form.Subscribe>
-                                    </div>
-                                    <div>
-                                      <Label className="text-muted-foreground text-xs">
-                                        Payload (JSON)
-                                      </Label>
-                                      <form.Field
-                                        name={`notificationWebhookUrls[${index}].payload`}
-                                      >
-                                        {(subfield) => (
-                                          <Textarea
-                                            name={subfield.name}
-                                            value={subfield.state.value}
-                                            onChange={(e) =>
-                                              subfield.handleChange(
-                                                e.target.value,
-                                              )
+                                          >
+                                            {(fieldMeta) => (
+                                              <FieldInfo
+                                                fieldMeta={fieldMeta}
+                                              />
+                                            )}
+                                          </form.Subscribe>
+                                        </div>
+                                        <div>
+                                          <Label className="text-muted-foreground text-xs">
+                                            Payload (JSON)
+                                          </Label>
+                                          <form.Field
+                                            name={`notificationWebhookUrls[${index}].payload`}
+                                          >
+                                            {(subfield) => (
+                                              <Textarea
+                                                name={subfield.name}
+                                                value={subfield.state.value}
+                                                onChange={(e) =>
+                                                  subfield.handleChange(
+                                                    e.target.value,
+                                                  )
+                                                }
+                                                onBlur={subfield.handleBlur}
+                                                placeholder='{"topic": "cross-seed", "priority": 3, "tags": ["seedbox"]}'
+                                                rows={2}
+                                                className="resize-y font-mono text-xs"
+                                              />
+                                            )}
+                                          </form.Field>
+                                          <form.Subscribe
+                                            selector={(f) =>
+                                              f.fieldMeta[
+                                                `notificationWebhookUrls[${index}].payload` as keyof typeof f.fieldMeta
+                                              ]
                                             }
-                                            onBlur={subfield.handleBlur}
-                                            placeholder='{"topic": "cross-seed", "priority": 3, "tags": ["seedbox"]}'
-                                            rows={2}
-                                            className="resize-y font-mono text-xs"
-                                          />
-                                        )}
-                                      </form.Field>
-                                      <form.Subscribe
-                                        selector={(f) =>
-                                          f.fieldMeta[
-                                            `notificationWebhookUrls[${index}].payload` as keyof typeof f.fieldMeta
-                                          ]
-                                        }
-                                      >
-                                        {(fieldMeta) => (
-                                          <FieldInfo fieldMeta={fieldMeta} />
-                                        )}
-                                      </form.Subscribe>
-                                    </div>
-                                  </div>
-                                )}
+                                          >
+                                            {(fieldMeta) => (
+                                              <FieldInfo
+                                                fieldMeta={fieldMeta}
+                                              />
+                                            )}
+                                          </form.Subscribe>
+                                        </div>
+                                      </div>
+                                    ) : null
+                                  }
+                                </form.Subscribe>
                               </fieldset>
                             ),
                           )}

--- a/packages/webui/src/types/config.ts
+++ b/packages/webui/src/types/config.ts
@@ -104,10 +104,10 @@ export const connectValidationSchema = z.object({
   sonarr: z.array(z.string().url().or(z.literal(''))).transform((v) => v ?? []),
   notificationWebhookUrls: z.array(
     z.object({
-      id: z.string(),
       url: z.string().url().or(z.literal('')),
       payload: optionalJsonObjectString,
       headers: optionalJsonHeadersString,
+      advancedOpen: z.boolean(),
     }),
   ),
 });


### PR DESCRIPTION

## Fixes
Small follow-up for PR #1104
### fix(webhook): move advanced-toggle state into form data to prevent desync on test
Clicking Test Webhooks silently flips _Custom Headers & Payload_ switch to OFF, collapses the headers/payload section, and the switch then becomes unresponsive to clicks until the user reloads the page. Before clicking Test, the switch toggles flawlessly.

### fix(webhook): show/hide advanced section immediately when toggling switch
flipping the _Custom Headers & Payload_ switch updates the Switch (via its own form.Field) but doesn't re-render the conditional below, causing the advanced sections to show/hide only after clicking _Test_ or _Save_ button.

### Testing image
This image contains the fixes introduced with this PR:
```
ghcr.io/v3djg6gl/cross-seed:test-webhook-advanced-toggle-desync
```

## LLM disclosure
*Developed with assistance from Claude Code (Opus 4.7). The LLM helped me identify the related files, code parts and proposed possible fixes.*
*I've manually reviewed the code the best I could, but since my TypeScript capabilities are not that good, proper code review is required in any case.**