### PR TITLE
fix: adjust calculateLabel behaviour to reflect documented behaviour

### DIFF
--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -100,7 +100,7 @@ export default class Deluge implements TorrentClient {
 	private delugeCookie: string | null = null;
 	readonly delugeLabel = TORRENT_TAG;
 	readonly delugeLabelSuffix = TORRENT_CATEGORY_SUFFIX;
-	private isLabelEnabled: boolean;
+	private isLabelEnabled: boolean = false;
 	private delugeRequestId: number = 0;
 
 	constructor(
@@ -128,6 +128,7 @@ export default class Deluge implements TorrentClient {
 		});
 		await this.call<boolean>("auth.delete_session", [], 0);
 		if (!torrentDir) return;
+
 		if (!(await readdir(torrentDir)).some((f) => f.endsWith(".state"))) {
 			throw new CrossSeedError(
 				`[${this.label}] Invalid torrentDir, if no torrents are in client set to null for now: https://www.cross-seed.org/docs/basics/options#torrentdir`,
@@ -369,6 +370,7 @@ export default class Deluge implements TorrentClient {
 					});
 					return;
 				}
+
 				const maxRemainingBytes = getMaxRemainingBytes(meta, decision, {
 					torrentLog,
 					label: this.label,
@@ -384,6 +386,7 @@ export default class Deluge implements TorrentClient {
 					) {
 						logger.warn({
 							label: this.label,
+
 							message: `autoResumeMaxDownload will not resume ${torrentLog}: remainingSize ${humanReadableSize(torrentInfo.total_remaining!, { binary: true })} > ${humanReadableSize(maxRemainingBytes, { binary: true })} limit`,
 						});
 						return;
@@ -395,6 +398,7 @@ export default class Deluge implements TorrentClient {
 			}
 			logger.info({
 				label: this.label,
+
 				message: `Resuming ${torrentLog}: ${humanReadableSize(torrentInfo.total_remaining!, { binary: true })} remaining`,
 			});
 			await this.call<string>("core.resume_torrent", [[infoHash]]);
@@ -503,7 +507,7 @@ export default class Deluge implements TorrentClient {
 					return InjectionResult.TORRENT_NOT_COMPLETE;
 			}
 			if (
-				!options.destinationDir &&
+				typeof options.destinationDir !== "string" &&
 				(!searchee.infoHash || !torrentInfo!)
 			) {
 				logger.debug({
@@ -512,12 +516,14 @@ export default class Deluge implements TorrentClient {
 				});
 				return InjectionResult.FAILURE;
 			}
-
+			let destinationDir: string;
 			const torrentFileName = `${newTorrent.getFileSystemSafeName()}.cross-seed.torrent`;
 			const encodedTorrentData = newTorrent.encode().toString("base64");
-			const destinationDir = options.destinationDir
-				? options.destinationDir
-				: torrentInfo!.save_path!;
+			if (typeof options.destinationDir == "string") {
+				destinationDir = options.destinationDir;
+			} else {
+				destinationDir = torrentInfo!.save_path!;
+			}
 			const toRecheck = shouldRecheck(newTorrent, decision);
 			const params = this.formatData(
 				torrentFileName,
@@ -701,7 +707,7 @@ export default class Deluge implements TorrentClient {
 			if (infoHash in torrents) return resultOf(true);
 			return resultOf(false);
 		} catch (e) {
-			return resultOfErr(e);
+			return resultOfErr(e as Error);
 		}
 	}
 

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -416,13 +416,13 @@ export default class Deluge implements TorrentClient {
 		searchee: Searchee,
 		torrentInfo: TorrentInfo,
 	): string {
-		const { linkCategory, duplicateCategories } = getRuntimeConfig();
+		const { linkCategory, duplicateCategories, linkDirs } = getRuntimeConfig();
 		if (!searchee.infoHash || !torrentInfo.label) {
-			return this.delugeLabel;
+			return linkDirs.length ? linkCategory : this.delugeLabel;
 		}
 		const ogLabel = torrentInfo.label;
 		if (!duplicateCategories) {
-			return ogLabel;
+			return linkDirs.length ? linkCategory : ogLabel;
 		}
 		const shouldSuffixLabel =
 			!ogLabel.endsWith(this.delugeLabelSuffix) && // no .cross-seed

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -417,13 +417,13 @@ export default class Deluge implements TorrentClient {
 		torrentInfo: TorrentInfo,
 		destinationDir?: string,
 	): string {
-		const { linkCategory, duplicateCategories, linkDirs } = getRuntimeConfig();
+		const { linkCategory, duplicateCategories } = getRuntimeConfig();
 		if (!searchee.infoHash || !torrentInfo.label) {
 			return destinationDir ? linkCategory : this.delugeLabel;
 		}
 		const ogLabel = torrentInfo.label;
 		if (!duplicateCategories) {
-			rreturn destinationDir ? linkCategory : ogLabel;
+			return destinationDir ? linkCategory : ogLabel;
 		}
 		const shouldSuffixLabel =
 			!ogLabel.endsWith(this.delugeLabelSuffix) && // no .cross-seed

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -546,7 +546,11 @@ export default class Deluge implements TorrentClient {
 			// addResponse is known to be OK
 			await this.setLabel(
 				newTorrent,
-				this.calculateLabel(searchee, torrentInfo!, options.destinationDir),
+				this.calculateLabel(
+					searchee,
+					torrentInfo!,
+					options.destinationDir,
+				),
 			);
 
 			if (toRecheck) {

--- a/cross-seed/src/clients/Deluge.ts
+++ b/cross-seed/src/clients/Deluge.ts
@@ -415,14 +415,15 @@ export default class Deluge implements TorrentClient {
 	private calculateLabel(
 		searchee: Searchee,
 		torrentInfo: TorrentInfo,
+		destinationDir?: string,
 	): string {
 		const { linkCategory, duplicateCategories, linkDirs } = getRuntimeConfig();
 		if (!searchee.infoHash || !torrentInfo.label) {
-			return linkDirs.length ? linkCategory : this.delugeLabel;
+			return destinationDir ? linkCategory : this.delugeLabel;
 		}
 		const ogLabel = torrentInfo.label;
 		if (!duplicateCategories) {
-			return linkDirs.length ? linkCategory : ogLabel;
+			rreturn destinationDir ? linkCategory : ogLabel;
 		}
 		const shouldSuffixLabel =
 			!ogLabel.endsWith(this.delugeLabelSuffix) && // no .cross-seed
@@ -545,7 +546,7 @@ export default class Deluge implements TorrentClient {
 			// addResponse is known to be OK
 			await this.setLabel(
 				newTorrent,
-				this.calculateLabel(searchee, torrentInfo!),
+				this.calculateLabel(searchee, torrentInfo!, options.destinationDir),
 			);
 
 			if (toRecheck) {

--- a/cross-seed/src/preFilter.ts
+++ b/cross-seed/src/preFilter.ts
@@ -77,7 +77,7 @@ export function isSingleEpisode(
 
 function isCrossSeed(searchee: Searchee): boolean {
 	const { linkCategory } = getRuntimeConfig();
-	if (linkCategory?.length && searchee.category === linkCategory) return true; // qBit, Deluge
+	if (linkCategory.length && searchee.category === linkCategory) return true; // qBit, Deluge
 	if (searchee.category === TORRENT_TAG) return true; // Deluge
 	if (searchee.category?.endsWith(TORRENT_CATEGORY_SUFFIX)) return true; // qBit, Deluge
 	if (searchee.tags?.includes(TORRENT_TAG)) return true; // qBit, rTorrent, Transmission

--- a/shared/configSchema.ts
+++ b/shared/configSchema.ts
@@ -22,7 +22,7 @@ export const RUNTIME_CONFIG_SCHEMA = z.object({
 	linkType: z.nativeEnum(LinkType),
 	flatLinking: z.boolean(),
 	maxDataDepth: z.number().int().min(1),
-	linkCategory: z.string().optional(),
+	linkCategory: z.string(),
 	torrentDir: z.string().optional(),
 	outputDir: z.string(),
 	injectDir: z.string().optional(),

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -115,7 +115,7 @@ export const defaultConfig: RuntimeConfig = {
 	matchMode: MatchMode.STRICT,
 	skipRecheck: true,
 	autoResumeMaxDownload: 52428800,
-	linkCategory: undefined,
+	linkCategory: "cross-seed-link",
 	linkDirs: [],
 	linkType: LinkType.HARDLINK,
 	flatLinking: false,

--- a/webui/src/components/Form/shared-form.ts
+++ b/webui/src/components/Form/shared-form.ts
@@ -31,7 +31,7 @@ export const defaultTrackerFormValues: Partial<RuntimeConfig> = {
 export const defaultDownloadClientFormValues: Partial<RuntimeConfig> = {
   action: Action.INJECT,
   duplicateCategories: false,
-  linkCategory: undefined,
+  linkCategory: "cross-seed-link",
   outputDir: "",
   skipRecheck: true,
   torrentClients: [],


### PR DESCRIPTION
When using `deluge` client, otherwise with "linkCategory": "cross-seed" and "duplicateCategories": false, it *would* duplicate, i.e. always return the original category on linking, despite setting "linkCategory".

These changes also align the behaviour with qBittorrent.