### PR TITLE
Fix Torrent Clients settings save validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"proseWrap": "always"
 	},
 	"lint-staged": {
-		"*.{js,ts}": "eslint --cache",
-		"*.{js,json,ts,css,md}": "prettier --write"
+		"*.{js,jsx,ts,tsx}": "eslint --cache",
+		"*.{js,jsx,json,ts,tsx,css,md}": "prettier --write"
 	}
 }

--- a/webui/src/routes/settings/clients.tsx
+++ b/webui/src/routes/settings/clients.tsx
@@ -42,7 +42,7 @@ import { useSaveConfigHook } from "@/hooks/saveFormHook";
 import z from "zod";
 import { RuntimeConfig } from "@cross-seed/shared/configSchema";
 
-type ClientFormData = z.input<typeof downloaderValidationSchema>;
+type ClientOptionsFormData = z.input<typeof downloaderValidationSchema>;
 
 function TorrentClientsSettings() {
   const trpc = useTRPC();
@@ -65,15 +65,18 @@ function TorrentClientsSettings() {
       select: (data: {
         config: RuntimeConfig;
         apiKey: string;
-      }): Partial<ClientFormData> => {
+      }): {
+        formData: Partial<ClientOptionsFormData>;
+        torrentClients: Array<string | TDownloadClient>;
+      } => {
         const fullDataset = formatConfigDataForForm(data.config);
-        const filteredData = pickSchemaFields(
-          downloaderValidationSchema,
-          fullDataset,
-          { includeUndefined: true },
-        );
 
-        return filteredData;
+        return {
+          formData: pickSchemaFields(downloaderValidationSchema, fullDataset, {
+            includeUndefined: true,
+          }),
+          torrentClients: data.config.torrentClients,
+        };
       },
     }),
   );
@@ -81,8 +84,8 @@ function TorrentClientsSettings() {
   const handleSubmit = useSettingsFormSubmit();
 
   const form = useAppForm({
-    defaultValues: (configData ??
-      defaultDownloadClientFormValues) as ClientFormData,
+    defaultValues: (configData?.formData ??
+      defaultDownloadClientFormValues) as ClientOptionsFormData,
     onSubmit: handleSubmit,
     validators: {
       onSubmit: downloaderValidationSchema,

--- a/webui/src/types/config.ts
+++ b/webui/src/types/config.ts
@@ -73,7 +73,6 @@ export const clientValidationSchema = z.object({
 });
 
 export const downloaderValidationSchema = z.object({
-  torrentClients: z.array(clientValidationSchema).nullish(),
   action: z.nativeEnum(Action),
   duplicateCategories: z.boolean(),
   useClientTorrents: z.boolean(),


### PR DESCRIPTION
## Summary

Fixes the Torrent Clients settings page so Torrent Client Options can save independently from the client list/table state.

The options form was using `downloaderValidationSchema`, which includes `torrentClients`. That field is not submitted by the options form, and runtime `torrentClients` are serialized strings while the client editor/table works with UI-shaped objects. That mismatch could make saving options such as `useClientTorrents` fail before the settings mutation ran.

This PR omits `torrentClients` from the options form validation and keeps the client list data separate for display/add/edit/delete handling.

Fixes #1151.

## Validation

- `npm -w webui run typecheck`
- `npm -w webui run lint` (passes with existing coverage-file warnings)
- `npm run typecheck`
- `npm run test`
- `npm run build`
