### PR TITLE
fix: resume rTorrent injected torrents by checking d.state, not d.is_active

### DIFF
--- a/cross-seed/src/clients/RTorrent.ts
+++ b/cross-seed/src/clients/RTorrent.ts
@@ -203,7 +203,7 @@ export default class RTorrent implements TorrentClient {
 				bytesLeft: number;
 				hashing: 0 | 1 | 2 | 3;
 				isMultiFile: boolean;
-				isActive: boolean;
+				isStarted: boolean;
 			},
 			"FAILURE" | "TORRENT_NOT_COMPLETE" | "NOT_FOUND"
 		>
@@ -249,7 +249,7 @@ export default class RTorrent implements TorrentClient {
 					params: [hash],
 				},
 				{
-					methodName: "d.is_active",
+					methodName: "d.state",
 					params: [hash],
 				},
 			],
@@ -285,7 +285,7 @@ export default class RTorrent implements TorrentClient {
 				[hashingStr],
 				[isCompleteStr],
 				[isMultiFileStr],
-				[isActiveStr],
+				[stateStr],
 			] = response;
 			const isComplete = Boolean(Number(isCompleteStr));
 			if (options.onlyCompleted && !isComplete) {
@@ -297,7 +297,7 @@ export default class RTorrent implements TorrentClient {
 				bytesLeft: Number(bytesLeftStr),
 				hashing: Number(hashingStr) as 0 | 1 | 2 | 3,
 				isMultiFile: Boolean(Number(isMultiFileStr)),
-				isActive: Boolean(Number(isActiveStr)),
+				isStarted: Boolean(Number(stateStr)),
 			});
 		} catch (e) {
 			logger.error({ label: this.label, message: String(e) });
@@ -800,10 +800,10 @@ export default class RTorrent implements TorrentClient {
 				continue;
 			}
 			const torrentLog = `${torrentInfo.name} [${sanitizeInfoHash(infoHash)}]`;
-			if (torrentInfo.isActive) {
+			if (torrentInfo.isStarted) {
 				logger.warn({
 					label: this.label,
-					message: `Will not resume torrent ${torrentLog}: active`,
+					message: `Will not resume torrent ${torrentLog}: started`,
 				});
 				return;
 			}

--- a/cross-seed/tests/rtorrent.test.ts
+++ b/cross-seed/tests/rtorrent.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import RTorrent from "../src/clients/RTorrent.js";
+
+// A minimal structural view of the internals this test drives, so it can stub the
+// XML-RPC layer and call the (private) query helper without resorting to `any`.
+type RTorrentInternals = {
+	methodCallP: (method: string, args: unknown[]) => unknown;
+	checkOriginalTorrent: (
+		infoHash: string,
+		options: { onlyCompleted: boolean },
+	) => Promise<{ isErr(): boolean; unwrap(): { isStarted: boolean } }>;
+};
+
+describe("RTorrent checkOriginalTorrent", () => {
+	// Regression test for #1200: rTorrent's d.is_active can report 1 even when the
+	// torrent is genuinely stopped (d.state = 0), which made resumeInjection give up
+	// on injected torrents and leave them stopped forever. The running/stopped state
+	// must be read from d.state, the persistent started/stopped flag.
+	it("reads d.state (not d.is_active) to decide whether a torrent is running", async () => {
+		const rtorrent = new RTorrent(
+			"http://127.0.0.1:8001/RPC2",
+			"127.0.0.1",
+			1,
+			false,
+		);
+		const internals = rtorrent as unknown as RTorrentInternals;
+
+		let multicallArgs: unknown;
+		internals.methodCallP = vi.fn(
+			(method: string, args: unknown[]): unknown => {
+				if (method === "system.multicall") {
+					multicallArgs = args;
+					// name, directory, left_bytes, hashing, complete, is_multi_file, state
+					// state = "0": the torrent is stopped and should be resumable.
+					return [
+						["name"],
+						["/dir"],
+						["0"],
+						["0"],
+						["1"],
+						["0"],
+						["0"],
+					];
+				}
+				return [];
+			},
+		);
+
+		const result = await internals.checkOriginalTorrent("abc123", {
+			onlyCompleted: false,
+		});
+
+		expect(result.isErr()).toBe(false);
+		expect(result.unwrap().isStarted).toBe(false);
+
+		const methods = (multicallArgs as [{ methodName: string }[]])[0].map(
+			(call) => call.methodName,
+		);
+		expect(methods).toContain("d.state");
+		expect(methods).not.toContain("d.is_active");
+	});
+});


### PR DESCRIPTION
## Problem

rTorrent-injected torrents never get resumed (#1200). `resumeInjection` decided a torrent was already running from `d.is_active`, but rTorrent can report `d.is_active = 1` while `d.state = 0` (genuinely stopped). When that happens cross-seed logs `Will not resume torrent [...]: active` and gives up, leaving it stopped indefinitely. The reporter confirmed it over XML-RPC: `d.state=0`, `d.is_active=1`, `d.complete=1`.

## Fix

Read running/stopped state from `d.state`, the persistent started/stopped flag, instead of the unreliable `d.is_active`:

- `checkOriginalTorrent` now queries `d.state` and returns it as `isStarted`.
- `resumeInjection` skips the resume only when the torrent is started.

This brings rTorrent in line with the Deluge, qBittorrent and Transmission clients, which all gate resume on state.

One intentional behavior change worth noting: a started-but-inactive torrent (`d.state=1`, `d.is_active=0`) is now left alone rather than resumed again. The inject-then-recheck flow loads the torrent stopped, so this should not occur in practice, and skipping a redundant resume is harmless.

## Tests

Adds `tests/rtorrent.test.ts`: stubs the XML-RPC layer and asserts `checkOriginalTorrent` queries `d.state` (not `d.is_active`) and reads it correctly. It fails without this change. The full suite and typecheck pass, and `npm run lint` is clean.

If you'd prefer a test that drives `resumeInjection` end to end (asserting `d.resume` is called when the torrent is stopped and skipped when it is started), I'm happy to add one.

Fixes #1200
