### PR TITLE
fix(client/rtorrent) start injected torrents instead of only resuming them

### DIFF
--- a/cross-seed/src/clients/RTorrent.ts
+++ b/cross-seed/src/clients/RTorrent.ts
@@ -203,6 +203,7 @@ export default class RTorrent implements TorrentClient {
 				bytesLeft: number;
 				hashing: 0 | 1 | 2 | 3;
 				isMultiFile: boolean;
+				isStarted: boolean;
 				isActive: boolean;
 			},
 			"FAILURE" | "TORRENT_NOT_COMPLETE" | "NOT_FOUND"
@@ -215,6 +216,7 @@ export default class RTorrent implements TorrentClient {
 					[string],
 					[string],
 					["0" | "1" | "2" | "3"],
+					["0" | "1"],
 					["0" | "1"],
 					["0" | "1"],
 					["0" | "1"],
@@ -246,6 +248,10 @@ export default class RTorrent implements TorrentClient {
 				},
 				{
 					methodName: "d.is_multi_file",
+					params: [hash],
+				},
+				{
+					methodName: "d.state",
 					params: [hash],
 				},
 				{
@@ -285,6 +291,7 @@ export default class RTorrent implements TorrentClient {
 				[hashingStr],
 				[isCompleteStr],
 				[isMultiFileStr],
+				[stateStr],
 				[isActiveStr],
 			] = response;
 			const isComplete = Boolean(Number(isCompleteStr));
@@ -297,6 +304,7 @@ export default class RTorrent implements TorrentClient {
 				bytesLeft: Number(bytesLeftStr),
 				hashing: Number(hashingStr) as 0 | 1 | 2 | 3,
 				isMultiFile: Boolean(Number(isMultiFileStr)),
+				isStarted: Boolean(Number(stateStr)),
 				isActive: Boolean(Number(isActiveStr)),
 			});
 		} catch (e) {
@@ -800,10 +808,16 @@ export default class RTorrent implements TorrentClient {
 				continue;
 			}
 			const torrentLog = `${torrentInfo.name} [${sanitizeInfoHash(infoHash)}]`;
-			if (torrentInfo.isActive) {
+			// Only bail when the torrent is genuinely running. d.state and
+			// d.is_active are independent: recheckTorrent() pauses before
+			// hashing, which clears is_active while leaving state at 1, and an
+			// injected torrent loaded by load.raw has state 0 while rTorrent
+			// may still report is_active as 1. Gating on either flag alone
+			// strands one of those two cases stopped.
+			if (torrentInfo.isStarted && torrentInfo.isActive) {
 				logger.warn({
 					label: this.label,
-					message: `Will not resume torrent ${torrentLog}: active`,
+					message: `Will not resume torrent ${torrentLog}: already running`,
 				});
 				return;
 			}
@@ -831,7 +845,13 @@ export default class RTorrent implements TorrentClient {
 				label: this.label,
 				message: `Resuming torrent ${torrentLog}`,
 			});
+			// d.start sets the started/stopped state; d.resume only clears the
+			// paused flag. Torrents injected for a recheck are loaded with
+			// load.raw (stopped), so resuming alone leaves them at d.state=0 --
+			// seeding nothing while reporting d.is_active=1.
+			await this.methodCallP<void>("d.start", [infoHash]);
 			await this.methodCallP<void>("d.resume", [infoHash]);
+			return;
 		}
 		logger.warn({
 			label: this.label,

--- a/cross-seed/tests/rtorrentResume.test.ts
+++ b/cross-seed/tests/rtorrentResume.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/logger.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/logger.js")>();
+	return {
+		...actual,
+		logger: {
+			debug: vi.fn(),
+			verbose: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	};
+});
+
+import RTorrent from "../src/clients/RTorrent.js";
+import { Decision } from "../src/constants.js";
+import { Metafile } from "../src/parseTorrent.js";
+import { getRuntimeConfig, setRuntimeConfig } from "../src/runtimeConfig.js";
+
+type Call = { method: string; args: unknown[] };
+
+/** [name, directory, left_bytes, hashing, complete, is_multi_file, state, is_active] */
+function multicallResponse(
+	state: "0" | "1",
+	isActive: "0" | "1",
+	leftBytes = "0",
+) {
+	return [
+		["Some.Release.2024.1080p.WEB-DL"],
+		["/data/links/tracker"],
+		[leftBytes],
+		["0"],
+		["1"],
+		["0"],
+		[state],
+		[isActive],
+	];
+}
+
+function stubClient(client: RTorrent, response: unknown): Call[] {
+	const calls: Call[] = [];
+	client.client = {
+		methodCall(
+			method: string,
+			args: unknown[],
+			callback: (error: unknown, value: unknown) => void,
+		) {
+			calls.push({ method, args });
+			callback(null, method === "system.multicall" ? response : "0");
+		},
+	} as unknown as RTorrent["client"];
+	return calls;
+}
+
+function newClient(): RTorrent {
+	return new RTorrent(
+		"http://localhost:8080/RPC2",
+		"localhost:8080",
+		0,
+		false,
+	);
+}
+
+const meta = {
+	infoHash: "abc123",
+	name: "Some.Release.2024.1080p.WEB-DL",
+	files: [{ name: "a.mkv", path: "a.mkv", length: 100 }],
+	length: 100,
+	pieceLength: 16384,
+} as unknown as Metafile;
+
+describe("rTorrent checkOriginalTorrent", () => {
+	it("reads started state from d.state, not d.is_active", async () => {
+		const client = newClient();
+		const calls = stubClient(client, multicallResponse("1", "1"));
+
+		const result = await (
+			client as unknown as {
+				checkOriginalTorrent(
+					infoHash: string,
+					options: { onlyCompleted: boolean },
+				): Promise<{ unwrap(): { isStarted: boolean } }>;
+			}
+		).checkOriginalTorrent("abc123", { onlyCompleted: false });
+
+		const methods = (calls[0].args[0] as { methodName: string }[]).map(
+			(c) => c.methodName,
+		);
+		expect(methods).toContain("d.state");
+		expect(methods).toContain("d.is_active");
+		expect(result.unwrap().isStarted).toBe(true);
+	});
+});
+
+describe("rTorrent resumeInjection", () => {
+	beforeEach(() => {
+		setRuntimeConfig({
+			...getRuntimeConfig(),
+			autoResumeMaxDownload: 0,
+			ignoreNonRelevantFilesToResume: false,
+		});
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function runResume(response: unknown): Promise<Call[]> {
+		const client = newClient();
+		const calls = stubClient(client, response);
+		const done = client.resumeInjection(meta, Decision.MATCH, {
+			checkOnce: true,
+		});
+		await vi.advanceTimersByTimeAsync(20_000);
+		await done;
+		return calls;
+	}
+
+	it("starts a stopped torrent instead of only resuming it", async () => {
+		const calls = await runResume(multicallResponse("0", "1"));
+		const methods = calls.map((c) => c.method);
+
+		expect(methods).toContain("d.start");
+		expect(methods).toContain("d.resume");
+		expect(methods.indexOf("d.start")).toBeLessThan(
+			methods.indexOf("d.resume"),
+		);
+	});
+
+	it("leaves a torrent that is already running alone", async () => {
+		const calls = await runResume(multicallResponse("1", "1"));
+		const methods = calls.map((c) => c.method);
+
+		expect(methods).not.toContain("d.start");
+		expect(methods).not.toContain("d.resume");
+	});
+
+	// recheckTorrent() pauses before hashing, which leaves d.state at 1 with
+	// d.is_active at 0. Gating the bail on state alone would strand every
+	// already-in-client torrent that cross-seed rechecks, paused by its own
+	// recheck -- see the ALREADY_EXISTS path in action.ts and inject.ts.
+	it("resumes a started torrent that cross-seed paused to recheck", async () => {
+		const calls = await runResume(multicallResponse("1", "0"));
+		const methods = calls.map((c) => c.method);
+
+		expect(methods).toContain("d.resume");
+	});
+});


### PR DESCRIPTION
While working on https://github.com/cross-seed/cross-seed/pull/1211 I kept facing this issue as well. In my setup, I have recheck turned on at the moment. Which causes the injected torrents to go into a stopped state after checking. As such, the existing resume logic doesn't work, they need to be started. So, this PR adds d.start support.

This PR overlaps #1201, which switches the same check to `d.state`. That change is
needed but not sufficient on its own: without `d.start` the torrent is retried
until `getResumeStopTime()` and still never starts.

In addition to the included tests, I'm also running this patch and so far it's working perfectly. 