### PR TITLE
refactor(client/deluge): minor refactor / logic updating / fix labeling logic and failures

### DIFF
--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -1,8 +1,8 @@
+import { humanReadableSize } from "@cross-seed/shared/utils";
 import { readdir } from "fs/promises";
 import ms from "ms";
 import { basename } from "path";
 import { inspect } from "util";
-import { humanReadableSize } from "@cross-seed/shared/utils";
 import {
 	DecisionAnyMatch,
 	InjectionResult,
@@ -33,7 +33,6 @@ import {
 	wait,
 } from "../utils.js";
 import {
-	shouldResumeFromNonRelevantFiles,
 	clientSearcheeModified,
 	ClientSearcheeResult,
 	getMaxRemainingBytes,
@@ -42,12 +41,14 @@ import {
 	resumeErrSleepTime,
 	resumeSleepTime,
 	shouldRecheck,
+	shouldResumeFromNonRelevantFiles,
 	TorrentClient,
 	TorrentMetadataInClient,
 } from "./TorrentClient.js";
 
 interface TorrentInfo {
 	name?: string;
+	hash?: string;
 	complete?: boolean;
 	save_path?: string;
 	state?: string;
@@ -58,6 +59,10 @@ interface TorrentInfo {
 	files?: { path: string; size: number }[];
 	trackers?: { url: string; tier: number }[];
 }
+
+type TorrentInfoField = keyof TorrentInfo;
+type UpdateUiFilter = { hash?: string } & Record<string, unknown>;
+type UpdateUiParams = [fields: TorrentInfoField[], filter: UpdateUiFilter];
 
 enum DelugeErrorCode {
 	NO_AUTH = 1,
@@ -93,8 +98,8 @@ export default class Deluge implements TorrentClient {
 	readonly readonly: boolean;
 	readonly label: string;
 	private delugeCookie: string | null = null;
-	private delugeLabel = TORRENT_TAG;
-	private delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
+	readonly delugeLabel = TORRENT_TAG;
+	readonly delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
 	private isLabelEnabled: boolean;
 	private delugeRequestId: number = 0;
 
@@ -199,6 +204,20 @@ export default class Deluge implements TorrentClient {
 		}
 		this.isLabelEnabled = await this.labelEnabled();
 	}
+
+	// web.update_ui method (typed params + forced return)
+	private async call(
+		method: "web.update_ui",
+		params: UpdateUiParams,
+		retries?: number,
+	): Promise<Result<TorrentStatus, ErrorType>>;
+
+	// standard RPC method fallback
+	private async call<ResultType>(
+		method: string,
+		params: unknown[],
+		retries?: number,
+	): Promise<Result<ResultType, ErrorType>>;
 
 	/**
 	 * ensures authentication and sends JSON-RPC calls to deluge
@@ -409,11 +428,9 @@ export default class Deluge implements TorrentClient {
 			!ogLabel.endsWith(this.delugeLabelSuffix) && // no .cross-seed
 			ogLabel !== linkCategory; // not data
 
-		return !searchee.infoHash
-			? (linkCategory ?? "")
-			: shouldSuffixLabel
-				? `${ogLabel}${this.delugeLabelSuffix}`
-				: ogLabel;
+		return shouldSuffixLabel
+			? `${ogLabel}${this.delugeLabelSuffix}`
+			: ogLabel;
 	}
 
 	/**
@@ -527,24 +544,24 @@ export default class Deluge implements TorrentClient {
 						label: this.label,
 						message: `Unknown injection failure: ${getLogString(newTorrent)}`,
 					});
-					return InjectionResult.FAILURE;
 				}
+				return InjectionResult.FAILURE;
 			}
-			if (addResponse.isOk()) {
-				await this.setLabel(
-					newTorrent,
-					this.calculateLabel(searchee, torrentInfo!),
-				);
 
-				if (toRecheck) {
-					// when paused, libtorrent doesnt start rechecking
-					// leaves torrent ready to download - ~99%
-					await wait(1000);
-					await this.recheckTorrent(newTorrent.infoHash);
-					void this.resumeInjection(newTorrent, decision, {
-						checkOnce: false,
-					});
-				}
+			// addResponse is known to be OK
+			await this.setLabel(
+				newTorrent,
+				this.calculateLabel(searchee, torrentInfo!),
+			);
+
+			if (toRecheck) {
+				// when paused, libtorrent doesnt start rechecking
+				// leaves torrent ready to download - ~99%
+				await wait(1000);
+				await this.recheckTorrent(newTorrent.infoHash);
+				void this.resumeInjection(newTorrent, decision, {
+					checkOnce: false,
+				});
 			}
 		} catch (error) {
 			logger.error({
@@ -601,9 +618,12 @@ export default class Deluge implements TorrentClient {
 		Result<string, "NOT_FOUND" | "TORRENT_NOT_COMPLETE" | "UNKNOWN_ERROR">
 	> {
 		let response: Result<TorrentStatus, ErrorType>;
-		const params = [["save_path", "progress"], { hash: meta.infoHash }];
+		const params: UpdateUiParams = [
+			["save_path", "progress", "state", "total_remaining"],
+			{ hash: meta.infoHash },
+		];
 		try {
-			response = await this.call<TorrentStatus>("web.update_ui", params);
+			response = await this.call("web.update_ui", params);
 		} catch {
 			return resultOfErr("UNKNOWN_ERROR");
 		}
@@ -618,7 +638,7 @@ export default class Deluge implements TorrentClient {
 		if (!torrent) {
 			return resultOfErr("NOT_FOUND");
 		}
-		if (options.onlyCompleted && torrent.progress !== 100) {
+		if (options.onlyCompleted && !this.isComplete(torrent)) {
 			return resultOfErr("TORRENT_NOT_COMPLETE");
 		}
 		return resultOf(torrent.save_path!);
@@ -635,9 +655,9 @@ export default class Deluge implements TorrentClient {
 	}): Promise<Map<string, string>> {
 		const dirs = new Map<string, string>();
 		let response: Result<TorrentStatus, ErrorType>;
-		const params = [["save_path", "progress"], {}];
+		const params: UpdateUiParams = [["save_path", "progress"], {}];
 		try {
-			response = await this.call<TorrentStatus>("web.update_ui", params);
+			response = await this.call("web.update_ui", params);
 		} catch {
 			return dirs;
 		}
@@ -649,7 +669,7 @@ export default class Deluge implements TorrentClient {
 			return dirs;
 		}
 		for (const [hash, torrent] of Object.entries(torrentResponse)) {
-			if (options.onlyCompleted && torrent.progress !== 100) continue;
+			if (options.onlyCompleted && !this.isComplete(torrent)) continue;
 			dirs.set(hash, torrent.save_path!);
 		}
 		return dirs;
@@ -665,10 +685,8 @@ export default class Deluge implements TorrentClient {
 	): Promise<Result<boolean, Error>> {
 		const infoHash = inputHash.toLowerCase();
 		try {
-			const torrentsRes = await this.call<TorrentStatus>(
-				"web.update_ui",
-				[[], {}],
-			);
+			const params: UpdateUiParams = [[], { hash: infoHash }];
+			const torrentsRes = await this.call("web.update_ui", params);
 			if (torrentsRes.isErr()) {
 				const err = torrentsRes.unwrapErr();
 				throw new Error(
@@ -677,9 +695,8 @@ export default class Deluge implements TorrentClient {
 			}
 			const torrents = torrentsRes.unwrap().torrents;
 			if (!torrents) throw new Error("No torrents found");
-			for (const hash of Object.keys(torrents)) {
-				if (hash.toLowerCase() === infoHash) return resultOf(true);
-			}
+			// torrents infoHash are already toLower() in deluge
+			if (infoHash in torrents) return resultOf(true);
 			return resultOf(false);
 		} catch (e) {
 			return resultOfErr(e);
@@ -726,11 +743,8 @@ export default class Deluge implements TorrentClient {
 	 * @return All torrents in the client
 	 */
 	async getAllTorrents(): Promise<TorrentMetadataInClient[]> {
-		const params = [["hash", "label"], {}];
-		const response = await this.call<TorrentStatus>(
-			"web.update_ui",
-			params,
-		);
+		const params: UpdateUiParams = [["hash", "label"], {}];
+		const response = await this.call("web.update_ui", params);
 		if (!response.isOk()) {
 			return [];
 		}
@@ -757,10 +771,11 @@ export default class Deluge implements TorrentClient {
 		const searchees: SearcheeClient[] = [];
 		const newSearchees: SearcheeClient[] = [];
 		const infoHashes = new Set<string>();
-		const torrentsRes = await this.call<TorrentStatus>("web.update_ui", [
+		const params: UpdateUiParams = [
 			["name", "label", "save_path", "total_size", "files", "trackers"],
 			{},
-		]);
+		];
+		const torrentsRes = await this.call("web.update_ui", params);
 		if (torrentsRes.isErr()) {
 			logger.error({
 				label: this.label,
@@ -841,6 +856,14 @@ export default class Deluge implements TorrentClient {
 		return { searchees, newSearchees };
 	}
 
+	private isComplete(t: TorrentInfo): boolean {
+		return (
+			t.state === "Seeding" ||
+			t.progress === 100 ||
+			(t.state === "Paused" && !t.total_remaining)
+		);
+	}
+
 	/**
 	 * returns information needed to complete/validate injection
 	 * @return Promise of TorrentInfo type
@@ -855,7 +878,7 @@ export default class Deluge implements TorrentClient {
 	): Promise<TorrentInfo> {
 		let torrent: TorrentInfo;
 		try {
-			const params = [
+			const params: UpdateUiParams = [
 				[
 					"name",
 					"state",
@@ -868,7 +891,7 @@ export default class Deluge implements TorrentClient {
 			];
 
 			const response = (
-				await this.call<TorrentStatus>("web.update_ui", params)
+				await this.call("web.update_ui", params)
 			).unwrapOrThrow(new Error("failed to fetch the torrent list"));
 
 			if (response.torrents) {
@@ -882,15 +905,10 @@ export default class Deluge implements TorrentClient {
 				throw new Error(`Torrent not found in client (${infoHash})`);
 			}
 
-			const completedTorrent =
-				(torrent.state === "Paused" &&
-					(torrent.progress === 100 || !torrent.total_remaining)) ||
-				torrent.state === "Seeding" ||
-				torrent.progress === 100 ||
-				!torrent.total_remaining;
+			const completedTorrent = this.isComplete(torrent);
 
 			const torrentLabel =
-				this.isLabelEnabled && torrent.label!.length != 0
+				this.isLabelEnabled && torrent.label?.length != 0
 					? torrent.label
 					: undefined;
 

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -117,7 +117,6 @@ export default class Deluge implements TorrentClient {
 	async validateConfig(): Promise<void> {
 		const { torrentDir } = getRuntimeConfig();
 		await this.authenticate();
-		this.isLabelEnabled = await this.labelEnabled();
 		logger.info({
 			label: this.label,
 			message: `Logged in successfully${this.readonly ? " (readonly)" : ""}`,
@@ -198,6 +197,7 @@ export default class Deluge implements TorrentClient {
 				);
 			}
 		}
+		this.isLabelEnabled = await this.labelEnabled();
 	}
 
 	/**

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -529,25 +529,19 @@ export default class Deluge implements TorrentClient {
 				"core.add_torrent_file",
 				params,
 			);
+
 			if (addResponse.isErr()) {
-				const addResponseError = addResponse.unwrapErr();
-				if (addResponseError.message.includes("already")) {
+				const err = addResponse.unwrapErr();
+				if (err.message.includes("already")) {
 					return InjectionResult.ALREADY_EXISTS;
-				} else if (addResponseError) {
-					logger.debug({
-						label: this.label,
-						message: `Injection failed: ${addResponseError.message}`,
-					});
-					return InjectionResult.FAILURE;
-				} else {
-					logger.debug({
-						label: this.label,
-						message: `Unknown injection failure: ${getLogString(newTorrent)}`,
-					});
 				}
+				logger.debug({
+					label: this.label,
+					message: `Injection failed: ${err.message}`,
+				});
 				return InjectionResult.FAILURE;
 			}
-
+			await wait(250);
 			// addResponse is known to be OK
 			await this.setLabel(
 				newTorrent,
@@ -655,7 +649,10 @@ export default class Deluge implements TorrentClient {
 	}): Promise<Map<string, string>> {
 		const dirs = new Map<string, string>();
 		let response: Result<TorrentStatus, ErrorType>;
-		const params: UpdateUiParams = [["save_path", "progress"], {}];
+		const params: UpdateUiParams = [
+			["save_path", "progress", "state", "total_remaining"],
+			{},
+		];
 		try {
 			response = await this.call("web.update_ui", params);
 		} catch {

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -122,7 +122,7 @@ export default class Deluge implements TorrentClient {
 			label: this.label,
 			message: `Logged in successfully${this.readonly ? " (readonly)" : ""}`,
 		});
-
+		await this.call<boolean>("auth.delete_session", [], 0);
 		if (!torrentDir) return;
 		if (!(await readdir(torrentDir)).some((f) => f.endsWith(".state"))) {
 			throw new CrossSeedError(

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -139,12 +139,12 @@ export default class Deluge implements TorrentClient {
 			this.url,
 		).unwrapOrThrow(
 			new CrossSeedError(
-				`[${this.label}] delugeRpcUrl must be percent-encoded`,
+				`[${this.label}] The Deluge WebUI URL must be percent-encoded`,
 			),
 		);
 		if (!password) {
 			throw new CrossSeedError(
-				`[${this.label}] You need to define a password in the delugeRpcUrl. (e.g. http://:<PASSWORD>@localhost:8112)`,
+				`[${this.label}] You need to define a password in the Deluge WebUI URL. (e.g. http://:<PASSWORD>@localhost:8112)`,
 			);
 		}
 		try {
@@ -212,14 +212,20 @@ export default class Deluge implements TorrentClient {
 		params: unknown[],
 		retries = 1,
 	): Promise<Result<ResultType, ErrorType>> {
-		const msg = `Calling method ${method} with params ${inspect(params, { depth: null, compact: true })}`;
-		const message = msg.length > 1000 ? `${msg.slice(0, 1000)}...` : msg;
-		logger.verbose({ label: this.label, message });
+		const truncate = (message: string) =>
+			message.length > 1000 ? `${message.slice(0, 1000)}...` : message;
 		const { href } = extractCredentialsFromUrl(this.url).unwrapOrThrow(
 			new CrossSeedError(
-				`[${this.label}] delugeRpcUrl must be percent-encoded`,
+				`[${this.label}] The Deluge WebUI URL must be percent-encoded`,
 			),
 		);
+
+		const message =
+			method === "auth.login"
+				? `Calling authentication method ${method}`
+				: `Calling method ${method} with params ${inspect(params, { depth: null, compact: true })}`;
+		logger.verbose({ label: this.label, message: truncate(message) });
+
 		const headers = new Headers({
 			"Content-Type": "application/json",
 			"User-Agent": USER_AGENT,


### PR DESCRIPTION
- [x] typing for call() function to help with autocomplete in the language server (signatures)
- [x] fix labeling not being recognized outside of authenticate function
- [x] redact password from auth.login method usage
- [x] type method params and have stricter filtering types
- [x] change TORRENT_TAG and SUFFIX to readonly (possible revert needed if custom torrent cat/label is done)
- [x] remove `auth.login` session after validating (`authenticate` from TorrentClient's `validate()`)
- [x] cleanup dead end logic for `calculateLabel()` and maintain persistant label plugin status
- [x] add `wait()` to allow for better accessing of data/partial/ensemble injections rechecking
<hr>

While these aren't major changes, a few are bugfixes that have been accrued over the course of v6 and v7, this fixes most of the above listed things and improves accuracy in the functions cross-seed has when interfacing with Deluge.

<hr>

## TODO:

- [ ] ?