### PR TITLE
feature(client/rtorrent) support SCGI socket connection

### DIFF
--- a/cross-seed.org/docs/basics/options.md
+++ b/cross-seed.org/docs/basics/options.md
@@ -1083,12 +1083,41 @@ The url of your **rTorrent** XMLRPC interface prefixed with `rtorrent`:
 `rtorrent:http://user:pass@localhost:8080/RPC2` or
 `rtorrent:http://user:pass@localhost:8080/rutorrent/plugins/httprpc/action.php`
 
+`cross-seed` can also speak SCGI directly, which needs no webserver in front of
+rTorrent:
+
+- `rtorrent:scgi:///path/to/.rpc.socket` for a socket, set in `.rtorrent.rc` by
+  `network.scgi.open_local` (older configs spell this `scgi_local`).
+- `rtorrent:scgi://localhost:5000` for a port, set by `network.scgi.open_port`
+  (older configs spell this `scgi_port`). IPv6 literals go in brackets, as in
+  `rtorrent:scgi://[::1]:5000`.
+
+Prefer the socket where you can, and only ever bind the port to localhost:
+anyone who can reach either endpoint can run commands as the user rTorrent runs
+as. SCGI has no authentication of its own, so any credentials in an `scgi://`
+url are ignored — restrict the socket with filesystem permissions instead.
+
+:::caution
+
+`cross-seed` sends the whole `.torrent` in one XML-RPC call when it injects, so
+a torrent with many files can exceed rTorrent's `network.xmlrpc.size_limit` and
+fail to inject. Raise it in `.rtorrent.rc` if injections fail on large torrents:
+
+```ini
+network.xmlrpc.size_limit.set = 8M
+```
+
+:::
+
+If `cross-seed` runs in a container, the socket has to be reachable inside it at
+the same path and make sure the container user can write to it.
+
 :::info
 
 If you use **Sonarr** or **Radarr**, `cross-seed` is configured the same way.
 **ruTorrent** installations come with this endpoint configured, but naked
 **rTorrent** does not provide this wrapper. If you don't use **ruTorrent**,
-you'll have to
+connect over SCGI as shown above, or
 [set up the endpoint yourself](https://github.com/linuxserver/docker-rutorrent/issues/122#issuecomment-769009432)
 with a webserver.
 

--- a/cross-seed/src/clients/RTorrent.ts
+++ b/cross-seed/src/clients/RTorrent.ts
@@ -2,7 +2,7 @@ import { type Stats } from "fs";
 import { readdir, stat } from "fs/promises";
 import { basename, dirname, join, resolve, sep } from "path";
 import { inspect } from "util";
-import xmlrpc, { Client } from "xmlrpc";
+import xmlrpc from "xmlrpc";
 import { humanReadableSize } from "@cross-seed/shared/utils";
 import {
 	DecisionAnyMatch,
@@ -35,6 +35,7 @@ import {
 	sanitizeInfoHash,
 	wait,
 } from "../utils.js";
+import { createScgiClient, parseScgiUrl, type RpcTransport } from "./scgi.js";
 import {
 	shouldResumeFromNonRelevantFiles,
 	clientSearcheeModified,
@@ -108,7 +109,7 @@ async function createLibTorrentResumeTree(
 }
 
 export default class RTorrent implements TorrentClient {
-	client: Client;
+	client: RpcTransport;
 	readonly clientHost: string;
 	readonly clientPriority: number;
 	readonly clientType = Label.RTORRENT;
@@ -126,6 +127,19 @@ export default class RTorrent implements TorrentClient {
 		this.clientPriority = priority;
 		this.readonly = readonly;
 		this.label = `${this.clientType}@${this.clientHost}`;
+
+		const scgiUrl = parseScgiUrl(url);
+		if (scgiUrl) {
+			if (scgiUrl.username || scgiUrl.password) {
+				logger.warn({
+					label: this.label,
+					message: `Ignoring the credentials in this SCGI url: SCGI has no authentication. Restrict the socket with filesystem permissions, or keep network.scgi.open_port bound to localhost.`,
+				});
+			}
+			this.client = createScgiClient(scgiUrl, { label: this.label });
+			return;
+		}
+
 		const { href, username, password } = extractCredentialsFromUrl(
 			url,
 		).unwrapOrThrow(
@@ -157,20 +171,15 @@ export default class RTorrent implements TorrentClient {
 		const message = msg.length > 1000 ? `${msg.slice(0, 1000)}...` : msg;
 		logger.verbose({ label: this.label, message });
 		return new Promise<R>((resolve, reject) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-			(this.client as any).methodCall(
-				method,
-				args,
-				(err: unknown, data: R) => {
-					if (err)
-						return reject(
-							err instanceof Error
-								? err
-								: new Error(errorMessage(err)),
-						);
-					return resolve(data);
-				},
-			);
+			this.client.methodCall(method, args, (err, data) => {
+				if (err)
+					return reject(
+						err instanceof Error
+							? err
+							: new Error(errorMessage(err)),
+					);
+				return resolve(data as R);
+			});
 		});
 	}
 

--- a/cross-seed/src/clients/TorrentClient.ts
+++ b/cross-seed/src/clients/TorrentClient.ts
@@ -26,7 +26,7 @@ import {
 	SearcheeClient,
 	SearcheeWithInfoHash,
 } from "../searchee.js";
-import { hasExt, isTruthy, wait } from "../utils.js";
+import { hasExt, hostIdentity, isTruthy, wait } from "../utils.js";
 import Deluge from "./Deluge.js";
 import QBittorrent from "./QBittorrent.js";
 import RTorrent from "./RTorrent.js";
@@ -143,8 +143,8 @@ export function clientsAreUnique(torrentClients: string[]): {
 } {
 	const uniqueHosts =
 		new Set(
-			torrentClients.map(
-				(entry) => new URL(parseClientEntry(entry)!.url).host,
+			torrentClients.map((entry) =>
+				hostIdentity(new URL(parseClientEntry(entry)!.url)),
 			),
 		).size === torrentClients.length;
 	if (uniqueHosts) return { uniqueHosts: true, uniqueWithPathname: true };
@@ -165,7 +165,7 @@ export function instantiateDownloadClients() {
 		const { clientType, readonly, url } = parseClientEntry(clientEntryRaw)!;
 		const urlObj = new URL(url);
 		const clientHost = uniqueHosts
-			? urlObj.host
+			? hostIdentity(urlObj)
 			: `${urlObj.host}${urlObj.pathname}`;
 		switch (clientType) {
 			case Label.QBITTORRENT:

--- a/cross-seed/src/clients/scgi.ts
+++ b/cross-seed/src/clients/scgi.ts
@@ -1,0 +1,130 @@
+import ms from "ms";
+import { createConnection, type NetConnectOpts } from "net";
+import { Readable } from "stream";
+import Deserializer from "xmlrpc/lib/deserializer.js";
+import { serializeMethodCall } from "xmlrpc/lib/serializer.js";
+import { CrossSeedError } from "../errors.js";
+
+const SCGI_PROTOCOL = "scgi:";
+const HEADER_SEPARATOR = Buffer.from("\r\n\r\n");
+const NUL = "\0";
+const IDLE_TIMEOUT = ms("2 minutes");
+
+export function parseScgiUrl(url: string): URL | null {
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === SCGI_PROTOCOL ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+/** The endpoint without userinfo: these strings reach the log and the Web UI. */
+function describeEndpoint(url: URL): string {
+	return `${url.protocol}//${url.host}${url.pathname}`;
+}
+
+export interface ScgiClientOptions {
+	/** Prefixes configuration errors, matching the other clients' log format. */
+	label?: string;
+	/** Overridable so tests need not wait out the real interval. */
+	idleTimeout?: number;
+}
+
+export interface RpcTransport {
+	methodCall(
+		method: string,
+		params: unknown[],
+		callback: (error: unknown, value: unknown) => void,
+	): void;
+}
+
+export function scgiConnectOptions(url: URL, label?: string): NetConnectOpts {
+	if (!url.host) {
+		return { path: decodeURIComponent(url.pathname) };
+	}
+	if (!url.port) {
+		throw new CrossSeedError(
+			`${label ? `[${label}] ` : ""}SCGI url ${describeEndpoint(url)} needs a port: use scgi://host:port for an rTorrent network.scgi.open_port, or scgi:///path/to/socket for network.scgi.open_local`,
+		);
+	}
+	return {
+		host: url.hostname.replace(/^\[|\]$/g, ""),
+		port: Number(url.port),
+	};
+}
+
+export function encodeScgiRequest(payload: Buffer): Buffer {
+	const headers = Buffer.from(
+		["CONTENT_LENGTH", String(payload.length), "SCGI", "1"]
+			.map((field) => field + NUL)
+			.join(""),
+		"utf8",
+	);
+	return Buffer.concat([
+		Buffer.from(`${headers.length}:`),
+		headers,
+		Buffer.from(","),
+		payload,
+	]);
+}
+
+export function createScgiClient(
+	url: URL,
+	{ label, idleTimeout = IDLE_TIMEOUT }: ScgiClientOptions = {},
+): RpcTransport {
+	const options = scgiConnectOptions(url, label);
+	return {
+		methodCall(method, params, callback) {
+			let payload: Buffer;
+			try {
+				payload = Buffer.from(
+					serializeMethodCall(method, params),
+					"utf8",
+				);
+			} catch (error) {
+				callback(error, undefined);
+				return;
+			}
+
+			const chunks: Buffer[] = [];
+			const socket = createConnection(options);
+			let settled = false;
+			const settle = (error: unknown, value?: unknown): void => {
+				if (settled) return;
+				settled = true;
+				socket.destroy();
+				callback(error, value);
+			};
+
+			socket.setTimeout(idleTimeout, () => {
+				settle(
+					new Error(
+						`SCGI request to ${describeEndpoint(url)} timed out after ${ms(idleTimeout, { long: true })} of inactivity`,
+					),
+				);
+			});
+			socket.on("error", settle);
+			socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+			socket.on("end", () => {
+				const response = Buffer.concat(chunks);
+				const separator = response.indexOf(HEADER_SEPARATOR);
+				if (separator === -1) {
+					settle(
+						new Error(
+							`Malformed SCGI response from ${describeEndpoint(url)}`,
+						),
+					);
+					return;
+				}
+				new Deserializer().deserializeMethodResponse(
+					Readable.from([
+						response.subarray(separator + HEADER_SEPARATOR.length),
+					]),
+					settle,
+				);
+			});
+			socket.write(encodeScgiRequest(payload));
+		},
+	};
+}

--- a/cross-seed/src/trpc/routers/clients.ts
+++ b/cross-seed/src/trpc/routers/clients.ts
@@ -4,6 +4,7 @@ import QBittorrent from "../../clients/QBittorrent.js";
 import RTorrent from "../../clients/RTorrent.js";
 import Deluge from "../../clients/Deluge.js";
 import Transmission from "../../clients/Transmission.js";
+import { hostIdentity } from "../../utils.js";
 
 const testConnectionInputSchema = z.object({
 	client: z.enum(["qbittorrent", "rtorrent", "transmission", "deluge"]),
@@ -20,7 +21,7 @@ export const clientsRouter = router({
 		.mutation(async ({ input }) => {
 			const { client: clientName, url, readonly } = input;
 
-			const clientHost = new URL(url).host;
+			const clientHost = hostIdentity(new URL(url));
 
 			let message = "";
 			try {

--- a/cross-seed/src/utils.ts
+++ b/cross-seed/src/utils.ts
@@ -480,6 +480,10 @@ export function getApikey(url: string) {
 	return new URL(url).searchParams.get("apikey");
 }
 
+export function hostIdentity(url: URL): string {
+	return url.host || url.pathname;
+}
+
 export function extractCredentialsFromUrl(
 	url: string,
 	basePath?: string,

--- a/cross-seed/src/xmlrpc-internals.d.ts
+++ b/cross-seed/src/xmlrpc-internals.d.ts
@@ -1,0 +1,19 @@
+declare module "xmlrpc/lib/serializer.js" {
+	export function serializeMethodCall(
+		method: string,
+		params?: unknown[],
+		encoding?: string,
+	): string;
+}
+
+declare module "xmlrpc/lib/deserializer.js" {
+	import type { Readable } from "stream";
+
+	export default class Deserializer {
+		constructor(encoding?: string);
+		deserializeMethodResponse(
+			stream: Readable,
+			callback: (error: unknown, value: unknown) => void,
+		): void;
+	}
+}

--- a/cross-seed/tests/scgi.test.ts
+++ b/cross-seed/tests/scgi.test.ts
@@ -1,0 +1,359 @@
+import { randomUUID } from "crypto";
+import { createServer, type Server, type Socket } from "net";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createScgiClient,
+	encodeScgiRequest,
+	parseScgiUrl,
+	scgiConnectOptions,
+} from "../src/clients/scgi.js";
+import { hostIdentity } from "../src/utils.js";
+
+let server: Server | undefined;
+const openSockets = new Set<Socket>();
+
+afterEach(async () => {
+	for (const socket of openSockets) socket.destroy();
+	openSockets.clear();
+	if (!server) return;
+	const listening = server;
+	server = undefined;
+	await new Promise<void>((resolve) => listening.close(() => resolve()));
+});
+
+function decodeScgiRequest(request: Buffer): {
+	headers: string[];
+	body: string;
+} {
+	const colon = request.indexOf(":");
+	const length = Number(request.subarray(0, colon).toString());
+	return {
+		headers: request
+			.subarray(colon + 1, colon + 1 + length)
+			.toString()
+			.split("\0")
+			.slice(0, -1),
+		body: request.subarray(colon + 2 + length).toString(),
+	};
+}
+
+function isCompleteScgiRequest(request: Buffer): boolean {
+	const colon = request.indexOf(":");
+	if (colon === -1) return false;
+	const headerLength = Number(request.subarray(0, colon).toString());
+	const bodyStart = colon + 2 + headerLength;
+	if (request.length < bodyStart) return false;
+	const [, contentLength] = request
+		.subarray(colon + 1, colon + 1 + headerLength)
+		.toString()
+		.split("\0");
+	return request.length >= bodyStart + Number(contentLength);
+}
+
+function methodResponse(inner: string): string {
+	const body = `<?xml version="1.0"?><methodResponse>${inner}</methodResponse>`;
+	return [
+		"Status: 200 OK",
+		"Content-Type: text/xml",
+		`Content-Length: ${Buffer.byteLength(body)}`,
+		"",
+		body,
+	].join("\r\n");
+}
+
+async function listen(
+	respond: (request: Buffer) => string,
+): Promise<{ url: URL; received: Buffer[] }> {
+	const received: Buffer[] = [];
+	const socketPath = join(
+		tmpdir(),
+		`cs-scgi-${randomUUID().slice(0, 8)}.sock`,
+	);
+	const created = createServer((socket) => {
+		openSockets.add(socket);
+		const chunks: Buffer[] = [];
+		socket.on("data", (chunk: Buffer) => {
+			chunks.push(chunk);
+			const request = Buffer.concat(chunks);
+			if (!isCompleteScgiRequest(request)) return;
+			received.push(request);
+			socket.end(respond(request));
+		});
+	});
+	server = created;
+	await new Promise<void>((resolve) =>
+		created.listen(socketPath, () => resolve()),
+	);
+	return { url: new URL(`scgi://${socketPath}`), received };
+}
+
+/** A server that accepts the connection and hands the raw socket over. */
+async function listenRaw(
+	handle: (socket: import("net").Socket) => void | Promise<void>,
+): Promise<{ url: URL }> {
+	const socketPath = join(
+		tmpdir(),
+		`cs-raw-${randomUUID().slice(0, 8)}.sock`,
+	);
+	const created = createServer((socket) => {
+		openSockets.add(socket);
+		void handle(socket);
+	});
+	server = created;
+	await new Promise<void>((resolve) =>
+		created.listen(socketPath, () => resolve()),
+	);
+	return { url: new URL(`scgi://${socketPath}`) };
+}
+
+function methodCallWithTimeout(
+	url: URL,
+	method: string,
+	idleTimeout: number,
+): Promise<unknown> {
+	return new Promise<unknown>((resolve, reject) => {
+		createScgiClient(url, { idleTimeout }).methodCall(
+			method,
+			[],
+			(error, value) => {
+				if (error)
+					reject(
+						error instanceof Error
+							? error
+							: new Error(JSON.stringify(error)),
+					);
+				else resolve(value);
+			},
+		);
+	});
+}
+
+function methodCall(url: URL, method: string, params: unknown[] = []) {
+	return new Promise<unknown>((resolve, reject) => {
+		createScgiClient(url).methodCall(method, params, (error, value) => {
+			if (error)
+				reject(
+					error instanceof Error
+						? error
+						: new Error(JSON.stringify(error)),
+				);
+			else resolve(value);
+		});
+	});
+}
+
+describe("encodeScgiRequest", () => {
+	it("frames the payload as a netstring with CONTENT_LENGTH first", () => {
+		const request = encodeScgiRequest(Buffer.from("hello"));
+		const { headers, body } = decodeScgiRequest(request);
+
+		expect(headers).toEqual(["CONTENT_LENGTH", "5", "SCGI", "1"]);
+		expect(body).toBe("hello");
+	});
+
+	it("terminates the netstring with a comma", () => {
+		const nul = "\0";
+		const request = encodeScgiRequest(Buffer.from("hi")).toString();
+
+		expect(request).toBe(
+			`24:CONTENT_LENGTH${nul}2${nul}SCGI${nul}1${nul},hi`,
+		);
+	});
+});
+
+describe("parseScgiUrl", () => {
+	it("returns the url for unix socket and tcp scgi", () => {
+		expect(parseScgiUrl("scgi:///run/rtorrent/.rpc.socket")?.pathname).toBe(
+			"/run/rtorrent/.rpc.socket",
+		);
+		expect(parseScgiUrl("scgi://127.0.0.1:5000")?.host).toBe(
+			"127.0.0.1:5000",
+		);
+	});
+
+	it("returns null for non-scgi urls and garbage", () => {
+		expect(parseScgiUrl("http://localhost:8080/RPC2")).toBeNull();
+		expect(parseScgiUrl("https://user:pass@host/RPC2")).toBeNull();
+		expect(parseScgiUrl("not a url")).toBeNull();
+	});
+
+	it("preserves a socket path that origin-based rebuilding would destroy", () => {
+		const url = "scgi:///run/rtorrent/.rpc.socket";
+		const parsed = new URL(url);
+
+		expect(parsed.origin).toBe("null");
+		expect(parsed.origin + parsed.pathname).toBe(
+			"null/run/rtorrent/.rpc.socket",
+		);
+		expect(parseScgiUrl(url)!.href).toBe(url);
+	});
+});
+
+describe("scgiConnectOptions", () => {
+	it("uses a unix socket path when there is no host", () => {
+		expect(
+			scgiConnectOptions(new URL("scgi:///run/rtorrent/.rpc.socket")),
+		).toEqual({ path: "/run/rtorrent/.rpc.socket" });
+	});
+
+	it("decodes percent-encoded socket paths", () => {
+		expect(scgiConnectOptions(new URL("scgi:///run/my%20sock"))).toEqual({
+			path: "/run/my sock",
+		});
+	});
+
+	it("uses host and port for tcp scgi", () => {
+		expect(scgiConnectOptions(new URL("scgi://127.0.0.1:5000"))).toEqual({
+			host: "127.0.0.1",
+			port: 5000,
+		});
+	});
+
+	it("strips the brackets from an ipv6 literal", () => {
+		// net resolves "[::1]" as a hostname and fails with ENOTFOUND
+		expect(scgiConnectOptions(new URL("scgi://[::1]:5000"))).toEqual({
+			host: "::1",
+			port: 5000,
+		});
+	});
+
+	it("rejects a tcp url without a port, naming both valid forms", () => {
+		expect(() => scgiConnectOptions(new URL("scgi://127.0.0.1"))).toThrow(
+			/needs a port.*open_port.*open_local/s,
+		);
+	});
+
+	it("keeps credentials out of the error message", () => {
+		expect(() =>
+			scgiConnectOptions(new URL("scgi://user:sekrit@127.0.0.1")),
+		).toThrow(/scgi:\/\/127\.0\.0\.1/);
+		expect(() =>
+			scgiConnectOptions(new URL("scgi://user:sekrit@127.0.0.1")),
+		).not.toThrow(/sekrit/);
+	});
+
+	it("labels the missing-port error with the client", () => {
+		expect(() =>
+			scgiConnectOptions(new URL("scgi://127.0.0.1"), "rtorrent@x"),
+		).toThrow(/^\[rtorrent@x\]/);
+	});
+});
+
+describe("hostIdentity", () => {
+	it("falls back to the path when a url has no host", () => {
+		expect(hostIdentity(new URL("scgi:///run/rtorrent/.rpc.socket"))).toBe(
+			"/run/rtorrent/.rpc.socket",
+		);
+	});
+
+	it("leaves http clients on their host, unchanged", () => {
+		expect(hostIdentity(new URL("http://localhost:8080/RPC2"))).toBe(
+			"localhost:8080",
+		);
+		expect(hostIdentity(new URL("https://qbit.example.com/"))).toBe(
+			"qbit.example.com",
+		);
+	});
+
+	it("keeps two socket clients distinct", () => {
+		expect(hostIdentity(new URL("scgi:///run/a.sock"))).not.toBe(
+			hostIdentity(new URL("scgi:///run/b.sock")),
+		);
+	});
+});
+
+// The round-trip tests bind unix sockets, which Windows has no equivalent for.
+describe.skipIf(process.platform === "win32")("createScgiClient", () => {
+	it("round-trips a method call over a unix socket", async () => {
+		const { url, received } = await listen(() =>
+			methodResponse(
+				"<params><param><value><string>0.9.8</string></value></param></params>",
+			),
+		);
+
+		await expect(methodCall(url, "system.client_version")).resolves.toBe(
+			"0.9.8",
+		);
+		expect(decodeScgiRequest(received[0]).body).toContain(
+			"<methodName>system.client_version</methodName>",
+		);
+	});
+
+	it("serializes params into the request body", async () => {
+		const { url, received } = await listen(() =>
+			methodResponse(
+				"<params><param><value><i4>1</i4></value></param></params>",
+			),
+		);
+
+		await methodCall(url, "d.custom1.set", ["ABC", "cross-seed"]);
+
+		expect(decodeScgiRequest(received[0]).body).toContain(
+			"<string>cross-seed</string>",
+		);
+	});
+
+	it("surfaces xml-rpc faults as errors", async () => {
+		const { url } = await listen(() =>
+			methodResponse(
+				"<fault><value><struct>" +
+					"<member><name>faultCode</name><value><int>-501</int></value></member>" +
+					"<member><name>faultString</name><value><string>Method not found</string></value></member>" +
+					"</struct></value></fault>",
+			),
+		);
+
+		await expect(methodCall(url, "nope")).rejects.toThrow(
+			"Method not found",
+		);
+	});
+
+	it("errors when the response has no header separator", async () => {
+		const { url } = await listen(() => "garbage");
+
+		await expect(methodCall(url, "system.client_version")).rejects.toThrow(
+			/Malformed SCGI response/,
+		);
+	});
+
+	it("reassembles a response split across multiple tcp chunks", async () => {
+		const body = methodResponse(
+			"<params><param><value><string>0.9.8</string></value></param></params>",
+		);
+		const { url } = await listenRaw(async (socket) => {
+			for (const piece of [
+				body.slice(0, 12),
+				body.slice(12, 40),
+				body.slice(40),
+			]) {
+				socket.write(piece);
+				await new Promise((r) => setTimeout(r, 5));
+			}
+			socket.end();
+		});
+
+		await expect(methodCall(url, "system.client_version")).resolves.toBe(
+			"0.9.8",
+		);
+	});
+
+	it("times out instead of hanging when the peer never replies", async () => {
+		const { url } = await listenRaw(() => {});
+
+		await expect(
+			methodCallWithTimeout(url, "system.client_version", 150),
+		).rejects.toThrow(/timed out/);
+	}, 10_000);
+
+	it("errors when the socket does not exist", async () => {
+		const url = new URL(
+			`scgi://${join(tmpdir(), "cross-seed-absent.sock")}`,
+		);
+
+		await expect(methodCall(url, "system.client_version")).rejects.toThrow(
+			/ENOENT/,
+		);
+	});
+});

--- a/webui/src/features/download-client-actions/ClientEditSheet.tsx
+++ b/webui/src/features/download-client-actions/ClientEditSheet.tsx
@@ -225,13 +225,20 @@ export default function ClientEditSheet({
                 }) => {
                   // Determine if test button should be enabled
                   const urlValid = urlValue && !urlMeta?.errors?.length;
+                  // SCGI has no credentials to enter.
+                  const isScgi =
+                    typeof urlValue === "string" &&
+                    urlValue.trimStart().toLowerCase().startsWith("scgi:");
                   const passwordValid =
-                    clientValue === "transmission" &&
-                    passwordValue === undefined
+                    isScgi ||
+                    (clientValue === "transmission" &&
+                      passwordValue === undefined)
                       ? true
                       : passwordValue && !passwordMeta?.errors?.length;
                   const userValid =
-                    clientValue === "deluge" || clientValue === "transmission"
+                    isScgi ||
+                    clientValue === "deluge" ||
+                    clientValue === "transmission"
                       ? true
                       : userValue && !userMeta?.errors?.length;
 


### PR DESCRIPTION
This PR adds initial support for cross-seed to talk directly to an rtorrent SCGI socket instead of requiring the http xml-rpm proxy setup. This can either be a local port or (my preference) a local unix socket. i.e. 

```js
torrentClients: ["rtorrent:scgi:///opt/foobar/rtorren/.rpc.socket"]
or
torrentClients: ["rtorrent:scgi://localhost:5000"]
```

Overall the changes needed for this were:
- src/clients/scgi.ts: Reuses xmlrpc's serializer/deserializer and configures the SCGI bits.
- RTorrent.ts: an scgi:// url selects the transport before credential
  parsing. Since SCGI has no auth the existing extractCredentialsFromUrl got in the way so this is tweaked now to handle that. If a user does put creds in like `scgi://user:pass@host:5000` they get ignored with a warning.
- hostIdentity() in utils.ts: a socket url has no host, so clientHost
  falls back to the path. http/https always parse with a non-empty host, so
  this is a no-op for existing clients.


Outside of the included tests, I've built and am running this with rtorrent over a local unix socket without issue so far. 

Closes #218 