### PR TITLE
fix(parseTorrent): re-encode hybrid/v2 torrents from their original bytes (#1192)

### DIFF
--- a/cross-seed/src/parseTorrent.ts
+++ b/cross-seed/src/parseTorrent.ts
@@ -101,6 +101,10 @@ export class Metafile {
 	tags?: string[];
 	trackers: string[];
 	raw: Torrent;
+	// The bytes decode(buf) was given. bencode's decode is not the inverse of its
+	// encode for binary dict keys (see encode()), so these are re-encode's source of
+	// truth. Held by reference: decode already aliases buf through this.raw.
+	private originalBytes?: Buffer;
 
 	constructor(raw: Torrent) {
 		ensure(raw.info, "info");
@@ -169,7 +173,9 @@ export class Metafile {
 	}
 
 	static decode(buf: Buffer) {
-		return new Metafile(bencode.decode(buf) as Torrent);
+		const meta = new Metafile(bencode.decode(buf) as Torrent);
+		meta.originalBytes = buf;
+		return meta;
 	}
 
 	getFileSystemSafeName(): string {
@@ -177,6 +183,12 @@ export class Metafile {
 	}
 
 	encode(): Buffer {
-		return bencode.encode(this.raw);
+		// bencode's decode is not the inverse of its encode for binary dict keys: it
+		// turns every key into a string, so the 32-byte binary keys in a hybrid or v2
+		// torrent's top-level "piece layers" dict do not survive a re-encode and the
+		// client rejects the injected torrent (#1192). Return the original bytes when
+		// we have them; a metafile built from a raw object (the rTorrent resume path)
+		// has none and re-encodes.
+		return this.originalBytes ?? bencode.encode(this.raw);
 	}
 }

--- a/cross-seed/tests/parseTorrent.test.ts
+++ b/cross-seed/tests/parseTorrent.test.ts
@@ -1,0 +1,82 @@
+import bencode from "bencode";
+import { describe, expect, it } from "vitest";
+
+import { Metafile, type Torrent } from "../src/parseTorrent.js";
+
+// A bencoded byte string: "<length>:<bytes>".
+function bstr(buf: Buffer): Buffer {
+	return Buffer.concat([Buffer.from(`${buf.length}:`), buf]);
+}
+
+// Build a hybrid (v1 + v2) torrent whose top-level "piece layers" dict is keyed
+// by a 32-byte binary hash, the shape BEP 52 uses. bencode.decode turns that key
+// into a string, so a re-encode no longer reproduces the original bytes (#1192).
+// The info dict, by contrast, has only string keys and round-trips faithfully.
+// Keys are assembled in bencode's required sorted order ("info" < "piece layers").
+function hybridTorrentBytes(pieceLayerKey: Buffer): Buffer {
+	const info = bencode.encode({
+		"file tree": {
+			"hybrid.bin": {
+				"": { length: 1024, "pieces root": Buffer.alloc(32, 0x11) },
+			},
+		},
+		length: 1024,
+		"meta version": 2,
+		name: Buffer.from("hybrid.bin"),
+		"piece length": 16384,
+		pieces: Buffer.alloc(20, 0x01),
+	});
+	const pieceLayers = Buffer.concat([
+		Buffer.from("d"),
+		bstr(pieceLayerKey),
+		bstr(Buffer.alloc(32, 0xab)),
+		Buffer.from("e"),
+	]);
+	return Buffer.concat([
+		Buffer.from("d"),
+		bstr(Buffer.from("info")),
+		info,
+		bstr(Buffer.from("piece layers")),
+		pieceLayers,
+		Buffer.from("e"),
+	]);
+}
+
+describe("Metafile.encode", () => {
+	// 32 lone UTF-8 continuation bytes (0x80..0x9f): not valid UTF-8, so the key
+	// cannot survive a decode-to-string then re-encode.
+	const binaryKey = Buffer.from(
+		Array.from({ length: 32 }, (_, i) => 0x80 + i),
+	);
+
+	it("re-encodes a hybrid torrent to its exact original bytes (#1192)", () => {
+		const original = hybridTorrentBytes(binaryKey);
+
+		// Precondition: this torrent is one bencode cannot round-trip.
+		expect(bencode.encode(bencode.decode(original)).equals(original)).toBe(
+			false,
+		);
+
+		const meta = Metafile.decode(original);
+		// The metafile is usable, not merely a byte container.
+		expect(meta.name).toBe("hybrid.bin");
+		expect(meta.length).toBe(1024);
+		// The fix: encode() reproduces the original bytes exactly.
+		expect(meta.encode().equals(original)).toBe(true);
+	});
+
+	it("encodes from the raw object when not decoded from a buffer", () => {
+		// A metafile built from an object (the rTorrent resume path) has no source
+		// buffer and falls back to bencode.encode; all-string keys round-trip.
+		const raw = {
+			info: {
+				length: 512,
+				name: Buffer.from("plain.bin"),
+				"piece length": 16384,
+				pieces: Buffer.alloc(20, 0x02),
+			},
+		} as unknown as Torrent;
+		const meta = new Metafile(raw);
+		expect(meta.encode().equals(bencode.encode(raw))).toBe(true);
+	});
+});


### PR DESCRIPTION
What this fixes:

Injecting a hybrid (v1/v2) torrent fails with "Failed to retrieve torrent after adding" (#1192).

Root cause:

Metafile.encode() re-encodes the decoded torrent with bencode.encode(this.raw). bencode's decode is not the inverse of its encode for binary dict keys: it turns each dict key into a string, and the 32-byte binary keys in a hybrid or v2 torrent's top-level "piece layers" dict (BEP 52) do not survive the round-trip (bencode@4 falls back to a hex string for a non-UTF-8 key, which re-encodes to different bytes). The re-encoded torrent no longer matches the original, so the client rejects it. The reporter measured 0 of 1000 random 32-byte keys surviving the round-trip.

Fix:

Metafile.decode(buf) keeps the original buffer, and encode() returns those exact bytes when present. Nothing mutates this.raw after decode, and bencode already aliases the buffer through this.raw (its decoded values are slices of it), so this adds no copy and no new ownership assumption. This matches the approach suggested in the issue: inspect the decoded form, but send the original bytes to the client.

Scope:

This covers the reported qBittorrent path plus Deluge, Transmission, and the on-disk torrent cache and save paths, which all encode an unmodified decoded metafile. The rTorrent path injects libtorrent_resume by building a new metafile from a modified object, so it has no original buffer and must re-encode; it is left as-is here (not made worse). A complete fix for that path would need bencode to preserve binary keys, which is a larger change.

Tests:

Adds tests/parseTorrent.test.ts. It builds a hybrid torrent whose top-level "piece layers" dict is keyed by a 32-byte binary hash, confirms a naive bencode round-trip does not reproduce it, and asserts Metafile.decode(bytes).encode() returns the exact original bytes. The test fails on the current encode() and passes with the fix.

Verification:

npm run build (tsc), the full test suite (npx vitest run), and npm run lint (prettier + eslint) all pass locally.
