### PR TITLE
Fix config import backup

### DIFF
--- a/packages/cross-seed/src/configuration.ts
+++ b/packages/cross-seed/src/configuration.ts
@@ -455,8 +455,12 @@ function collectWebhookUrls(
 	return entries.length ? entries : undefined;
 }
 
+export function getFileConfigPath(): string {
+	return path.join(appDir(), "config.js");
+}
+
 export async function getFileConfig(): Promise<FileConfig | undefined> {
-	const configPath = path.join(appDir(), "config.js");
+	const configPath = getFileConfigPath();
 
 	try {
 		return (await import(pathToFileURL(configPath).toString())).default;

--- a/packages/cross-seed/src/startup.ts
+++ b/packages/cross-seed/src/startup.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdir, rename } from "fs/promises";
+import { mkdir, readFile, rename, writeFile } from "fs/promises";
 import path from "path";
 import { resetApiKey } from "./auth.js";
 import { instantiateDownloadClients } from "./clients/TorrentClient.js";
@@ -81,6 +81,9 @@ type CommanderActionCb = (
 	options: Record<string, unknown>,
 ) => void | Promise<void>;
 
+const MIGRATED_CONFIG_COMMENT =
+	"// This config.js file was imported into the cross-seed v7 database. Use the Web UI to view or change settings.\n\n";
+
 /**
  * Initializes only the database, runs the callback, then cleans up
  */
@@ -132,6 +135,8 @@ async function backupFileConfig(): Promise<string> {
 	const configPath = getFileConfigPath();
 	const backupPath = await getFileConfigBackupPath(configPath);
 	await rename(configPath, backupPath);
+	const backupContents = await readFile(backupPath, "utf8");
+	await writeFile(backupPath, `${MIGRATED_CONFIG_COMMENT}${backupContents}`);
 	return backupPath;
 }
 

--- a/packages/cross-seed/src/startup.ts
+++ b/packages/cross-seed/src/startup.ts
@@ -1,11 +1,13 @@
-import { mkdir } from "fs/promises";
 import { spawn } from "node:child_process";
+import { mkdir, rename } from "fs/promises";
+import path from "path";
 import { resetApiKey } from "./auth.js";
 import { instantiateDownloadClients } from "./clients/TorrentClient.js";
 import {
 	createAppDirHierarchy,
 	getDefaultRuntimeConfig,
 	getFileConfig,
+	getFileConfigPath,
 	stripDefaults,
 	transformFileConfig,
 } from "./configuration.js";
@@ -112,7 +114,30 @@ async function applyExistingApiKey(config: RuntimeConfig): Promise<void> {
 	}
 }
 
-async function determineRuntimeConfig(rawOptions: Record<string, unknown>) {
+async function getFileConfigBackupPath(configPath: string): Promise<string> {
+	const basePath = `${configPath}.bak`;
+	if (await notExists(basePath)) {
+		return basePath;
+	}
+
+	for (let index = 1; ; index++) {
+		const candidate = `${basePath}.${index}`;
+		if (await notExists(candidate)) {
+			return candidate;
+		}
+	}
+}
+
+async function backupFileConfig(): Promise<string> {
+	const configPath = getFileConfigPath();
+	const backupPath = await getFileConfigBackupPath(configPath);
+	await rename(configPath, backupPath);
+	return backupPath;
+}
+
+export async function determineRuntimeConfig(
+	rawOptions: Record<string, unknown>,
+) {
 	const cliOptions = omitUndefined(rawOptions) as Partial<RuntimeConfig>;
 
 	// first, try to load from database (existing user happy path)
@@ -143,7 +168,12 @@ async function determineRuntimeConfig(rawOptions: Record<string, unknown>) {
 			await applyExistingApiKey(runtimeFromFile);
 			await setDbConfig(runtimeFromFile);
 			const resolvedOverrides = stripDefaults(runtimeFromFile);
-			logger.info("Migrated file config to database");
+			const backupPath = await backupFileConfig();
+			logger.info(
+				`Migrated file config to database; v7 now uses database/Web UI settings. Preserved old config file as ${path.basename(
+					backupPath,
+				)}.`,
+			);
 			return {
 				...getDefaultRuntimeConfig(),
 				...resolvedOverrides,

--- a/packages/cross-seed/tests/startup.test.ts
+++ b/packages/cross-seed/tests/startup.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const TEST_ROOT = await mkdtemp(join(tmpdir(), "cross-seed-startup-tests-"));
+const MIGRATED_CONFIG_COMMENT =
+	"// This config.js file was imported into the cross-seed v7 database. Use the Web UI to view or change settings.\n\n";
 
 type StartupEnv = {
 	configDir: string;
@@ -63,7 +65,7 @@ export default {
 			code: "ENOENT",
 		});
 		await expect(readFile(`${env.configPath}.bak`, "utf8")).resolves.toBe(
-			configContents,
+			`${MIGRATED_CONFIG_COMMENT}${configContents}`,
 		);
 		expect(runtimeConfig.torznab).toEqual([
 			"https://example.com/api?apikey=abc",
@@ -106,7 +108,7 @@ export default {
 			"previous backup",
 		);
 		await expect(readFile(`${env.configPath}.bak.1`, "utf8")).resolves.toBe(
-			configContents,
+			`${MIGRATED_CONFIG_COMMENT}${configContents}`,
 		);
 	});
 });

--- a/packages/cross-seed/tests/startup.test.ts
+++ b/packages/cross-seed/tests/startup.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const TEST_ROOT = await mkdtemp(join(tmpdir(), "cross-seed-startup-tests-"));
+
+type StartupEnv = {
+	configDir: string;
+	configPath: string;
+	db: typeof import("../src/db.js").db;
+	determineRuntimeConfig: typeof import("../src/startup.js").determineRuntimeConfig;
+	getDbConfig: typeof import("../src/dbConfig.js").getDbConfig;
+};
+
+let currentDb: StartupEnv["db"] | undefined;
+
+async function createStartupEnv(): Promise<StartupEnv> {
+	const configDir = await mkdtemp(join(TEST_ROOT, "config-"));
+	process.env.CONFIG_DIR = configDir;
+	vi.resetModules();
+
+	const { db } = await import("../src/db.js");
+	const { createAppDirHierarchy } = await import("../src/configuration.js");
+	const { initializeLogger } = await import("../src/logger.js");
+	const { determineRuntimeConfig } = await import("../src/startup.js");
+	const { getDbConfig } = await import("../src/dbConfig.js");
+
+	createAppDirHierarchy();
+	initializeLogger({ verbose: false });
+	await db.migrate.latest();
+	currentDb = db;
+
+	return {
+		configDir,
+		configPath: join(configDir, "config.js"),
+		db,
+		determineRuntimeConfig,
+		getDbConfig,
+	};
+}
+
+describe.sequential("startup config migration", () => {
+	afterEach(async () => {
+		await currentDb?.destroy();
+		currentDb = undefined;
+		delete process.env.CONFIG_DIR;
+	});
+
+	it("renames config.js after importing file config into the database", async () => {
+		const env = await createStartupEnv();
+		const configContents = `
+export default {
+	torznab: ["https://example.com/api?apikey=abc"],
+	useClientTorrents: false,
+};
+`;
+		await writeFile(env.configPath, configContents);
+
+		const runtimeConfig = await env.determineRuntimeConfig({});
+
+		await expect(readFile(env.configPath, "utf8")).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+		await expect(readFile(`${env.configPath}.bak`, "utf8")).resolves.toBe(
+			configContents,
+		);
+		expect(runtimeConfig.torznab).toEqual([
+			"https://example.com/api?apikey=abc",
+		]);
+		expect((await env.getDbConfig())?.torznab).toEqual([
+			"https://example.com/api?apikey=abc",
+		]);
+	});
+
+	it("leaves config.js untouched when file config import fails", async () => {
+		const env = await createStartupEnv();
+		const configContents = "export default { torznab: [";
+		await writeFile(env.configPath, configContents);
+
+		await env.determineRuntimeConfig({});
+
+		await expect(readFile(env.configPath, "utf8")).resolves.toBe(
+			configContents,
+		);
+		await expect(
+			readFile(`${env.configPath}.bak`, "utf8"),
+		).rejects.toMatchObject({
+			code: "ENOENT",
+		});
+	});
+
+	it("chooses a collision-safe backup filename", async () => {
+		const env = await createStartupEnv();
+		const configContents = `
+export default {
+	useClientTorrents: false,
+};
+`;
+		await writeFile(env.configPath, configContents);
+		await writeFile(`${env.configPath}.bak`, "previous backup");
+
+		await env.determineRuntimeConfig({});
+
+		await expect(readFile(`${env.configPath}.bak`, "utf8")).resolves.toBe(
+			"previous backup",
+		);
+		await expect(readFile(`${env.configPath}.bak.1`, "utf8")).resolves.toBe(
+			configContents,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- rename `config.js` to a collision-safe backup after a successful v6-to-v7 database import
- leave `config.js` in place when import fails so startup can retry after the file is fixed
- add startup migration tests for success, failure, and existing backup collisions

## Root cause

After importing legacy file config into the database, startup left `config.js` in place. Future launches could continue treating that file as active migration input instead of clearly moving users onto database/Web UI settings.

## Validation

- `npm -w packages/cross-seed run test`
- `npm -w packages/cross-seed run typecheck`
- `npm -w packages/cross-seed run lint`
- `npm -w packages/cross-seed run build`
